### PR TITLE
Fix settings rescrape menu button

### DIFF
--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -41,8 +41,8 @@
 <div class="mt-6">
   <form
     id="rescrape-form"
-    hx-post="{% url 'settings-rescrape-menu' restaurant.id %}"
-    hx-swap="none"
+    action="{% url 'settings-rescrape-menu' restaurant.id %}"
+    method="post"
     class="inline-block"
   >
     {% csrf_token %}
@@ -96,35 +96,69 @@
   const label = btn ? btn.querySelector(".label") : null;
   const spinner = btn ? btn.querySelector(".spinner") : null;
 
-  // Show loading spinner before request
-  document.body.addEventListener("htmx:beforeRequest", function(evt) {
-    if (evt.detail.elt === form && btn && label && spinner) {
+  function setLoading(isLoading) {
+    if (!btn || !label || !spinner) {
+      return;
+    }
+
+    if (isLoading) {
       label.textContent = "Refreshing…";
       spinner.classList.remove("hidden");
       btn.disabled = true;
       btn.classList.add("opacity-70", "cursor-not-allowed");
-    }
-  });
-
-  // Reset button + show toast after request
-  document.body.addEventListener("htmx:afterRequest", function(evt) {
-    if (evt.detail.elt === form && btn && label && spinner) {
+    } else {
       label.textContent = "Rescrape Restaurant Data";
       spinner.classList.add("hidden");
       btn.disabled = false;
       btn.classList.remove("opacity-70", "cursor-not-allowed");
-
-      if (evt.detail.successful && evt.detail.xhr && evt.detail.xhr.responseText.includes("rescrape_complete")) {
-        showToast("Restaurant data refreshed successfully!");
-      } else if (!evt.detail.successful) {
-        const responseText = evt.detail.xhr ? evt.detail.xhr.responseText : "";
-        const message = responseText.includes("missing_menu_url")
-          ? "Add a menu URL before refreshing."
-          : "Unable to refresh the menu right now.";
-        showToast(message);
-      }
     }
-  });
+  }
+
+  async function handleRescrape(event) {
+    event.preventDefault();
+    if (!form) {
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        body: new FormData(form),
+        headers: {
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        credentials: "same-origin",
+      });
+
+      let data = {};
+      try {
+        data = await response.json();
+      } catch (error) {
+        data = {};
+      }
+
+      let message;
+      if (response.ok && data.rescrape_complete) {
+        message = "Restaurant data refreshed successfully!";
+      } else if (response.status === 400 && data.error === "missing_menu_url") {
+        message = "Add a menu URL before refreshing.";
+      } else {
+        message = "Unable to refresh the menu right now.";
+      }
+
+      showToast(message);
+    } catch (error) {
+      showToast("Unable to refresh the menu right now.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (form) {
+    form.addEventListener("submit", handleRescrape);
+  }
 
   function showToast(message) {
     const container = document.getElementById("toast-container");


### PR DESCRIPTION
## Summary
- update the settings rescrape form to submit directly to the menu refresh endpoint
- replace the unused HTMX hooks with a fetch-based handler that shows loading state and toast messages

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68c87ff7a640833290ee3914767f274f