### PR TITLE
Add menu rescrape endpoint on settings page

### DIFF
--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -39,21 +39,27 @@
 
 <!-- Rescrape Button -->
 <div class="mt-6">
-  <button
-    id="rescrape-btn"
-    hx-post=""
-    hx-trigger="click"
+  <form
+    id="rescrape-form"
+    hx-post="{% url 'settings-rescrape-menu' restaurant.id %}"
     hx-swap="none"
-    class="px-4 py-2 bg-[#f08000] text-white font-semibold rounded-lg shadow hover:bg-[#d96f00]"
+    class="inline-block"
   >
-    <span class="label">Rescrape Restaurant Data</span>
-    <span class="spinner hidden ml-2">
-      <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-      </svg>
-    </span>
-  </button>
+    {% csrf_token %}
+    <button
+      type="submit"
+      id="rescrape-btn"
+      class="px-4 py-2 bg-[#f08000] text-white font-semibold rounded-lg shadow hover:bg-[#d96f00]"
+    >
+      <span class="label">Rescrape Restaurant Data</span>
+      <span class="spinner hidden ml-2">
+        <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+      </span>
+    </button>
+  </form>
 </div>
 
 
@@ -85,13 +91,14 @@
 <!-- TOAST CONTAINER -->
 <div id="toast-container" class="fixed bottom-4 right-4 space-y-2 z-50"></div>
 <script>
+  const form = document.getElementById("rescrape-form");
   const btn = document.getElementById("rescrape-btn");
-  const label = btn.querySelector(".label");
-  const spinner = btn.querySelector(".spinner");
+  const label = btn ? btn.querySelector(".label") : null;
+  const spinner = btn ? btn.querySelector(".spinner") : null;
 
   // Show loading spinner before request
   document.body.addEventListener("htmx:beforeRequest", function(evt) {
-    if (evt.detail.elt === btn) {
+    if (evt.detail.elt === form && btn && label && spinner) {
       label.textContent = "Refreshing…";
       spinner.classList.remove("hidden");
       btn.disabled = true;
@@ -101,14 +108,20 @@
 
   // Reset button + show toast after request
   document.body.addEventListener("htmx:afterRequest", function(evt) {
-    if (evt.detail.elt === btn) {
+    if (evt.detail.elt === form && btn && label && spinner) {
       label.textContent = "Rescrape Restaurant Data";
       spinner.classList.add("hidden");
       btn.disabled = false;
       btn.classList.remove("opacity-70", "cursor-not-allowed");
 
-      if (evt.detail.xhr && evt.detail.xhr.responseText.includes("rescrape_complete")) {
+      if (evt.detail.successful && evt.detail.xhr && evt.detail.xhr.responseText.includes("rescrape_complete")) {
         showToast("Restaurant data refreshed successfully!");
+      } else if (!evt.detail.successful) {
+        const responseText = evt.detail.xhr ? evt.detail.xhr.responseText : "";
+        const message = responseText.includes("missing_menu_url")
+          ? "Add a menu URL before refreshing."
+          : "Unable to refresh the menu right now.";
+        showToast(message);
       }
     }
   });

--- a/app/views.py
+++ b/app/views.py
@@ -385,15 +385,24 @@ def update_creativity(request, restaurant_id):
 @require_POST
 def rescrape_menu(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
+    menu_url = (request.POST.get("menu_url") or "").strip()
+    if menu_url and menu_url != restaurant.primary_menu_url:
+        restaurant.primary_menu_url = menu_url
+        restaurant.save(update_fields=["primary_menu_url"])
+    menu_url = restaurant.primary_menu_url
+
+    if not menu_url:
+        return JsonResponse({"error": "missing_menu_url"}, status=400)
+
     mv = models.MenuVersion.objects.create(
         restaurant=restaurant,
-        source_url=restaurant.primary_menu_url,
+        source_url=menu_url,
         source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
         raw_markdown="",
         status=models.MenuVersion.Status.QUEUED,
     )
     scrape_menu.delay(str(mv.id))
-    return redirect("settings")
+    return JsonResponse({"rescrape_complete": True, "menu_version_id": str(mv.id)})
 
 
 @login_required

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -49,6 +49,11 @@ urlpatterns = [
     path("settings/", app_views.settings_view, name="settings"),
     path("settings/info/", app_views.update_restaurant_info, name="update_restaurant_info"),
     path("settings/<uuid:restaurant_id>/rescrape/", app_views.rescrape_restaurant, name="rescrape_restaurant"),
+    path(
+        "settings/<uuid:restaurant_id>/rescrape-menu/",
+        app_views.rescrape_menu,
+        name="settings-rescrape-menu",
+    ),
     path("settings/<uuid:restaurant_id>/update-creativity/", app_views.update_creativity, name="update_creativity"),
     path("settings/notifications/", app_views.update_notifications, name="update_notifications"),
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -172,10 +174,40 @@ class ViewSmokeTests(TestCase):
     def test_settings_views(self):
         resp = self.client.get(reverse("settings"))
         self.assertEqual(resp.status_code, 200)
-        rescrape = self.client.post(reverse("settings-rescrape-menu"))
+        self.restaurant.primary_menu_url = "https://example.com/menu"
+        self.restaurant.save(update_fields=["primary_menu_url"])
+        with patch("app.views.scrape_menu.delay") as mock_delay:
+            rescrape = self.client.post(
+                reverse("settings-rescrape-menu", args=[self.restaurant.id])
+            )
         self.assertEqual(rescrape.status_code, 200)
-        slider = self.client.post(reverse("settings-slider-update"), {"value": 60})
-        self.assertEqual(slider.json()["value"], 60)
+        self.assertTrue(rescrape.json()["rescrape_complete"])
+        mv = models.MenuVersion.objects.get(restaurant=self.restaurant)
+        self.assertEqual(mv.source_url, "https://example.com/menu")
+        self.assertEqual(mv.status, models.MenuVersion.Status.QUEUED)
+        mock_delay.assert_called_once_with(str(mv.id))
+        slider = self.client.post(
+            reverse("update_creativity", args=[self.restaurant.id]),
+            {"classic_creative_slider": 60},
+        )
+        self.assertEqual(slider.json()["status"], "ok")
+        self.restaurant.refresh_from_db()
+        self.assertEqual(
+            self.restaurant.restaurantsettings.classic_creative_slider,
+            60,
+        )
+
+    def test_rescrape_menu_requires_url(self):
+        self.restaurant.primary_menu_url = None
+        self.restaurant.save(update_fields=["primary_menu_url"])
+        with patch("app.views.scrape_menu.delay") as mock_delay:
+            resp = self.client.post(
+                reverse("settings-rescrape-menu", args=[self.restaurant.id])
+            )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json()["error"], "missing_menu_url")
+        self.assertFalse(models.MenuVersion.objects.exists())
+        mock_delay.assert_not_called()
 
     def test_billing_views(self):
         resp = self.client.get(reverse("billing"))


### PR DESCRIPTION
## Summary
- add a dedicated settings URL for rescraping a restaurant menu and queue the ScraperAPI task
- hook the settings page button into the new endpoint and show HTMX feedback for success or failure
- cover the menu rescrape flow and missing URL error with smoke tests

## Testing
- python manage.py test
- python manage.py test tests.test_appertivo_views


------
https://chatgpt.com/codex/tasks/task_e_68c870872ea48332945dd1cce5579cb1