### PR TITLE
Fix signup onboarding flow and menu onboarding

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -3,6 +3,7 @@
 import requests, os
 from celery import shared_task
 from django.conf import settings
+from django.core.files.storage import default_storage
 from django.utils import timezone
 from app import llm, models
 from dotenv import load_dotenv
@@ -26,7 +27,6 @@ def run_outscraper_search(payload_id: str) -> dict:
     data = response.json()
     payload.response_json = data
 
-    # Outscraper response: {"data": [[{...business...}]]}
     businesses = (
         data.get("data", [])[0]
         if data.get("data") and isinstance(data["data"][0], list)
@@ -40,7 +40,9 @@ def run_outscraper_search(payload_id: str) -> dict:
         restaurant = payload.restaurant
         restaurant.name = business.get("name", restaurant.name)
         restaurant.location_text = business.get("full_address", restaurant.location_text)
-        restaurant.primary_menu_url = business.get("menu_link") or restaurant.primary_menu_url
+        menu_url = business.get("menu_link") or business.get("menu_url")
+        if menu_url:
+            restaurant.primary_menu_url = menu_url
         restaurant.phone = business.get("phone")
         restaurant.website = business.get("site")
         restaurant.google_place_id = business.get("place_id")
@@ -49,17 +51,18 @@ def run_outscraper_search(payload_id: str) -> dict:
         restaurant.review_count = business.get("reviews")
         restaurant.hours_json = business.get("working_hours")
         restaurant.about_json = business.get("about")
-        restaurant.context_json = business  # raw snapshot
+        restaurant.context_json = business
         restaurant.save()
-
 
     payload.discovered_menu_url = menu_url
     payload.status = models.OutscraperPayload.Status.SUCCEEDED
     payload.finished_at = timezone.now()
     payload.save(
         update_fields=[
-            "response_json", "discovered_menu_url",
-            "status", "finished_at"
+            "response_json",
+            "discovered_menu_url",
+            "status",
+            "finished_at",
         ]
     )
 
@@ -96,6 +99,12 @@ def scrape_menu(menu_version_id: str) -> str:
     mv.status = models.MenuVersion.Status.SUCCEEDED
     mv.parsed_at = timezone.now()
     mv.save(update_fields=["raw_markdown", "status", "parsed_at"])
+
+    restaurant = mv.restaurant
+    restaurant.active_menu_version = mv
+    if mv.source_url and not restaurant.primary_menu_url:
+        restaurant.primary_menu_url = mv.source_url
+    restaurant.save(update_fields=["active_menu_version", "primary_menu_url"])
     return mv.raw_markdown
 
 
@@ -125,35 +134,45 @@ def parse_pdf_menu(menu_version_id: str, storage_path: str):
     mv.save(update_fields=["status"])
 
     try:
-        # Load file from storage
         with default_storage.open(storage_path, "rb") as f:
             files = {"file": (os.path.basename(storage_path), f, "application/pdf")}
             headers = {"Authorization": f"Bearer {settings.OPENAI_API_KEY}"}
 
             response = requests.post(
-                "https://api.openai.com/v1/files",  # upload
+                "https://api.openai.com/v1/files",
                 headers=headers,
-                files=files
+                files=files,
             )
             file_id = response.json()["id"]
 
-        # Use Assistants or Responses API with file input
         payload = {
-            "model": "gpt-4.1-mini",  # or `gpt-4o-mini`
+            "model": "gpt-4.1-mini",
             "input": [
-                {"role": "system", "content": "You are an expert at extracting restaurant menus into clean Markdown."},
-                {"role": "user", "content": f"Extract the full menu in Markdown from file {file_id}."}
-            ]
+                {
+                    "role": "system",
+                    "content": "You are an expert at extracting restaurant menus into clean Markdown.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Extract the full menu in Markdown from file {file_id}.",
+                },
+            ],
         }
         resp = requests.post("https://api.openai.com/v1/responses", json=payload, headers=headers)
