### PR TITLE
Add signup API endpoint

### DIFF
--- a/app/test_signup.py
+++ b/app/test_signup.py
@@ -1,0 +1,38 @@
+import json
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from app import models
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class SignupViewTests(TestCase):
+    """Tests for the signup API endpoint."""
+
+    def test_signup_creates_records(self):
+        """Posting to signup should create user and related objects."""
+        payload = {
+            "email": "owner@example.com",
+            "password": "pw",
+            "restaurant_name": "Tasty Place",
+            "location": "City, State",
+            "menu_url": "http://example.com/menu",
+        }
+        response = self.client.post(
+            reverse("api-signup"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.filter(username="owner@example.com").exists())
+        account = models.Account.objects.get()
+        self.assertTrue(
+            models.Membership.objects.filter(account=account, user__username="owner@example.com").exists()
+        )
+        restaurant = models.Restaurant.objects.get()
+        self.assertEqual(restaurant.name, "Tasty Place")
+        self.assertEqual(restaurant.location_text, "City, State")
+        self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
+        self.assertTrue(models.OutscraperPayload.objects.filter(restaurant=restaurant).exists())

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,46 @@
+"""Application views."""
+
+import json
+
+from django.contrib.auth.models import User
+from django.db import transaction
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from app import models
+
+
+@csrf_exempt
+@require_POST
+def signup(request):
+    """Handle user signup and initial restaurant creation."""
+    data = json.loads(request.body.decode("utf-8"))
+    email = data["email"]
+    password = data["password"]
+    restaurant_name = data["restaurant_name"]
+    location = data["location"]
+    menu_url = data.get("menu_url")
+
+    with transaction.atomic():
+        user = User.objects.create_user(username=email, email=email, password=password)
+        models.UserProfile.objects.create(user=user)
+        account = models.Account.objects.create(name=restaurant_name)
+        models.Membership.objects.create(
+            account=account, user=user, role=models.Membership.Role.OWNER
+        )
+        restaurant = models.Restaurant.objects.create(
+            account=account,
+            name=restaurant_name,
+            location_text=location,
+            primary_menu_url=menu_url,
+        )
+        if menu_url:
+            models.OutscraperPayload.objects.create(
+                restaurant=restaurant,
+                status=models.OutscraperPayload.Status.QUEUED,
+                request_params={"menu_url": menu_url},
+                discovered_menu_url=menu_url,
+            )
+
+    return JsonResponse({"status": "queued"})

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.urls import path
 
+from app import views as app_views
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/signup/", app_views.signup, name="api-signup"),
 ]


### PR DESCRIPTION
## Summary
- provide `/api/signup/` endpoint that creates user, account, restaurant and queues Outscraper payload
- register new route in project urls
- cover signup flow with unit test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc886c9083329d0af672e05c7fc5