### PR TITLE
Adjust dish grid actions layout

### DIFF
--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -7,6 +7,7 @@
 
   .flip-card {
     position: relative;
+    display: grid;
     width: 100%;
     min-height: 280px;
     transition: transform 0.6s;
@@ -18,14 +19,12 @@
   }
 
   .flip-face {
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative;
+    grid-area: 1 / 1;
     width: 100%;
-    height: 100%;
     backface-visibility: hidden;
     border-radius: 1rem;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .flip-face.front {
@@ -35,52 +34,68 @@
   .flip-face.flip-back {
     transform: rotateY(180deg);
   }
-  .dish-card-wrapper .flip-face.front p {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;  /* show only 3 lines */
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
+
+  .dish-card-wrapper {
+    padding-bottom: 2.5rem;
+  }
+  .dish-card-actions {
+    position: absolute;
+    right: 1.5rem;
+    bottom: -1.5rem;
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 9999px;
+    background: #ffffff;
+    box-shadow: 0 10px 25px rgba(73, 71, 91, 0.12);
+    align-items: center;
+  }
+
+  .dish-card-actions button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
 
 </style>
 
   {% for dish in dishes %}
         <div class="flip-scene dish-card-wrapper" id="dish-{{ dish.id }}">
       <div class="flip-card">
-        <div class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition flex flex-col justify-between hover:shadow-lg">
+        <div class="flip-face front bg-white p-6 pb-16 rounded-2xl shadow-md border border-slate-200 transition flex flex-col gap-4 hover:shadow-lg">
           <div>
             <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
             <p class="text-slate-600 mt-2">{{ dish.description }}</p>
             <div class="mt-3 flex flex-wrap gap-2">
-              {% for tag in dish.category_tags %}
+              {% for tag in dish.category_tags|slice:":3" %}
                 <span class="px-2 py-1 rounded-full bg-[#B993D6]/10 text-[#49475B] text-xs">{{ tag }}</span>
               {% endfor %}
               {% with ingredients=dish.ingredient_names %}
                 {% if ingredients %}
-                  {% for tag in ingredients %}
+                  {% for tag in ingredients|slice:":3" %}
                     <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
                   {% endfor %}
                 {% elif dish.ingredient_overlap %}
-                  {% for tag in dish.ingredient_overlap %}
+                  {% for tag in dish.ingredient_overlap|slice:":3" %}
                     <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
                   {% endfor %}
                 {% endif %}
               {% endwith %}
             </div>
           </div>
-          <div class="mt-4 flex items-center justify-between">
-            <div class="flex items-center gap-3">
-              {% include "dishes/_favorite_button.html" %}
-              <button
-                type="button"
-                class="dish-variation-btn text-slate-500 hover:text-slate-700 transition"
-                hx-post="{% url 'dish-variation' dish.id %}"
-                hx-trigger="click"
-                hx-target="closest .dish-card-wrapper"
-                hx-swap="outerHTML"
-                aria-label="Generate a variation of {{ dish.title }}"
-              >♻️</button>
-            </div>
+          <div class="dish-card-actions">
+            {% include "dishes/_favorite_button.html" %}
+            <button
+              type="button"
+              class="dish-variation-btn text-slate-500 hover:text-slate-700 transition"
+              hx-post="{% url 'dish-variation' dish.id %}"
+              hx-trigger="click"
+              hx-target="closest .dish-card-wrapper"
+              hx-swap="outerHTML"
+              aria-label="Generate a variation of {{ dish.title }}"
+            >
+              <i class="fa-solid fa-rotate" aria-hidden="true"></i>
+            </button>
           </div>
         </div>
         <div class="flip-face flip-back bg-slate-800 text-white p-6 rounded-2xl flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- update dish grid cards to size naturally, reposition the favorite and variation controls in a floating action tab, and switch the variation trigger to the Font Awesome rotate icon
- show at most three category tags and three ingredient tags while keeping full dish descriptions visible

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68caf772d2008332a61c7e822c167b1e