### PR TITLE
Improve auth feedback, settings details, and favorites UI

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,4 +1,3 @@
-<html><body>Login</body></html>
 {% load static %}
 
 <!DOCTYPE html>
@@ -10,15 +9,22 @@
 </head>
 <body class="bg-gradient-to-br from-[#2E005D] via-[#5C008B] to-[#8E008B] min-h-screen flex items-center justify-center">
 
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8">
-    <h1 class="text-3xl font-bold text-center text-[#2E005D] mb-6">Welcome Back</h1>
+  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 space-y-4">
+    <h1 class="text-3xl font-bold text-center text-[#2E005D]">Welcome Back</h1>
+
+    {% if error %}
+      <div class="rounded-xl bg-red-50 border border-red-200 text-red-700 px-4 py-3 text-sm">
+        {{ error }}
+      </div>
+    {% endif %}
+
     <form method="post" class="space-y-4">
       {% csrf_token %}
 
       <!-- Email -->
       <div>
         <label class="block text-sm font-medium text-slate-700">Email</label>
-        <input type="email" name="email" required
+        <input type="email" name="email" value="{{ form_data.email }}" required autofocus
           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
       </div>
 

--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -9,15 +9,22 @@
 </head>
 <body class="bg-gradient-to-br from-[#2E005D] via-[#5C008B] to-[#8E008B] min-h-screen flex items-center justify-center">
 
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8">
-    <h1 class="text-3xl font-bold text-center text-[#2E005D] mb-6">Create an Account</h1>
+  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 space-y-4">
+    <h1 class="text-3xl font-bold text-center text-[#2E005D]">Create an Account</h1>
+
+    {% if error %}
+      <div class="rounded-xl bg-red-50 border border-red-200 text-red-700 px-4 py-3 text-sm">
+        {{ error }}
+      </div>
+    {% endif %}
+
     <form method="post" class="space-y-4">
       {% csrf_token %}
-      
+
       <!-- Email -->
       <div>
         <label class="block text-sm font-medium text-slate-700">Email</label>
-        <input type="email" name="email" required
+        <input type="email" name="email" value="{{ form_data.email }}" required
           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
       </div>
 
@@ -38,14 +45,21 @@
       <!-- Restaurant Name -->
       <div>
         <label class="block text-sm font-medium text-slate-700">Restaurant Name</label>
-        <input type="text" name="restaurant_name" required
+        <input type="text" name="restaurant_name" value="{{ form_data.restaurant_name }}" required
           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
       </div>
 
       <!-- Location -->
       <div>
         <label class="block text-sm font-medium text-slate-700">Location</label>
-        <input type="text" name="location" required
+        <input type="text" name="location" value="{{ form_data.location }}" required
+          class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+      </div>
+
+      <!-- Optional Menu URL -->
+      <div>
+        <label class="block text-sm font-medium text-slate-700">Menu URL (optional)</label>
+        <input type="url" name="menu_url" value="{{ form_data.menu_url }}"
           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
       </div>
 

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -23,8 +23,8 @@
           <button 
             hx-post="{% url 'concept-favorite' concept.id %}" 
             hx-swap="none"
-            class="favorite-btn text-sm px-3 py-1 rounded-lg font-medium {% if concept.favoriteconcept_set.filter(user=request.user).exists %}bg-[#B993D6] text-white{% else %}bg-slate-100 text-slate-600{% endif %}">
-            {% if concept.favoriteconcept_set.filter(user=request.user).exists %}
+            class="favorite-btn text-sm px-3 py-1 rounded-lg font-medium {% if concept.is_favorited %}bg-[#B993D6] text-white{% else %}bg-slate-100 text-slate-600{% endif %}">
+            {% if concept.is_favorited %}
               ★ Favorited
             {% else %}
               ☆ Favorite

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -67,4 +67,22 @@
     </ul>
   </div>
 </div>
