### PR TITLE
Add dish variation generator with flip-card UI

### DIFF
--- a/app/templates/dishes/_dish_card.html
+++ b/app/templates/dishes/_dish_card.html
@@ -1,0 +1,47 @@
+<div class="flip-scene dish-card-wrapper" id="dish-{{ dish.id }}">
+  <div class="flip-card">
+    <div class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition flex flex-col justify-between hover:shadow-lg">
+      <div>
+        <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
+        <p class="text-slate-600 mt-2">{{ dish.description }}</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          {% for tag in dish.category_tags %}
+            <span class="px-2 py-1 rounded-full bg-[#B993D6]/10 text-[#49475B] text-xs">{{ tag }}</span>
+          {% endfor %}
+          {% with ingredients=dish.ingredient_names %}
+            {% if ingredients %}
+              {% for tag in ingredients %}
+                <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
+              {% endfor %}
+            {% elif dish.ingredient_overlap %}
+              {% for tag in dish.ingredient_overlap %}
+                <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
+              {% endfor %}
+            {% endif %}
+          {% endwith %}
+        </div>
+      </div>
+      <div class="mt-4 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          {% include "dishes/_favorite_button.html" %}
+          <button
+            type="button"
+            class="dish-variation-btn text-slate-500 hover:text-slate-700 transition"
+            hx-post="{% url 'dish-variation' dish.id %}"
+            hx-trigger="click"
+            hx-target="closest .dish-card-wrapper"
+            hx-swap="outerHTML"
+            aria-label="Generate a variation of {{ dish.title }}"
+          >♻️</button>
+        </div>
+      </div>
+    </div>
+    <div class="flip-face flip-back bg-slate-800 text-white p-6 rounded-2xl flex flex-col items-center justify-center">
+      <svg class="animate-spin h-8 w-8 mb-3 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+      </svg>
+      <p class="text-sm font-medium">Mixing up a fresh variation…</p>
+    </div>
+  </div>
+</div>

