### PR TITLE
Validate scraped menus before saving

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 from openai import OpenAI
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+_openai_api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=_openai_api_key) if _openai_api_key else None
 
 
 
@@ -89,12 +90,25 @@ def run_outscraper_search(payload_id: str) -> dict:
 
 
 def validate_menu_text(raw_markdown: str) -> bool:
-    resp = client.responses.create(
-        model="gpt-4.1-mini",  # cheap, fast
-        input=f"Does the following text contain a food or restaurant menu? Reply only 'yes' or 'no'.\n\n{raw_markdown[:3000]}"
-    )
+    """Return True when the scraped markdown looks like a menu."""
+
+    if not client or not raw_markdown or not raw_markdown.strip():
+        return False
+
+    try:
+        resp = client.responses.create(
+            model="gpt-4.1-mini",  # inexpensive "nano" style check
+            input=(
+                "You are checking if text belongs to a food or restaurant menu. "
+                "Answer only 'yes' or 'no'.\n\n"
+                f"Text:\n{raw_markdown[:3000]}"
+            ),
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.warning("Menu validation request failed: %s", exc, exc_info=True)
+        return False
+
     answer = resp.output_text.strip().lower()
-    logger.info(answer)
     return answer.startswith("y")
 
 @shared_task
@@ -111,17 +125,26 @@ def scrape_menu(menu_version_id: str) -> str:
         "output_format": "markdown",
     }
     response = requests.get("https://api.scraperapi.com/", params=params)
-    mv.raw_markdown = response.text
-    logger.info(mv.raw_markdown)
-    mv.status = models.MenuVersion.Status.SUCCEEDED
-    mv.parsed_at = timezone.now()
-    if validate_menu_text(response.text):
-        mv.raw_markdown = response.text
+    candidate_markdown = response.text or ""
+
+    is_valid_menu = False
+    try:
+        is_valid_menu = validate_menu_text(candidate_markdown)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.warning("Menu validation crashed for MenuVersion %s: %s", mv.id, exc, exc_info=True)
+
+    if is_valid_menu:
+        mv.raw_markdown = candidate_markdown
         mv.status = models.MenuVersion.Status.SUCCEEDED
         mv.parsed_at = timezone.now()
+        mv.error_message = ""
     else:
+        mv.raw_markdown = ""
         mv.status = models.MenuVersion.Status.FAILED
-    mv.save(update_fields=["raw_markdown", "status", "parsed_at"])
+        mv.parsed_at = None
+        mv.error_message = "Scraped page did not look like a menu."
+
+    mv.save(update_fields=["raw_markdown", "status", "parsed_at", "error_message"])
 
     restaurant = mv.restaurant
     restaurant.active_menu_version = mv

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -122,8 +122,9 @@ class TaskExecutionTests(TestCase):
         self.assertEqual(models.MenuVersion.objects.count(), 0)
         mock_scrape.delay.assert_not_called()
 
+    @patch("app.tasks.validate_menu_text", return_value=True)
     @patch("app.tasks.requests.get")
-    def test_scrape_menu_updates_menu_version(self, mock_get):
+    def test_scrape_menu_updates_menu_version(self, mock_get, mock_validate):
         mock_get.return_value.text = "menu markdown"
         mv = models.MenuVersion.objects.create(
             restaurant=self.restaurant,
@@ -140,4 +141,29 @@ class TaskExecutionTests(TestCase):
         self.assertEqual(mv.status, models.MenuVersion.Status.SUCCEEDED)
         self.assertEqual(mv.raw_markdown, "menu markdown")
         self.assertIsNotNone(mv.parsed_at)
+        self.assertEqual(self.restaurant.active_menu_version, mv)
+
+    @patch("app.tasks.validate_menu_text", return_value=False)
+    @patch("app.tasks.requests.get")
+    def test_scrape_menu_marks_failed_when_no_menu(self, mock_get, mock_validate):
+        mock_get.return_value.text = "Welcome to our homepage"
+        mv = models.MenuVersion.objects.create(
+            restaurant=self.restaurant,
+            source_url="http://example.com/menu",
+            source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
+            raw_markdown="",
+            status=models.MenuVersion.Status.QUEUED,
+        )
+
+        tasks.scrape_menu(str(mv.id))
+
+        mv.refresh_from_db()
+        self.restaurant.refresh_from_db()
+        self.assertEqual(mv.status, models.MenuVersion.Status.FAILED)
+        self.assertEqual(mv.raw_markdown, "")
+        self.assertIsNone(mv.parsed_at)
+        self.assertEqual(
+            mv.error_message,
+            "Scraped page did not look like a menu.",
+        )
         self.assertEqual(self.restaurant.active_menu_version, mv)


### PR DESCRIPTION
## Summary
- validate scraped markdown with an inexpensive OpenAI model before accepting it and clear the content when no menu is found so the dashboard prompts for manual capture
- fall back gracefully when no OpenAI API key is configured to avoid import-time crashes
- extend the task tests to cover both successful and failed scrape scenarios

## Testing
- python manage.py test tests.test_llm_views_tasks.TaskExecutionTests

------
https://chatgpt.com/codex/tasks/task_e_68c88518b1d48332bbb377542c223c30