-        markdown_text = resp.json()["output_text"]
+        markdown_text = resp.json().get("output_text", "")
 
         mv.raw_markdown = markdown_text
         mv.status = models.MenuVersion.Status.SUCCEEDED
         mv.parsed_at = timezone.now()
         mv.save(update_fields=["raw_markdown", "status", "parsed_at"])
 
+        restaurant = mv.restaurant
+        restaurant.active_menu_version = mv
+        restaurant.save(update_fields=["active_menu_version"])
+
     except Exception as e:
         mv.status = models.MenuVersion.Status.FAILED
         mv.error_message = str(e)
         mv.save(update_fields=["status", "error_message"])
+
+    return mv.raw_markdown

--- a/app/templates/_partials/menu_modal.html
+++ b/app/templates/_partials/menu_modal.html
@@ -1,7 +1,13 @@
 <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
   <div class="bg-white rounded-xl shadow-lg w-full max-w-lg p-6 space-y-4">
     <h2 class="text-xl font-bold text-gray-800">Provide Your Menu</h2>
-    <form hx-post="{% url 'upload_menu' restaurant.id %}" hx-target="#restaurant-status" hx-swap="outerHTML">
+    <form
+      hx-post="{% url 'upload_menu' restaurant.id %}"
+      hx-target="#restaurant-status"
+      hx-swap="outerHTML"
+      hx-encoding="multipart/form-data"
+      hx-on::after-request="document.getElementById('menu-modal').innerHTML=''"
+    >
       <label class="block text-sm font-medium">Menu URL</label>
       <input type="url" name="menu_url" class="w-full border rounded p-2 mb-3">
       

--- a/app/templates/_partials/restaurant_status.html
+++ b/app/templates/_partials/restaurant_status.html
@@ -3,6 +3,8 @@
     <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
     <p class="text-green-800 font-medium">✅ Your restaurant is ready!</p>
   </div>
+{% elif payload and payload.status == "succeeded" and not payload.discovered_menu_url %}
+  {% include "_partials/status_need_menu.html" %}
 {% elif payload and payload.status == "failed" %}
   <div class="rounded-xl bg-red-50 border border-red-200 p-4">
     <p class="text-red-700 font-medium">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,14 +11,21 @@
 <body class="bg-[#F9F7F2] text-[#14080E] font-inter h-full flex flex-col">
 
   <!-- NAVBAR -->
+  {% if restaurant %}
+    {% url 'dashboard' restaurant.id as dashboard_url %}
+  {% elif request.resolver_match.kwargs.restaurant_id %}
+    {% url 'dashboard' request.resolver_match.kwargs.restaurant_id as dashboard_url %}
+  {% else %}
+    {% url 'home' as dashboard_url %}
+  {% endif %}
   <header class="bg-gradient-to-r from-[#2E005D] via-[#5C008B] to-[#8E008B] text-white shadow">
     <div class="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
       <!-- Left: Brand -->
-      <a href="{% url 'dashboard' %}" class="text-2xl font-bold tracking-tight">Appertivo</a>
+      <a href="{{ dashboard_url }}" class="text-2xl font-bold tracking-tight">Appertivo</a>
 
       <!-- Center: Desktop Nav -->
       <nav class="hidden md:flex gap-8 text-sm font-medium">
-        <a href="{% url 'dashboard' %}" class="hover:underline">Dashboard</a>
+        <a href="{{ dashboard_url }}" class="hover:underline">Dashboard</a>
         <a href="{% url 'favorites' %}" class="hover:underline">Favorites</a>
         <a href="{% url 'menus' %}" class="hover:underline">Menus</a>
         <a href="{% url 'settings' %}" class="hover:underline">Settings</a>
@@ -47,7 +54,7 @@
 
     <!-- Mobile nav panel -->
     <div x-show="mobileMenuOpen" class="md:hidden bg-[#5C008B] text-white px-6 py-4 space-y-4">
-      <a href="{% url 'dashboard' %}" class="block">Dashboard</a>
+      <a href="{{ dashboard_url }}" class="block">Dashboard</a>
       <a href="{% url 'favorites' %}" class="block">Favorites</a>
       <a href="{% url 'menus' %}" class="block">Menus</a>
       <a href="{% url 'settings' %}" class="block">Settings</a>