--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -1,41 +1,70 @@
 {# templates/dishes/grid.html #}
 
+<style>
+  .flip-scene {
+    perspective: 1200px;
+  }
+
+  .flip-card {
+    position: relative;
+    width: 100%;
+    min-height: 220px;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+  }
+
+  .flip-card.flipped {
+    transform: rotateY(180deg);
+  }
+
+  .flip-face {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: 1rem;
+    overflow: hidden;
+  }
+
+  .flip-face.front {
+    transform: rotateY(0deg);
+  }
+
+  .flip-face.flip-back {
+    transform: rotateY(180deg);
+  }
+</style>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
   {% for dish in dishes %}
-
-    <div class="p-6 rounded-2xl shadow-md bg-white border border-slate-200 hover:shadow-lg transition flex flex-col justify-between">
-      <div>
-        <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
-        <p class="text-slate-600 mt-2">{{ dish.description }}</p>
-        <div class="mt-3 flex flex-wrap gap-2">
-          {% for tag in dish.category_tags %}
-            <span class="px-2 py-1 rounded-full bg-[#B993D6]/10 text-[#49475B] text-xs">
-              {{ tag }}
-            </span>
-          {% endfor %}
-                    {% for tag in dish.ingredient_overlap %}
-            <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">
-              {{ tag }}
-            </span>
-          {% endfor %}
-        </div>
-      </div>
-
-      <!-- Heart toggle -->
-      <div class="mt-4 flex items-center justify-between">
-       <button
-  hx-post="{% url 'dish_favorite' dish.id %}"
-  hx-trigger="click"
-  hx-swap="outerHTML"
-  class="favorite-btn text-[#f08000] transition"
-  aria-label="Favorite {{ dish.title }}"
->
-  {% if dish.is_favorited %}
-    ❤️
-  {% else %}
-    🤍
-  {% endif %}
-</button>
-
-      </div>
-    </div>
+    {% include "dishes/_dish_card.html" %}
   {% endfor %}
+</div>
+
+<script>
+  if (!window.__dishVariationHandlers) {
+    window.__dishVariationHandlers = true;
+
+    document.body.addEventListener("htmx:beforeRequest", function (evt) {
+      const trigger = evt.detail.elt;
+      if (trigger && trigger.classList.contains("dish-variation-btn")) {
+        const card = trigger.closest(".flip-card");
+        if (card) {
+          card.classList.add("flipped");
+        }
+      }
+    });
+
+    document.body.addEventListener("htmx:responseError", function (evt) {
+      const trigger = evt.detail.elt;
+      if (trigger && trigger.classList.contains("dish-variation-btn")) {
+        const card = trigger.closest(".flip-card");
+        if (card) {
+          card.classList.remove("flipped");
+        }
+      }
+    });
+  }
+</script>

--- a/app/views.py
+++ b/app/views.py
@@ -578,11 +578,156 @@ def dish_favorite_view(request, dish_id):
     return HttpResponse(html)
 
 
+@login_required
+@require_POST
 def dish_variation_view(request, dish_id):
-    """Return a variation of a dish."""
-    dish = get_object_or_404(models.DishIdea, id=dish_id)
-    variation = llm.generate_dishes(dish.title)[0]
-    return JsonResponse({"title": variation["title"]})
+    """Return a freshly generated variation of a dish."""
+    dish = get_object_or_404(
+        models.DishIdea.objects.select_related(
+            "restaurant", "parent_concept", "parent_dish", "ideation_run"
+        ),
+        id=dish_id,
+    )
+
+    base_dish = dish.parent_dish or dish
+    concept = dish.parent_concept
+    restaurant = dish.restaurant
+
+    restaurant_payload = restaurant.context_json or {}
+    menu_markdown = restaurant.primary_menu_url or ""
+    context = serialize_restaurant_context(restaurant_payload, menu_markdown, concept)
+
+    existing_variations = list(
+        models.DishIdea.objects.filter(parent_dish=base_dish).order_by("created_at")
+    )
+    previous_titles = [base_dish.title] + [v.title for v in existing_variations]
+    variation_number = len(existing_variations) + 1
+
+    schema = {
+        "name": "dish_variation",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "ingredient_overlap": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "category_tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": [
+                "title",
+                "description",
+                "ingredient_overlap",
+                "category_tags",
+            ],
+            "additionalProperties": False,
+        },
+        "type": "json_schema",
+        "strict": True,
+    }
+
+    variation_payload = {
+        "context": context,
+        "original_dish": {
+            "title": base_dish.title,
+            "description": base_dish.description,
+            "ingredient_overlap": getattr(base_dish, "ingredient_names", []),
+            "category_tags": base_dish.category_tags,
+        },
+        "previous_variations": [
+            {
+                "title": v.title,
+                "description": v.description,
+            }
+            for v in existing_variations
+        ],
+    }
+
+    result = None
+    max_attempts = 3
+
+    for attempt in range(max_attempts):
+        attempt_number = variation_number + attempt
+        prompt = (
+            "Generate a fresh culinary variation number {num} for the dish "
+            "'{title}' that fits the restaurant context and concept. Avoid repeating "
+            "any of these titles: {avoid}. Provide descriptive but concise copy."
+        ).format(
+            num=attempt_number,
+            title=base_dish.title,
+            avoid=", ".join(previous_titles) if previous_titles else "none",
+        )
+
+        try:
+            if client:
+                response = client.responses.create(
+                    model="gpt-4.1",
+                    input=[
+                        {"role": "user", "content": prompt},
+                        {"role": "user", "content": json.dumps(variation_payload, indent=2)},
+                    ],
+                    text={"format": schema},
+                )
+                raw_text = response.output[0].content[0].text
+                candidate = json.loads(raw_text)
+            else:
+                candidate = {
+                    "title": f"{base_dish.title} Variation {attempt_number}",
+                    "description": (
+                        f"A playful take on {base_dish.title} inspired by variation {attempt_number}."
+                    ),
+                    "ingredient_overlap": list(
+                        getattr(base_dish, "ingredient_names", [])[:3]
+                    ),
+                    "category_tags": list(base_dish.category_tags or []),
+                }
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Dish variation generation failed: %s", exc)
+            candidate = None
+
+        if candidate and candidate.get("title") not in previous_titles:
+            result = candidate
+            break
+
+        if candidate:
+            previous_titles.append(candidate.get("title"))
+
+    if not result:
+        result = {
+            "title": f"{base_dish.title} Variation {variation_number}",
+            "description": (
+                f"A creative riff on {base_dish.title} with new textures and flavors."
+            ),
+            "ingredient_overlap": list(getattr(base_dish, "ingredient_names", [])[:3]),
+            "category_tags": list(base_dish.category_tags or []),
+        }
+
+    ingredient_overlap = result.get("ingredient_overlap") or []
+    category_tags = result.get("category_tags") or []
+
+    new_dish = models.DishIdea.objects.create(
+        restaurant=restaurant,
+        ideation_run=dish.ideation_run,
+        parent_concept=concept,
+        parent_dish=base_dish,
+        title=result["title"],
+        description=result["description"],
+        ingredient_names=ingredient_overlap,
+        category_tags=category_tags,
+    )
+
+    new_dish.is_favorited = False
+    new_dish.ingredient_overlap = new_dish.ingredient_names
+
+    html = render_to_string(
+        "dishes/_dish_card.html", {"dish": new_dish}, request=request
+    )
+    return HttpResponse(html)
 
 
 @login_required

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -48,6 +48,77 @@ class ConceptGridViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "concept-card", count=9)
 
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class DishVariationViewTests(TestCase):
+    """Ensure dish variations can be generated on demand."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="chef@example.com", password="pass1234"
+        )
+        account = models.Account.objects.create(name="Chef Co")
+        models.Membership.objects.create(
+            account=account, user=self.user, role=models.Membership.Role.OWNER
+        )
+        self.restaurant = models.Restaurant.objects.create(
+            account=account,
+            name="Flavor Town",
+            location_text="Somewhere",
+            context_json={"name": "Flavor Town"},
+        )
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="mock",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=concept_run,
+            name="Garden Fresh",
+            subtitle="",
+            rank_order=1,
+        )
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="mock",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=self.concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.dish = models.DishIdea.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=dish_run,
+            parent_concept=self.concept,
+            title="Sunrise Salad",
+            description="Citrus-dressed greens.",
+            ingredient_names=["orange", "mint"],
+            category_tags=["salad"],
+        )
+
+    @patch("app.views.client", new=None)
+    def test_variation_request_creates_child_dish(self, _client=None):
+        self.client.login(username="chef@example.com", password="pass1234")
+        url = reverse("dish-variation", args=[self.dish.id])
+        response = self.client.post(url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        children = models.DishIdea.objects.filter(parent_dish=self.dish)
+        self.assertEqual(children.count(), 1)
+        new_dish = children.first()
+        self.assertIn(str(new_dish.id), response.content.decode())
+        self.assertTrue(new_dish.title.startswith(self.dish.title))
+
+
 @override_settings(SECURE_SSL_REDIRECT=False)
 class TaskExecutionTests(TestCase):
     """Tests for external API tasks."""


### PR DESCRIPTION
## Summary
- add a singular dish variation endpoint that reuses restaurant and concept context when prompting the LLM
- refresh the dishes grid with flip-card UI, a recycle trigger, and loading state while fetching variations
- cover the variation flow with a Django test to ensure a new child dish is created and returned

## Testing
- python manage.py test tests.test_llm_views_tasks.DishVariationViewTests.test_variation_request_creates_child_dish


------
https://chatgpt.com/codex/tasks/task_e_68caed4ff4b883329c934a1b7c12f41d