### PR TITLE
Wire up auth and dashboard routes

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Dashboard</h1>
+</body>
+</html>

--- a/app/templates/menus/main.html
+++ b/app/templates/menus/main.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Menus</h1>
+</body>
+</html>

--- a/app/views.py
+++ b/app/views.py
@@ -4,6 +4,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login
+from django.contrib.auth.decorators import login_required
 from django.utils import timezone
 from django.db import transaction
 from django.http import JsonResponse
@@ -102,6 +103,18 @@ def login_view(request):
             return redirect("/concepts/")
         return render(request, "auth/login.html", {"error": "invalid"})
     return render(request, "auth/login.html")
+
+
+@login_required
+def dashboard_view(request):
+    """Render user dashboard."""
+    return render(request, "dashboard.html")
+
+
+@login_required
+def menus_view(request):
+    """Render menus page."""
+    return render(request, "menus/main.html")
 
 
 def onboarding_view(request):

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from django.contrib.messages import constants as message_constants
+from django.urls import reverse_lazy
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
@@ -219,9 +220,9 @@ LOGGING = {
 }
 SERVER_EMAIL = 'ian.larsen.1976@gmail.com'
 DEFAULT_FROM_EMAIL = 'ian@appertivo.com'
-LOGIN_REDIRECT_URL = '/dashboard/'
-LOGOUT_REDIRECT_URL = '/dashboard/'
-LOGIN_URL = "/login/"
+LOGIN_URL = reverse_lazy("login")
+LOGIN_REDIRECT_URL = reverse_lazy("dashboard")
+LOGOUT_REDIRECT_URL = reverse_lazy("login")
 SITE_ID=1
 BREVO_API_KEY = os.getenv('BREVO_API_KEY')
 print(f"BREVO_API_KEY: {BREVO_API_KEY}")  # Debugging line to check if the key is loaded

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import path
+from django.contrib.auth import views as auth_views
 
 from app import views as app_views
 
@@ -7,6 +8,8 @@ urlpatterns = [
     path("", app_views.home_view, name="home"),
     path("signup/", app_views.signup_view, name="signup"),
     path("login/", app_views.login_view, name="login"),
+    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("dashboard/", app_views.dashboard_view, name="dashboard"),
     path("onboarding/", app_views.onboarding_view, name="onboarding"),
     path("onboarding/status/", app_views.onboarding_status_view, name="onboarding-status"),
     path("onboarding/manual_menu/", app_views.manual_menu_view, name="manual-menu"),
@@ -18,6 +21,7 @@ urlpatterns = [
     path("dishes/favorite/<uuid:dish_id>/", app_views.dish_favorite_view, name="dish-favorite"),
     path("dishes/variation/<uuid:dish_id>/", app_views.dish_variation_view, name="dish-variation"),
     path("favorites/", app_views.favorites_view, name="favorites"),
+    path("menus/", app_views.menus_view, name="menus"),
     path("favorites/remove/<str:type>/<uuid:id>/", app_views.favorite_remove_view, name="favorite-remove"),
     path("menus/create/", app_views.menu_collection_create_view, name="menu-collection-create"),
     path("menus/add/<uuid:dish_id>/<uuid:collection_id>/", app_views.menu_item_add_view, name="menu-item-add"),


### PR DESCRIPTION
## Summary
- configure LOGIN_URL and LOGIN_REDIRECT_URL
- add top-level routes for dashboard, menus, and auth
- stub minimal dashboard and menus views and templates

## Testing
- `python3 manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c81b6004e48332b7eda3a5055ed592