--- a/app/templates/base_logged_in.html
+++ b/app/templates/base_logged_in.html
@@ -9,20 +9,27 @@
 <body class="bg-gray-50 text-[#14080E] min-h-screen flex flex-col">
 
   <!-- NAVBAR -->
+  {% if restaurant %}
+    {% url 'dashboard' restaurant.id as dashboard_url %}
+  {% elif request.resolver_match.kwargs.restaurant_id %}
+    {% url 'dashboard' request.resolver_match.kwargs.restaurant_id as dashboard_url %}
+  {% else %}
+    {% url 'home' as dashboard_url %}
+  {% endif %}
   <header class="bg-white shadow-md">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center h-16">
         
         <!-- Left: Logo -->
         <div class="flex-shrink-0">
-          <a href="{% url 'dashboard' %}" class="text-2xl font-bold text-[#B993D6]">
+          <a href="{{ dashboard_url }}" class="text-2xl font-bold text-[#B993D6]">
             Appertivo
           </a>
         </div>
 
         <!-- Desktop Nav -->
         <nav class="hidden md:flex space-x-6">
-          <a href="{% url 'dashboard' %}" class="hover:text-[#B993D6]">Dashboard</a>
+          <a href="{{ dashboard_url }}" class="hover:text-[#B993D6]">Dashboard</a>
           <a href="{% url 'concepts' %}" class="hover:text-[#B993D6]">Concepts</a>
           <a href="{% url 'favorites' %}" class="hover:text-[#B993D6]">Favorites</a>
           <a href="{% url 'settings' %}" class="hover:text-[#B993D6]">Settings</a>
@@ -53,7 +60,7 @@
     <!-- Mobile Nav -->
     <div id="mobile-menu" class="hidden md:hidden bg-white border-t border-gray-200">
       <nav class="px-2 py-3 space-y-1">
-        <a href="{% url 'dashboard' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Dashboard</a>
+        <a href="{{ dashboard_url }}" class="block px-3 py-2 rounded hover:bg-gray-100">Dashboard</a>
         <a href="{% url 'concepts' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Concepts</a>
         <a href="{% url 'favorites' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Favorites</a>
         <a href="{% url 'settings' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Settings</a>

--- a/app/views.py
+++ b/app/views.py
@@ -11,7 +11,7 @@ from django.http import JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from .tasks import run_outscraper_search, scrape_menu
+from .tasks import run_outscraper_search, scrape_menu, parse_pdf_menu
 from django.urls import reverse
 from app import llm, models
 
@@ -35,17 +35,41 @@ def home_view(request):
 def signup_view(request):
     """Register a new user and restaurant."""
     if request.method == "POST":
-        email = request.POST["email"]
-        password1 = request.POST.get("password1")
-        password2 = request.POST.get("password2")
+        is_json = request.content_type == "application/json"
+        if is_json:
+            try:
+                data = json.loads(request.body or "{}")
+            except json.JSONDecodeError:
+                return JsonResponse({"error": "invalid_json"}, status=400)
+        else:
+            data = request.POST
 
-        if password1 != password2:
-            return render(request, "auth/signup.html", {"error": "Passwords do not match"})
+        email = (data.get("email") or "").strip()
+        restaurant_name = (data.get("restaurant_name") or "").strip()
+        location = (data.get("location") or "").strip()
+        menu_url = (data.get("menu_url") or "").strip() or None
 
