### PR TITLE
Make concept cards trigger dish generation on click

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -1,5 +1,7 @@
-<button 
-  hx-post="{% url 'concept-favorite' concept.id %}" 
+<button
+  type="button"
+  onclick="event.stopPropagation();"
+  hx-post="{% url 'concept-favorite' concept.id %}"
   hx-target="this"
   hx-swap="outerHTML"
   class="text-xl transition duration-200 {% if favorited %}text-red-500{% else %}text-slate-400{% endif %}">

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -25,21 +25,22 @@
   <div id="concepts-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     {% for concept in concepts %}
       <div class="flip-scene">
-        <div class="flip-card" id="concept-{{ concept.id }}">
+        <div
+          class="flip-card cursor-pointer"
+          id="concept-{{ concept.id }}"
+          hx-post="{% url 'dishes-generate' concept.id %}"
+          hx-target="#concepts-grid"
+          hx-swap="outerHTML"
+          hx-trigger="click"
+        >
           <!-- FRONT -->
-          <div class="flip-face bg-white p-6 rounded-2xl shadow-md border border-slate-200">
+          <div class="flip-face bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg">
             <h2 class="text-xl font-bold text-[#49475B]">{{ concept.name }}</h2>
             <div class="mt-4 flex justify-between items-center">
               <span class="text-sm text-slate-500">Rank: {{ concept.rank_order }}</span>
               {% include "concepts/_favorite_button.html" %}
             </div>
-            <button 
-              hx-post="{% url 'dishes-generate' concept.id %}"
-              hx-target="#concepts-grid"
-              hx-swap="outerHTML"
-              class="mt-4 w-full px-4 py-2 bg-[#FF8300] text-white rounded-xl shadow hover:bg-[#d96f00] transition">
-              View Dish Ideas
-            </button>
+            <p class="mt-4 text-sm text-slate-500">Click to generate dish ideas.</p>
           </div>
 
           <!-- BACK (loading state) -->


### PR DESCRIPTION
## Summary
- trigger dish generation by clicking anywhere on a concept card and remove the separate call-to-action button
- add inline copy and hover styling to reinforce the new interaction
- prevent clicks on the favorite heart from bubbling up and firing the dish generation request

## Testing
- `pytest` *(fails: Django settings are not configured in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c38fdba48332b7117d09bebbbf79