+{% if prompt_for_menu %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const modalTarget = document.getElementById('menu-modal');
+  if (!modalTarget) {
+    return;
+  }
+  fetch('{% url 'show_menu_modal' restaurant.id %}', {
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
+    .then(function (response) { return response.text(); })
+    .then(function (html) { modalTarget.innerHTML = html; })
+    .catch(function () {});
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -1,1 +1,104 @@
-<html><body>Favorites</body></html>
+{% extends "base.html" %}
+{% block title %}Favorites — Appertivo{% endblock %}
+
+{% block content %}
+<section class="bg-gradient-to-r from-[#2E005D] via-[#5C008B] to-[#8E008B] text-white py-10 px-6 rounded-xl shadow mb-8">
+  <h1 class="text-3xl font-bold">Favorites Hub</h1>
+  {% if restaurant %}
+    <p class="text-slate-200 mt-2">Curated picks for {{ restaurant.name }}.</p>
+  {% else %}
+    <p class="text-slate-200 mt-2">Curated picks from your recent sessions.</p>
+  {% endif %}
+  <p class="text-slate-100 mt-4 max-w-2xl">Quickly revisit the concepts and dishes that inspired you. Everything you star lives here so it’s easy to plan your next menu update.</p>
+</section>
+
+<div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+  <!-- Concepts column -->
+  <div class="xl:col-span-2 space-y-6">
+    <div class="bg-white rounded-xl shadow p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h2 class="text-xl font-semibold text-[#49475B]">Saved Concepts</h2>
+          <p class="text-sm text-slate-500">Ideas you marked for later.</p>
+        </div>
+        <a href="{% url 'concepts' %}" class="text-sm text-[#5C008B] font-medium hover:underline">Explore concepts</a>
+      </div>
+      {% if favorite_concepts %}
+        <ul class="space-y-4">
+          {% for favorite in favorite_concepts %}
+            <li class="border border-slate-200 rounded-lg p-4 flex flex-col gap-2 bg-slate-50">
+              <div class="flex items-center justify-between gap-3">
+                <span class="text-lg font-semibold text-[#2E005D]">{{ favorite.concept.name }}</span>
+                <span class="text-xs text-slate-500 uppercase tracking-wide">Saved {{ favorite.favorited_at|date:"M d, Y" }}</span>
+              </div>
+              <div class="flex items-center justify-between text-sm text-slate-500">
+                <span>Rank: {{ favorite.concept.rank_order }}</span>
+                {% if favorite.concept.restaurant %}
+                  <span>{{ favorite.concept.restaurant.name }}</span>
+                {% endif %}
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-slate-600">You haven't saved any concepts yet. Visit the concepts tab to start collecting ideas.</p>
+      {% endif %}
+    </div>
+
+    <div class="bg-white rounded-xl shadow p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h2 class="text-xl font-semibold text-[#49475B]">Favorite Dishes</h2>
+          <p class="text-sm text-slate-500">Dishes worth featuring on your next menu.</p>
+        </div>
+        <a href="{% url 'menus' %}" class="text-sm text-[#5C008B] font-medium hover:underline">Build menus</a>
+      </div>
+      {% if favorite_dishes %}
+        <ul class="space-y-4">
+          {% for favorite in favorite_dishes %}
+            <li class="border border-slate-200 rounded-lg p-4 bg-white/80">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p class="text-lg font-semibold text-[#2E005D]">{{ favorite.dish.title }}</p>
+                  {% if favorite.dish.parent_concept %}
+                    <p class="text-sm text-slate-500">Concept: {{ favorite.dish.parent_concept.name }}</p>
+                  {% endif %}
+                </div>
+                <span class="text-xs text-slate-500 uppercase tracking-wide">Saved {{ favorite.favorited_at|date:"M d, Y" }}</span>
+              </div>
+              {% if favorite.dish.description %}
+                <p class="text-sm text-slate-600 mt-2">{{ favorite.dish.description }}</p>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-slate-600">No dishes in your favorites yet. Generate dishes from a concept to start building a list.</p>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Quick actions -->
+  <div class="space-y-6">
+    <div class="bg-white rounded-xl shadow p-6 space-y-4">
+      <h2 class="text-xl font-semibold text-[#49475B]">Quick Actions</h2>
+      <p class="text-sm text-slate-500">Jump back into the tools you use most.</p>
+      <div class="space-y-3">
+        <a href="{% url 'concepts' %}" class="block px-4 py-3 rounded-lg bg-gradient-to-r from-[#FF8300] to-[#FF5C00] text-white font-semibold text-center transition hover:scale-105">Generate new concepts</a>
+        <a href="{% url 'settings' %}" class="block px-4 py-3 rounded-lg border border-[#5C008B]/40 text-[#5C008B] font-semibold text-center hover:bg-[#5C008B]/5">Update restaurant settings</a>
+        <a href="{% url 'menus' %}" class="block px-4 py-3 rounded-lg border border-slate-200 text-slate-700 font-semibold text-center hover:bg-slate-100">Manage menus</a>
+      </div>
+    </div>
+
+    <div class="bg-gradient-to-r from-[#FF8300]/20 to-[#FF5C00]/20 rounded-xl shadow p-6 space-y-2">
+      <h2 class="text-lg font-semibold text-[#5C008B]">Need something fresh?</h2>
+      <p class="text-sm text-slate-700">Kick off a new ideation run whenever you’re ready for more inspiration.</p>
+      {% if restaurant %}
+        <a href="{% url 'concepts-generate' %}" class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#5C008B] text-white font-semibold hover:bg-[#2E005D]">Start a concept run</a>
+      {% else %}
+        <a href="{% url 'concepts-generate' %}" class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#5C008B] text-white font-semibold hover:bg-[#2E005D]">Start exploring</a>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -1,175 +1,157 @@
 {% extends "base_logged_in.html" %}
-
 {% block title %}Settings — Appertivo{% endblock %}
 
 {% block content %}
 <div class="space-y-8">
 
-  <!-- RESTAURANT INFO -->
-  <section class="bg-white p-6 rounded-xl shadow">
-    <h2 class="text-xl font-bold text-[#49475B] mb-4">Restaurant Info</h2>
-    <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <!-- RESTAURANT INFO + MENU URL -->
+  <section class="bg-white p-6 rounded-xl shadow space-y-6">
+    <div class="flex items-start justify-between gap-4">
       <div>
-        <dt class="font-medium text-gray-600">Name</dt>
-        <dd class="text-gray-900">{{ restaurant.name }}</dd>
+        <h2 class="text-xl font-bold text-[#49475B]">Restaurant Info</h2>
+        <p class="text-sm text-slate-500">Keep your public details and menu link up to date.</p>
       </div>
-      <div>
-        <dt class="font-medium text-gray-600">Address</dt>
-        <dd class="text-gray-900">{{ restaurant.location_text }}</dd>
-      </div>
-      <div>
-        <dt class="font-medium text-gray-600">City</dt>
-        <dd class="text-gray-900">{{ restaurant.city }}</dd>
-      </div>
-      <div>
-        <dt class="font-medium text-gray-600">State</dt>
-        <dd class="text-gray-900">{{ restaurant.state }}</dd>
-      </div>
-      <div>
-        <dt class="font-medium text-gray-600">Phone</dt>
-        <dd class="text-gray-900">{{ restaurant.phone }}</dd>
-      </div>
-      <div>
-        <dt class="font-medium text-gray-600">Website</dt>
-        <dd class="text-[#B993D6]">
-          <a href="{{ restaurant.website }}" target="_blank">{{ restaurant.website }}</a>
-        </dd>
-      </div>
-    </dl>
+    </div>
 
-<!-- Rescrape Button -->
-<div class="mt-6">
-  <form
-    id="rescrape-form"
-    action="{% url 'settings-rescrape-menu' restaurant.id %}"
-    method="post"
-    class="inline-block"
-  >{% csrf_token %}
-    <button
-      type="submit"
-      id="rescrape-btn"
-      class="px-4 py-2 bg-[#f08000] text-white font-semibold rounded-lg shadow hover:bg-[#d96f00]"
-    >
-      <span class="label">Rescrape Restaurant Data</span>
-      <span class="spinner hidden ml-2">
-        <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-        </svg>
-      </span>
-    </button>
-  </form>
-</div>
+    {% if restaurant %}
+      <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <dt class="font-medium text-gray-600">Name</dt>
+          <dd class="text-gray-900">{{ restaurant.name }}</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-gray-600">Address</dt>
+          <dd class="text-gray-900">{{ restaurant.location_text }}</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-gray-600">Phone</dt>
+          <dd class="text-gray-900">{{ restaurant.phone|default:"—" }}</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-gray-600">Website</dt>
+          <dd class="text-[#B993D6]">
+            {% if restaurant.website %}
+              <a href="{{ restaurant.website }}" target="_blank" rel="noopener">{{ restaurant.website }}</a>
+            {% else %}
+              —
+            {% endif %}
+          </dd>
+        </div>
+      </dl>
 
+      <form
+        action="{% url 'update_restaurant_info' %}"
+        method="post"
+        class="space-y-3 md:flex md:items-end md:space-y-0 md:space-x-4"
+      >
+        {% csrf_token %}
+        <div class="flex-1">
+          <label for="menu_url" class="block text-sm font-medium text-gray-600">Primary menu URL</label>
+          <input
+            id="menu_url"
+            type="url"
+            name="menu_url"
+            value="{{ restaurant.primary_menu_url }}"
+            placeholder="https://example.com/menu"
+            class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none"
+          >
+        </div>
+        <button
+          type="submit"
+          class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#f08000] text-white font-semibold shadow transition hover:bg-[#d96f00]"
+        >
+          Save Menu URL
+        </button>
+      </form>
 
+      <div class="flex flex-wrap items-center gap-3">
+        <form
+          id="rescrape-form"
+          action="{% url 'settings-rescrape-menu' restaurant.id %}"
+          method="post"
+          class="inline-block"
+        >
+          {% csrf_token %}
+          <button
+            type="submit"
+            id="rescrape-btn"
+            class="px-4 py-2 bg-[#f08000] text-white font-semibold rounded-lg shadow transition hover:bg-[#d96f00] flex items-center gap-2"
+          >
+            <span class="label">Rescrape Restaurant Data</span>
+            <span class="spinner hidden">
+              <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+              </svg>
+            </span>
+          </button>
+        </form>
+        {% if restaurant.primary_menu_url %}
+          <a href="{{ restaurant.primary_menu_url }}" target="_blank" rel="noopener"
+             class="text-sm text-[#5C008B] font-medium hover:underline">Open current menu</a>
+        {% endif %}
+      </div>
+    {% else %}
+      <p class="text-slate-600">No restaurant found for your account.</p>
+    {% endif %}
   </section>
 
-  <!-- CREATIVE SLIDER -->
-  <section class="bg-white p-6 rounded-xl shadow">
-    <h2 class="text-xl font-bold text-[#49475B] mb-4">Creativity</h2>
-    <div class="flex items-center space-x-4">
-      <span class="text-gray-600">Classic</span>
+
+  <!-- CREATIVITY SLIDER -->
+  {% if restaurant and restaurant_settings %}
+  <section class="bg-white p-6 rounded-xl shadow space-y-4">
+    <div>
+      <h2 class="text-xl font-bold text-[#49475B]">Creativity balance</h2>
+      <p class="text-sm text-slate-500">Choose how classic or adventurous your AI ideas should be.</p>
+    </div>
+    <form
+      hx-post="{% url 'update_creativity' restaurant.id %}"
+      hx-trigger="change delay:200ms"
+      hx-target="none"
+      class="flex items-center gap-4"
+    >
+      <span class="text-sm text-slate-600">Classic</span>
       <input
         type="range"
+        name="classic_creative_slider"
         min="0"
         max="100"
-        value="{{ restaurant.settings.classic_creative_slider }}"
-        hx-post=""
-        hx-trigger="change"
-        hx-target="none"
-        name="classic_creative_slider"
-        class="w-full accent-[#B993D6]" />
-      <span class="text-gray-600">Creative</span>
+        value="{{ restaurant_settings.classic_creative_slider|default:50 }}"
+        class="flex-1 accent-[#B993D6]"
+      >
+      <span class="text-sm text-slate-600">Creative</span>
+    </form>
+  </section>
+  {% endif %}
+
+  <!-- CONTEXT SNAPSHOT -->
+  <section class="bg-white p-6 rounded-xl shadow space-y-3">
+    <div>
+      <h2 class="text-xl font-bold text-[#49475B]">Restaurant context</h2>
+      <p class="text-sm text-slate-500">Raw data we use to understand your business.</p>
     </div>
-    <p class="text-sm text-gray-500 mt-2">
-      Adjusts how adventurous AI concepts and dishes will be.
-    </p>
+    <div class="max-h-72 overflow-y-auto bg-slate-50 border border-slate-200 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap break-all">
+      {% if restaurant and restaurant.context_json %}
+        {{ restaurant.context_json }}
+      {% else %}
+        No context has been collected yet.
+      {% endif %}
+    </div>
+  </section>
+
+  <!-- MENU MARKDOWN -->
+  <section class="bg-white p-6 rounded-xl shadow space-y-3">
+    <div>
+      <h2 class="text-xl font-bold text-[#49475B]">Menu content</h2>
+      <p class="text-sm text-slate-500">Latest menu markdown from your uploads or scrapes.</p>
+    </div>
+    <div class="max-h-80 overflow-y-auto bg-slate-50 border border-slate-200 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap">
+      {% if active_menu_version and active_menu_version.raw_markdown %}
+        {{ active_menu_version.raw_markdown|linebreaksbr }}
+      {% else %}
+        No menu has been processed yet.
+      {% endif %}
+    </div>
   </section>
 </div>
-
-<<<<<<< Updated upstream
-<!-- TOAST CONTAINER -->
-<div id="toast-container" class="fixed bottom-4 right-4 space-y-2 z-50"></div>
-<script>
-  const form = document.getElementById("rescrape-form");
-  const btn = document.getElementById("rescrape-btn");
-  const label = btn ? btn.querySelector(".label") : null;
-  const spinner = btn ? btn.querySelector(".spinner") : null;
-
-  function setLoading(isLoading) {
-    if (!btn || !label || !spinner) {
-      return;
-    }
-
-    if (isLoading) {
-      label.textContent = "Refreshing…";
-      spinner.classList.remove("hidden");
-      btn.disabled = true;
-      btn.classList.add("opacity-70", "cursor-not-allowed");
-    } else {
-      label.textContent = "Rescrape Restaurant Data";
-      spinner.classList.add("hidden");
-      btn.disabled = false;
-      btn.classList.remove("opacity-70", "cursor-not-allowed");
-    }
-  }
-
-  async function handleRescrape(event) {
-    event.preventDefault();
-    if (!form) {
-      return;
-    }
-
-    setLoading(true);
-
-    try {
-      const response = await fetch(form.action, {
-        method: "POST",
-        body: new FormData(form),
-        headers: {
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        credentials: "same-origin",
-      });
-
-      let data = {};
-      try {
-        data = await response.json();
-      } catch (error) {
-        data = {};
-      }
-
-      let message;
-      if (response.ok && data.rescrape_complete) {
-        message = "Restaurant data refreshed successfully!";
-      } else if (response.status === 400 && data.error === "missing_menu_url") {
-        message = "Add a menu URL before refreshing.";
-      } else {
-        message = "Unable to refresh the menu right now.";
-      }
-
-      showToast(message);
-    } catch (error) {
-      showToast("Unable to refresh the menu right now.");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  if (form) {
-    form.addEventListener("submit", handleRescrape);
-  }
-
-  function showToast(message) {
-    const container = document.getElementById("toast-container");
-    const toast = document.createElement("div");
-    toast.className = "bg-[#58B09C] text-white px-4 py-2 rounded-lg shadow";
-    toast.textContent = message;
-    container.appendChild(toast);
-    setTimeout(() => toast.remove(), 4000);
-  }
-</script>
-=======
->>>>>>> Stashed changes
-
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -2,18 +2,20 @@
 
 import json
 
-from django.contrib.auth.models import User
-from django.contrib.auth import authenticate, login
+from django.conf import settings
+from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
-from django.utils import timezone
-from django.db import transaction
-from django.http import JsonResponse
-from django.shortcuts import render, redirect, get_object_or_404
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
-from .tasks import run_outscraper_search, scrape_menu, parse_pdf_menu
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+from django.db.models import Prefetch
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils import timezone
+from django.views.decorators.http import require_http_methods, require_POST
+
 from app import llm, models
+from .tasks import parse_pdf_menu, run_outscraper_search, scrape_menu
 
 def concept_grid(request):
     """Render a 3x3 grid of concept names."""
@@ -32,6 +34,19 @@ def home_view(request):
     """Landing page with signup/login links."""
     return render(request, "home.html")
 
+
+def _with_favorite_flags(concepts, user):
+    """Annotate concept objects with a boolean for the current user."""
+    user_is_authenticated = getattr(user, "is_authenticated", False)
+    for concept in concepts:
+        if user_is_authenticated:
+            favorites = getattr(concept, "_favorites_for_request_user", [])
+            concept.is_favorited = bool(favorites)
+        else:
+            concept.is_favorited = False
+    return concepts
+
+
 def signup_view(request):
     """Register a new user and restaurant."""
     if request.method == "POST":
@@ -47,7 +62,14 @@ def signup_view(request):
         email = (data.get("email") or "").strip()
         restaurant_name = (data.get("restaurant_name") or "").strip()
         location = (data.get("location") or "").strip()
-        menu_url = (data.get("menu_url") or "").strip() or None
+        raw_menu_url = (data.get("menu_url") or "").strip()
+        menu_url = raw_menu_url or None
+        form_data = {
+            "email": email,
+            "restaurant_name": restaurant_name,
+            "location": location,
+            "menu_url": raw_menu_url,
+        }
 
         if is_json:
             password = data.get("password")
@@ -58,7 +80,9 @@ def signup_view(request):
             password2 = data.get("password2")
             if password1 != password2:
                 return render(
-                    request, "auth/signup.html", {"error": "Passwords do not match"}
+                    request,
+                    "auth/signup.html",
+                    {"error": "Passwords do not match", "form_data": form_data},
                 )
             password = password1
 
@@ -68,51 +92,61 @@ def signup_view(request):
             return render(
                 request,
                 "auth/signup.html",
-                {"error": "Please complete all fields."},
+                {"error": "Please complete all fields.", "form_data": form_data},
             )
 
-        with transaction.atomic():
-            user = User.objects.create_user(
-                username=email, email=email, password=password
-            )
-            models.UserProfile.objects.create(user=user)
-            account = models.Account.objects.create(name=restaurant_name)
-            models.Membership.objects.create(
-                account=account, user=user, role=models.Membership.Role.OWNER
-            )
-            restaurant = models.Restaurant.objects.create(
-                account=account,
-                name=restaurant_name,
-                location_text=location,
-                primary_menu_url=menu_url,
-            )
+        try:
+            with transaction.atomic():
+                user = User.objects.create_user(
+                    username=email, email=email, password=password
+                )
+                models.UserProfile.objects.create(user=user)
+                account = models.Account.objects.create(name=restaurant_name)
+                models.Membership.objects.create(
+                    account=account, user=user, role=models.Membership.Role.OWNER
+                )
+                restaurant = models.Restaurant.objects.create(
+                    account=account,
+                    name=restaurant_name,
+                    location_text=location,
+                    primary_menu_url=menu_url,
+                )
 
-            if menu_url:
-                mv = models.MenuVersion.objects.create(
-                    restaurant=restaurant,
-                    source_url=menu_url,
-                    source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
-                    raw_markdown="",
-                    status=models.MenuVersion.Status.QUEUED,
-                )
-                transaction.on_commit(
-                    lambda mv_id=str(mv.id): scrape_menu.delay(mv_id)
-                )
-            else:
-                payload = models.OutscraperPayload.objects.create(
-                    restaurant=restaurant,
-                    status=models.OutscraperPayload.Status.QUEUED,
-                    request_params={
-                        "query": f"{restaurant_name} {location}",
-                        "async": "false",
-                        "limit": 1,
-                    },
-                )
-                transaction.on_commit(
-                    lambda payload_id=str(payload.id): run_outscraper_search.delay(
-                        payload_id
+                if menu_url:
+                    mv = models.MenuVersion.objects.create(
+                        restaurant=restaurant,
+                        source_url=menu_url,
+                        source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
+                        raw_markdown="",
+                        status=models.MenuVersion.Status.QUEUED,
                     )
-                )
+                    transaction.on_commit(
+                        lambda mv_id=str(mv.id): scrape_menu.delay(mv_id)
+                    )
+                else:
+                    payload = models.OutscraperPayload.objects.create(
+                        restaurant=restaurant,
+                        status=models.OutscraperPayload.Status.QUEUED,
+                        request_params={
+                            "query": f"{restaurant_name} {location}",
+                            "async": "false",
+                            "limit": 1,
+                        },
+                    )
+                    transaction.on_commit(
+                        lambda payload_id=str(payload.id): run_outscraper_search.delay(
+                            payload_id
+                        )
+                    )
+        except IntegrityError:
+            error_message = "An account with that email already exists."
+            if is_json:
+                return JsonResponse({"error": "email_in_use"}, status=400)
+            return render(
+                request,
+                "auth/signup.html",
+                {"error": error_message, "form_data": form_data},
+            )
 
         login(request, user)
         redirect_url = reverse("dashboard", args=[restaurant.id])
@@ -132,7 +166,11 @@ def signup_view(request):
 def login_view(request):
     """Authenticate an existing user."""
     if request.method == "POST":
-        username = request.POST.get("username")
+        username = (
+            request.POST.get("username")
+            or request.POST.get("email")
+            or ""
+        ).strip()
         password = request.POST.get("password")
         user = authenticate(request, username=username, password=password)
         if user:
@@ -145,13 +183,48 @@ def login_view(request):
             if restaurant_id:
                 return redirect("dashboard", restaurant_id=restaurant_id)
             return redirect("/dashboard/")
-        return render(request, "auth/login.html", {"error": "invalid"})
+        return render(
+            request,
+            "auth/login.html",
+            {
+                "error": "We couldn't log you in. Double-check your email and password.",
+                "form_data": {"email": username},
+            },
+        )
     return render(request, "auth/login.html")
 
 
+@require_http_methods(["GET", "POST"])
+def logout_view(request):
+    """Log the user out and send them back to the login screen."""
+    logout(request)
+    redirect_target = getattr(settings, "LOGOUT_REDIRECT_URL", None) or reverse("login")
+    return redirect(redirect_target)
+
+
+@login_required
 def dashboard(request, restaurant_id):
-    restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
-    return render(request, "dashboard.html", {"restaurant": restaurant})
+    restaurant = get_object_or_404(
+        models.Restaurant.objects.select_related("account"),
+        id=restaurant_id,
+        account__membership__user=request.user,
+    )
+    recent_runs = (
+        models.IdeationRun.objects.filter(restaurant=restaurant)
+        .order_by("-created_at")[:5]
+    )
+    subscription = (
+        models.Subscription.objects.filter(account=restaurant.account)
+        .order_by("-created_at")
+        .first()
+    )
+    context = {
+        "restaurant": restaurant,
+        "recent_runs": recent_runs,
+        "subscription_status": getattr(subscription, "status", "free"),
+        "prompt_for_menu": not bool(restaurant.primary_menu_url),
+    }
+    return render(request, "dashboard.html", context)
 
 
 @login_required
@@ -191,12 +264,24 @@ def manual_menu_view(request):
     return render(request, "_partials/manual_menu.html")
 
 
+@login_required
 def concepts_view(request):
-    """Display latest concepts."""
-    concepts = models.Concept.objects.order_by("-created_at")[:9]
+    """Display latest concepts with favorite state for the user."""
+    concepts_qs = models.Concept.objects.order_by("-created_at")
+    if request.user.is_authenticated:
+        concepts_qs = concepts_qs.prefetch_related(
+            Prefetch(
+                "favoriteconcept_set",
+                queryset=models.FavoriteConcept.objects.filter(user=request.user),
+                to_attr="_favorites_for_request_user",
+            )
+        )
+    concepts = list(concepts_qs[:9])
+    concepts = _with_favorite_flags(concepts, request.user)
     return render(request, "concepts/grid.html", {"concepts": concepts})
 
 
+@login_required
 def concepts_generate_view(request):
     """Generate new concepts via mock LLM."""
     names = llm.generate_concepts()
@@ -221,9 +306,11 @@ def concepts_generate_view(request):
                 rank_order=idx,
             )
         )
+    concepts = _with_favorite_flags(concepts, request.user)
     return render(request, "concepts/grid.html", {"concepts": concepts})
 
 
+@login_required
 def concept_favorite_view(request, concept_id):
     """Toggle favorite on a concept."""
     concept = get_object_or_404(models.Concept, id=concept_id)
@@ -297,11 +384,29 @@ def dish_variation_view(request, dish_id):
     return JsonResponse({"title": variation["title"]})
 
 
+@login_required
 def favorites_view(request):
     """Render favorites dashboard."""
-    concepts = models.FavoriteConcept.objects.filter(user=request.user)
-    dishes = models.FavoriteDish.objects.filter(user=request.user)
-    ctx = {"concepts": concepts, "dishes": dishes}
+    restaurant = (
+        models.Restaurant.objects.filter(account__membership__user=request.user)
+        .select_related("account")
+        .first()
+    )
+    favorite_concepts = (
+        models.FavoriteConcept.objects.filter(user=request.user)
+        .select_related("concept__restaurant")
+        .order_by("-favorited_at")
+    )
+    favorite_dishes = (
+        models.FavoriteDish.objects.filter(user=request.user)
+        .select_related("dish__parent_concept", "dish__restaurant")
+        .order_by("-favorited_at")
+    )
+    ctx = {
+        "restaurant": restaurant,
+        "favorite_concepts": favorite_concepts,
+        "favorite_dishes": favorite_dishes,
+    }
     return render(request, "favorites/dashboard.html", ctx)
 
 
@@ -334,15 +439,22 @@ def menu_item_add_view(request, dish_id, collection_id):
 
 @login_required
 def settings_view(request):
-    restaurant = models.Restaurant.objects.filter(account__membership__user=request.user).first()
+    restaurant = (
+        models.Restaurant.objects.filter(account__membership__user=request.user)
+        .select_related("active_menu_version", "restaurantsettings")
+        .first()
+    )
     ingredients = list(
         models.Ingredient.objects.filter(restaurant=restaurant).values_list("name", flat=True)
     )
     prefs = getattr(request.user, "notificationpref", None)
+    active_menu = restaurant.active_menu_version if restaurant else None
     return render(request, "settings/main.html", {
         "restaurant": restaurant,
         "ingredients": ingredients,
         "prefs": prefs,
+        "restaurant_settings": getattr(restaurant, "restaurantsettings", None),
+        "active_menu_version": active_menu,
     })
 
 
@@ -350,12 +462,20 @@ def settings_view(request):
 @require_POST
 def update_restaurant_info(request):
     restaurant = models.Restaurant.objects.filter(account__membership__user=request.user).first()
-    restaurant.primary_menu_url = request.POST.get("menu_url")
+    if not restaurant:
+        return redirect("settings")
+
+    menu_url = (request.POST.get("menu_url") or "").strip() or None
+    restaurant.primary_menu_url = menu_url
     restaurant.save(update_fields=["primary_menu_url"])
 
-    ingredient_names = request.POST.get("ingredients", "").split(",")
+    ingredient_names = [
+        name.strip()
+        for name in (request.POST.get("ingredients", "") or "").split(",")
+        if name.strip()
+    ]
     for name in ingredient_names:
-        models.Ingredient.objects.get_or_create(restaurant=restaurant, name=name.strip())
+        models.Ingredient.objects.get_or_create(restaurant=restaurant, name=name)
 
     return redirect("settings")
 

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("", app_views.home_view, name="home"),
     path("signup/", app_views.signup_view, name="signup"),
     path("login/", app_views.login_view, name="login"),
-    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("logout/", app_views.logout_view, name="logout"),
     path("dashboard/", app_views.dashboard_redirect, name="dashboard-redirect"),
     path("dashboard/<uuid:restaurant_id>/", app_views.dashboard, name="dashboard"),
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -111,6 +111,16 @@ class ViewSmokeTests(TestCase):
         resp = self.client.post(reverse("concept-favorite", args=[concept.id]))
         self.assertTrue(resp.json()["favorited"])
 
+    def test_concepts_page_marks_existing_favorites(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+        models.FavoriteConcept.objects.create(
+            user=self.user, concept=concept, favorited_at=timezone.now()
+        )
+
+        response = self.client.get(reverse("concepts"))
+        self.assertContains(response, "★ Favorited")
+
     def test_dishes_and_generation(self):
         self._create_concepts()
         concept = models.Concept.objects.first()
@@ -172,8 +182,30 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(add_resp.status_code, 200)
 
     def test_settings_views(self):
+        self.restaurant.context_json = {"story": "Farm-to-table"}
+        self.restaurant.save(update_fields=["context_json"])
+        menu_version = models.MenuVersion.objects.create(
+            restaurant=self.restaurant,
+            source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
+            raw_markdown="Specials\n- Dish",
+            status=models.MenuVersion.Status.SUCCEEDED,
+        )
+        self.restaurant.active_menu_version = menu_version
+        self.restaurant.save(update_fields=["active_menu_version"])
+
         resp = self.client.get(reverse("settings"))
         self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Farm-to-table")
+        self.assertContains(resp, "Specials")
+
+        update_resp = self.client.post(
+            reverse("update_restaurant_info"),
+            {"menu_url": "https://example.com/new-menu"},
+        )
+        self.assertEqual(update_resp.status_code, 302)
+        self.restaurant.refresh_from_db()
+        self.assertEqual(self.restaurant.primary_menu_url, "https://example.com/new-menu")
+
         self.restaurant.primary_menu_url = "https://example.com/menu"
         self.restaurant.save(update_fields=["primary_menu_url"])
         with patch("app.views.scrape_menu.delay") as mock_delay:
@@ -182,10 +214,10 @@ class ViewSmokeTests(TestCase):
             )
         self.assertEqual(rescrape.status_code, 200)
         self.assertTrue(rescrape.json()["rescrape_complete"])
-        mv = models.MenuVersion.objects.get(restaurant=self.restaurant)
-        self.assertEqual(mv.source_url, "https://example.com/menu")
+        mv = models.MenuVersion.objects.get(restaurant=self.restaurant, source_url="https://example.com/menu")
         self.assertEqual(mv.status, models.MenuVersion.Status.QUEUED)
         mock_delay.assert_called_once_with(str(mv.id))
+
         slider = self.client.post(
             reverse("update_creativity", args=[self.restaurant.id]),
             {"classic_creative_slider": 60},
@@ -196,6 +228,25 @@ class ViewSmokeTests(TestCase):
             self.restaurant.restaurantsettings.classic_creative_slider,
             60,
         )
+
+    def test_dashboard_prompts_for_menu_when_missing(self):
+        self.restaurant.primary_menu_url = None
+        self.restaurant.save(update_fields=["primary_menu_url"])
+
+        response = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
+        self.assertContains(response, "show_menu_modal")
+
+    def test_dashboard_does_not_prompt_when_menu_exists(self):
+        self.restaurant.primary_menu_url = "https://example.com/menu"
+        self.restaurant.save(update_fields=["primary_menu_url"])
+
+        response = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
+        self.assertNotIn("show_menu_modal", response.content.decode())
+
+    def test_logout_via_get_redirects(self):
+        response = self.client.get(reverse("logout"))
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("_auth_user_id", self.client.session)
 
     def test_rescrape_menu_requires_url(self):
         self.restaurant.primary_menu_url = None

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -112,3 +112,31 @@ class SignupViewTests(TestCase):
         restaurant.refresh_from_db()
         self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
 
+    def test_form_signup_with_existing_email_shows_error(self):
+        """Duplicate email addresses should not trigger a server error."""
+        User.objects.create_user("owner@example.com", password="pw")
+
+        form_data = {
+            "email": "owner@example.com",
+            "password1": "pw",
+            "password2": "pw",
+            "restaurant_name": "Tasty Place",
+            "location": "City, State",
+        }
+
+        response = self.client.post(reverse("signup"), data=form_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already exists")
+        # Ensure no duplicate accounts were created.
+        self.assertEqual(User.objects.filter(username="owner@example.com").count(), 1)
+
+    def test_login_with_bad_credentials_returns_error(self):
+        """Failed logins should re-render the form with an error message."""
+        response = self.client.post(
+            reverse("login"), {"email": "missing@example.com", "password": "bad"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Double-check your email and password")
+


### PR DESCRIPTION
## Summary
- surface clear error messages for login and signup, allow GET-based logout, and tighten concept favorite handling
- enhance the settings page with an editable menu URL, creativity slider, and read-only context/menu snapshots
- refresh the favorites dashboard and prompt for menu details from the main dashboard when needed
- add regression tests covering the new auth feedback, dashboard prompt, settings data, and favorites indicators

## Testing
- `pytest` *(fails: Django settings/module path not configured in this environment)*
- `python manage.py test` *(reports no tests discovered in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97527ba3483328d456e555e2c242b