-        password = password1  # safe to use now
-        restaurant_name = request.POST["restaurant_name"]
-        location = request.POST["location"]
-        menu_url = request.POST.get("menu_url")  # optional
+        if is_json:
+            password = data.get("password")
+            if not password:
+                return JsonResponse({"error": "password_required"}, status=400)
+        else:
+            password1 = data.get("password1")
+            password2 = data.get("password2")
+            if password1 != password2:
+                return render(
+                    request, "auth/signup.html", {"error": "Passwords do not match"}
+                )
+            password = password1
+
+        if not email or not restaurant_name or not location:
+            if is_json:
+                return JsonResponse({"error": "missing_fields"}, status=400)
+            return render(
+                request,
+                "auth/signup.html",
+                {"error": "Please complete all fields."},
+            )
 
         with transaction.atomic():
             user = User.objects.create_user(
@@ -57,35 +81,49 @@ def signup_view(request):
                 account=account, user=user, role=models.Membership.Role.OWNER
             )
             restaurant = models.Restaurant.objects.create(
-                account=account, name=restaurant_name, location_text=location
+                account=account,
+                name=restaurant_name,
+                location_text=location,
+                primary_menu_url=menu_url,
             )
 
-            # If user provided menu_url, queue it immediately
             if menu_url:
                 mv = models.MenuVersion.objects.create(
                     restaurant=restaurant,
                     source_url=menu_url,
                     source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
-                    raw_markdown="",  # will be filled later
+                    raw_markdown="",
                     status=models.MenuVersion.Status.QUEUED,
                 )
-                scrape_menu.delay(str(mv.id))
+                transaction.on_commit(
+                    lambda mv_id=str(mv.id): scrape_menu.delay(mv_id)
+                )
             else:
-                # Otherwise, run Outscraper to discover menu_url
                 payload = models.OutscraperPayload.objects.create(
                     restaurant=restaurant,
                     status=models.OutscraperPayload.Status.QUEUED,
-                    request_params={"query": f"{restaurant_name} {location}",
-                            "async": "false",
-                            "limit":1,
-                            },
+                    request_params={
+                        "query": f"{restaurant_name} {location}",
+                        "async": "false",
+                        "limit": 1,
+                    },
                 )
                 transaction.on_commit(
-                    lambda: run_outscraper_search.delay(str(payload.id))
+                    lambda payload_id=str(payload.id): run_outscraper_search.delay(
+                        payload_id
+                    )
                 )
 
         login(request, user)
-        return redirect(reverse("dashboard", args=[restaurant.id]))
+        redirect_url = reverse("dashboard", args=[restaurant.id])
+        if is_json:
+            return JsonResponse(
+                {
+                    "redirect_url": redirect_url,
+                    "restaurant_id": str(restaurant.id),
+                }
+            )
+        return redirect(redirect_url)
 
     return render(request, "auth/signup.html")
 
@@ -379,22 +417,22 @@ def notification_list_view(request):
 def restaurant_status(request, restaurant_id):
     """HTMX endpoint that returns current status widget."""
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
+    payload = (
+        models.OutscraperPayload.objects.filter(restaurant=restaurant)
+        .order_by("-created_at")
+        .first()
+    )
+    context = {
+        "restaurant": restaurant,
+        "menu_version": restaurant.active_menu_version,
+        "payload": payload,
+    }
+    return render(request, "_partials/restaurant_status.html", context)
 
-    # Case 1: Active menu exists
-    if restaurant.active_menu_version and restaurant.active_menu_version.status == models.MenuVersion.Status.SUCCEEDED:
-        return render(request, "_partials/status_ready.html", {"restaurant": restaurant})
-
-    # Case 2: Outscraper finished but no menu_url → prompt user
-    latest_payload = models.OutscraperPayload.objects.filter(restaurant=restaurant).order_by("-created_at").first()
-    if latest_payload and latest_payload.status == models.OutscraperPayload.Status.SUCCEEDED and not latest_payload.discovered_menu_url:
-        return render(request, "_partials/status_need_menu.html", {"restaurant": restaurant})
-
-    # Default: still working
-    return render(request, "_partials/status_pending.html", {"restaurant": restaurant})
 
 def show_menu_modal(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
-    return render(request, "partials/menu_modal.html", {"restaurant": restaurant})
+    return render(request, "_partials/menu_modal.html", {"restaurant": restaurant})
 
 
 from django.core.files.storage import default_storage
@@ -404,36 +442,48 @@ def upload_menu(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
 
     if request.method == "POST":
-        if "menu_url" in request.POST and request.POST["menu_url"]:
+        menu_url = (request.POST.get("menu_url") or "").strip()
+        menu_text = (request.POST.get("menu_text") or "").strip()
+        menu_pdf = request.FILES.get("menu_pdf")
+
+        if menu_url:
+            restaurant.primary_menu_url = menu_url
+            restaurant.save(update_fields=["primary_menu_url"])
             mv = models.MenuVersion.objects.create(
                 restaurant=restaurant,
-                source_url=request.POST["menu_url"],
+                source_url=menu_url,
                 source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
                 raw_markdown="",
                 status=models.MenuVersion.Status.QUEUED,
             )
-            scrape_menu.delay(str(mv.id))
+            transaction.on_commit(lambda mv_id=str(mv.id): scrape_menu.delay(mv_id))
 
-        elif "menu_text" in request.POST and request.POST["menu_text"].strip():
-            models.MenuVersion.objects.create(
-                restaurant=restaurant,
-                source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
-                raw_markdown=request.POST["menu_text"].strip(),
-                status=models.MenuVersion.Status.SUCCEEDED,
-            )
-
-        elif "menu_pdf" in request.FILES:
-            pdf_file = request.FILES["menu_pdf"]
-            # Store temporarily in media storage
-            path = default_storage.save(f"menus/{restaurant.id}/{pdf_file.name}", ContentFile(pdf_file.read()))
-
+        elif menu_text:
             mv = models.MenuVersion.objects.create(
                 restaurant=restaurant,
-                source_url=path,  # stored location
+                source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
+                raw_markdown=menu_text,
+                status=models.MenuVersion.Status.SUCCEEDED,
+            )
+            restaurant.active_menu_version = mv
+            restaurant.save(update_fields=["active_menu_version"])
+
+        elif menu_pdf:
+            path = default_storage.save(
+                f"menus/{restaurant.id}/{menu_pdf.name}",
+                ContentFile(menu_pdf.read()),
+            )
+            mv = models.MenuVersion.objects.create(
+                restaurant=restaurant,
+                source_url=path,
                 source_kind=models.MenuVersion.SourceKind.IMAGE_OCR,
                 raw_markdown="",
                 status=models.MenuVersion.Status.QUEUED,
             )
-            parse_pdf_menu.delay(str(mv.id), path)
+            transaction.on_commit(
+                lambda mv_id=str(mv.id), storage_path=path: parse_pdf_menu.delay(
+                    mv_id, storage_path
+                )
+            )
 
-    return JsonResponse({"status": "queued"})
+    return restaurant_status(request, restaurant_id)

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -16,7 +16,21 @@ urlpatterns = [
     path("onboarding/", app_views.onboarding_view, name="onboarding"),
     path("onboarding/status/", app_views.onboarding_status_view, name="onboarding-status"),
     path("onboarding/manual_menu/", app_views.manual_menu_view, name="manual-menu"),
-    path("restaurants/<uuid:restaurant_id>/status/",app_views.restaurant_status,name="restaurant_status",),
+    path(
+        "restaurants/<uuid:restaurant_id>/status/",
+        app_views.restaurant_status,
+        name="restaurant_status",
+    ),
+    path(
+        "restaurants/<uuid:restaurant_id>/menu-modal/",
+        app_views.show_menu_modal,
+        name="show_menu_modal",
+    ),
+    path(
+        "restaurants/<uuid:restaurant_id>/upload-menu/",
+        app_views.upload_menu,
+        name="upload_menu",
+    ),
 
     path("concepts/", app_views.concepts_view, name="concepts"),
     path("concepts/generate/", app_views.concepts_generate_view, name="concepts-generate"),

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -56,11 +58,28 @@ class TaskExecutionTests(TestCase):
             account=self.account, name="R", location_text="City"
         )
 
+    @patch("app.tasks.scrape_menu")
     @patch("app.tasks.requests.get")
-    def test_run_outscraper_search_updates_payload(self, mock_get):
+    def test_run_outscraper_search_updates_payload(self, mock_get, mock_scrape):
+        """If Outscraper finds a menu URL we queue a scrape and persist context."""
         mock_get.return_value.json.return_value = {
-            "data": [],
-            "menu_link": "http://example.com/menu",
+            "data": [
+                [
+                    {
+                        "name": "Ristorante Uno",
+                        "full_address": "City, ST",
+                        "menu_link": "http://example.com/menu",
+                        "phone": "123",
+                        "site": "http://example.com",
+                        "place_id": "abc",
+                        "description": "Great food",
+                        "rating": 4.7,
+                        "reviews": 12,
+                        "working_hours": {"mon": "9-5"},
+                        "about": {"service": "Takeout"},
+                    }
+                ]
+            ]
         }
         mock_get.return_value.status_code = 200
         payload = models.OutscraperPayload.objects.create(
@@ -68,13 +87,40 @@ class TaskExecutionTests(TestCase):
             status=models.OutscraperPayload.Status.QUEUED,
             request_params={"q": "pizza"},
         )
-        tasks.run_outscraper_search(payload.id)
+
+        tasks.run_outscraper_search(str(payload.id))
+
         payload.refresh_from_db()
-        self.assertEqual(
-            payload.status, models.OutscraperPayload.Status.SUCCEEDED
-        )
-        self.assertEqual(payload.response_json["data"], [])
+        self.restaurant.refresh_from_db()
+        self.assertEqual(payload.status, models.OutscraperPayload.Status.SUCCEEDED)
         self.assertEqual(payload.discovered_menu_url, "http://example.com/menu")
+        self.assertEqual(self.restaurant.primary_menu_url, "http://example.com/menu")
+        self.assertEqual(models.MenuVersion.objects.count(), 1)
+        menu_version = models.MenuVersion.objects.get()
+        self.assertEqual(menu_version.status, models.MenuVersion.Status.QUEUED)
+        self.assertEqual(menu_version.source_url, "http://example.com/menu")
+        mock_scrape.delay.assert_called_once_with(str(menu_version.id))
+
+    @patch("app.tasks.scrape_menu")
+    @patch("app.tasks.requests.get")
+    def test_run_outscraper_without_menu_link(self, mock_get, mock_scrape):
+        """When no menu is found we still store context but do not queue a scrape."""
+        mock_get.return_value.json.return_value = {
+            "data": [[{"name": "No Menu", "full_address": "City"}]]
+        }
+        payload = models.OutscraperPayload.objects.create(
+            restaurant=self.restaurant,
+            status=models.OutscraperPayload.Status.QUEUED,
+            request_params={"q": "pizza"},
+        )
+
+        tasks.run_outscraper_search(str(payload.id))
+
+        payload.refresh_from_db()
+        self.assertEqual(payload.status, models.OutscraperPayload.Status.SUCCEEDED)
+        self.assertIsNone(payload.discovered_menu_url)
+        self.assertEqual(models.MenuVersion.objects.count(), 0)
+        mock_scrape.delay.assert_not_called()
 
     @patch("app.tasks.requests.get")
     def test_scrape_menu_updates_menu_version(self, mock_get):
@@ -86,7 +132,12 @@ class TaskExecutionTests(TestCase):
             raw_markdown="",
             status=models.MenuVersion.Status.QUEUED,
         )
-        tasks.scrape_menu(mv.id)
+
+        tasks.scrape_menu(str(mv.id))
+
         mv.refresh_from_db()
+        self.restaurant.refresh_from_db()
         self.assertEqual(mv.status, models.MenuVersion.Status.SUCCEEDED)
         self.assertEqual(mv.raw_markdown, "menu markdown")
+        self.assertIsNotNone(mv.parsed_at)
+        self.assertEqual(self.restaurant.active_menu_version, mv)

--- a/tests/test_restaurant_status.py
+++ b/tests/test_restaurant_status.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from app import models
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class RestaurantStatusViewTests(TestCase):
+    """Ensure status and menu upload flows behave end-to-end."""
+
+    def setUp(self):
+        self.account = models.Account.objects.create(name="Account")
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="My Place",
+            location_text="Town",
+        )
+
+    def test_status_pending_message_displayed(self):
+        response = self.client.get(
+            reverse("restaurant_status", args=[self.restaurant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "We’re building your AI menu assistant")
+
+    def test_status_prompts_for_menu_when_none_found(self):
+        models.OutscraperPayload.objects.create(
+            restaurant=self.restaurant,
+            status=models.OutscraperPayload.Status.SUCCEEDED,
+            request_params={},
+            response_json={"data": []},
+        )
+
+        response = self.client.get(
+            reverse("restaurant_status", args=[self.restaurant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Provide menu")
+
+    def test_status_ready_when_menu_available(self):
+        menu_version = models.MenuVersion.objects.create(
+            restaurant=self.restaurant,
+            source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
+            raw_markdown="Menu",
+            status=models.MenuVersion.Status.SUCCEEDED,
+        )
+        self.restaurant.active_menu_version = menu_version
+        self.restaurant.save(update_fields=["active_menu_version"])
+
+        response = self.client.get(
+            reverse("restaurant_status", args=[self.restaurant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "✅ Your restaurant is ready!")
+
+    def test_show_menu_modal_renders_form(self):
+        response = self.client.get(
+            reverse("show_menu_modal", args=[self.restaurant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Provide Your Menu")
+        self.assertContains(response, "name=\"menu_url\"")
+
+    @patch("app.views.parse_pdf_menu")
+    @patch("app.views.scrape_menu")
+    def test_upload_menu_with_url_queues_scrape(self, mock_scrape, mock_parse):
+        url = reverse("upload_menu", args=[self.restaurant.id])
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, {"menu_url": "http://example.com/menu"})
+
+        self.assertEqual(response.status_code, 200)
+        menu_version = models.MenuVersion.objects.get()
+        self.assertEqual(menu_version.status, models.MenuVersion.Status.QUEUED)
+        self.assertEqual(menu_version.source_url, "http://example.com/menu")
+        mock_scrape.delay.assert_called_once_with(str(menu_version.id))
+        self.assertContains(response, "We’re building your AI menu assistant")
+        self.restaurant.refresh_from_db()
+        self.assertEqual(self.restaurant.primary_menu_url, "http://example.com/menu")
+
+    def test_upload_menu_with_text_marks_ready(self):
+        url = reverse("upload_menu", args=[self.restaurant.id])
+        response = self.client.post(url, {"menu_text": "Menu body"})
+
+        self.assertEqual(response.status_code, 200)
+        menu_version = models.MenuVersion.objects.get()
+        self.assertEqual(menu_version.status, models.MenuVersion.Status.SUCCEEDED)
+        self.assertEqual(menu_version.raw_markdown, "Menu body")
+        self.restaurant.refresh_from_db()
+        self.assertEqual(self.restaurant.active_menu_version, menu_version)
+        self.assertContains(response, "✅ Your restaurant is ready!")

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
@@ -9,30 +10,104 @@ from app import models
 
 @override_settings(SECURE_SSL_REDIRECT=False)
 class SignupViewTests(TestCase):
-    """Tests for the signup API endpoint."""
+    """Tests for the signup endpoints."""
 
-    def test_signup_creates_records(self):
-        """Posting to signup should create user and related objects."""
-        payload = {
+    def _api_payload(self, **overrides):
+        base = {
             "email": "owner@example.com",
             "password": "pw",
             "restaurant_name": "Tasty Place",
             "location": "City, State",
-            "menu_url": "http://example.com/menu",
         }
-        response = self.client.post(
-            reverse("api-signup"),
-            data=json.dumps(payload),
-            content_type="application/json",
-        )
+        base.update(overrides)
+        return base
+
+    @patch("app.views.run_outscraper_search")
+    @patch("app.views.scrape_menu")
+    def test_api_signup_creates_records_and_returns_redirect(self, mock_scrape, mock_outscraper):
+        """JSON signup should create core objects and return a redirect URL."""
+        payload = self._api_payload()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("api-signup"),
+                data=json.dumps(payload),
+                content_type="application/json",
+            )
+
         self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertIn("redirect_url", body)
         self.assertTrue(User.objects.filter(username="owner@example.com").exists())
+
         account = models.Account.objects.get()
         self.assertTrue(
-            models.Membership.objects.filter(account=account, user__username="owner@example.com").exists()
+            models.Membership.objects.filter(
+                account=account, user__username="owner@example.com"
+            ).exists()
         )
         restaurant = models.Restaurant.objects.get()
         self.assertEqual(restaurant.name, "Tasty Place")
         self.assertEqual(restaurant.location_text, "City, State")
+        self.assertIsNone(restaurant.primary_menu_url)
+        self.assertEqual(body["redirect_url"], reverse("dashboard", args=[restaurant.id]))
+
+        payload_obj = models.OutscraperPayload.objects.get()
+        self.assertEqual(payload_obj.status, models.OutscraperPayload.Status.QUEUED)
+        self.assertIn("Tasty Place", payload_obj.request_params["query"])
+
+        mock_outscraper.delay.assert_called_once_with(str(payload_obj.id))
+        mock_scrape.delay.assert_not_called()
+
+    @patch("app.views.run_outscraper_search")
+    @patch("app.views.scrape_menu")
+    def test_form_signup_without_menu_triggers_outscraper(self, mock_scrape, mock_outscraper):
+        """HTML signup without menu URL should queue Outscraper and redirect."""
+        form_data = {
+            "email": "owner@example.com",
+            "password1": "pw",
+            "password2": "pw",
+            "restaurant_name": "Tasty Place",
+            "location": "City, State",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("signup"), data=form_data)
+
+        restaurant = models.Restaurant.objects.get()
+        self.assertRedirects(response, reverse("dashboard", args=[restaurant.id]))
+        self.assertIn("_auth_user_id", self.client.session)
+
+        payload_obj = models.OutscraperPayload.objects.get()
+        self.assertEqual(payload_obj.restaurant, restaurant)
+        mock_outscraper.delay.assert_called_once_with(str(payload_obj.id))
+        mock_scrape.delay.assert_not_called()
+
+    @patch("app.views.run_outscraper_search")
+    @patch("app.views.scrape_menu")
+    def test_form_signup_with_menu_url_scrapes_immediately(self, mock_scrape, mock_outscraper):
+        """Providing a menu URL should create a queued menu version and scrape it."""
+        form_data = {
+            "email": "owner@example.com",
+            "password1": "pw",
+            "password2": "pw",
+            "restaurant_name": "Tasty Place",
+            "location": "City, State",
+            "menu_url": "http://example.com/menu",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("signup"), data=form_data)
+
+        restaurant = models.Restaurant.objects.get()
+        self.assertRedirects(response, reverse("dashboard", args=[restaurant.id]))
+        self.assertEqual(models.OutscraperPayload.objects.count(), 0)
+
+        menu_version = models.MenuVersion.objects.get()
+        self.assertEqual(menu_version.source_url, "http://example.com/menu")
+        self.assertEqual(menu_version.status, models.MenuVersion.Status.QUEUED)
+        self.assertEqual(menu_version.source_kind, models.MenuVersion.SourceKind.URL_SCRAPE)
+        mock_scrape.delay.assert_called_once_with(str(menu_version.id))
+        mock_outscraper.delay.assert_not_called()
+        restaurant.refresh_from_db()
         self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
-        self.assertTrue(models.OutscraperPayload.objects.filter(restaurant=restaurant).exists())


### PR DESCRIPTION
## Summary
- handle both JSON and form submissions in the signup view while queueing menu scraping or Outscraper jobs appropriately
- align restaurant status widgets, modal routes, and navigation links so new users see pending, prompt, or ready states with the correct partials
- update menu scraping tasks to persist menu URLs, activate menu versions, and cover the flow with new tests

## Testing
- python manage.py test tests.test_signup tests.test_llm_views_tasks tests.test_restaurant_status
- python manage.py test
- python manage.py test tests *(fails: TypeError: expected str, bytes or os.PathLike object, not NoneType)*
- python -m unittest discover tests *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c84d6debdc833283b8cdd1fe07521e