### PR TITLE
Add enhanced dish card controls and delete endpoint

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -8,43 +8,57 @@
         style="background-image: url('{{ dish.enhancement_image_url }}');"
       {% endif %}
     >
-      <div class="card-inner p-6 gap-4">
-        <div>
+      <div class="card-inner p-6 pb-14 gap-4">
+        <div class="card-content">
           <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
           {% if dish.description %}
             <p class="text-slate-600 mt-2 clamp-3">{{ dish.description }}</p>
           {% endif %}
           <div class="mt-3 flex flex-wrap gap-2">
             {% if dish.enhancement_price_display %}
-              <span class="px-2 py-1 rounded-full bg-red-600 text-white text-xs font-semibold">
+              <span class="dish-tag dish-tag--price">
                 {{ dish.enhancement_price_display }}
               </span>
             {% endif %}
             {% for tag in dish.category_tags %}
-              <span class="px-2 py-1 rounded-full bg-[#B993D6]/10 text-[#49475B] text-xs">{{ tag }}</span>
+              <span class="dish-tag dish-tag--category">{{ tag }}</span>
             {% endfor %}
             {% with ingredients=dish.ingredient_overlap %}
               {% if ingredients %}
                 {% for tag in ingredients %}
-                  <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
+                  <span class="dish-tag dish-tag--ingredient">{{ tag }}</span>
                 {% endfor %}
               {% endif %}
             {% endwith %}
           </div>
         </div>
-        <div class="mt-4 flex items-center justify-between">
-          <div class="flex items-center gap-3">
-            {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name %}
-            <button
-              type="button"
-              class="dish-variation-btn text-slate-500 hover:text-slate-700 transition"
-              hx-post="{% url 'dish-variation' dish.id %}"
-              hx-trigger="click"
-              hx-target="closest .dish-card-wrapper"
-              hx-swap="outerHTML"
-              aria-label="Generate a variation of {{ dish.title }}"
-            >♻️</button>
-          </div>
+        <div class="card-footer mt-auto">
+          {% if dish.is_enhanced %}
+            <div class="card-action-tab">
+              <button
+                type="button"
+                class="dish-delete-btn card-action-button text-white transition"
+                hx-post="{% url 'dish-delete' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Delete {{ dish.title }}"
+              >🗑️</button>
+            </div>
+          {% else %}
+            <div class="card-action-tab">
+              {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name %}
+              <button
+                type="button"
+                class="dish-variation-btn card-action-button text-slate-500 hover:text-slate-700 transition"
+                hx-post="{% url 'dish-variation' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Generate a variation of {{ dish.title }}"
+              >♻️</button>
+            </div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -7,7 +7,7 @@
   .flip-card {
     position: relative;
     width: 100%;
-    min-height: 280px;
+    min-height: 340px;
     transition: transform 0.6s;
     transform-style: preserve-3d;
   }
@@ -29,6 +29,7 @@
 
   .flip-face.front {
     transform: rotateY(0deg);
+    overflow: visible;
   }
 
   .flip-face.flip-back {
@@ -82,6 +83,113 @@
 
   .flip-face.front.enhanced {
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+  }
+
+  .card-footer {
+    position: relative;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .card-action-tab {
+    position: absolute;
+    right: 1.5rem;
+    bottom: -1.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 9999px;
+    background: #ffffff;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.18);
+    z-index: 2;
+  }
+
+  .card-action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    background: transparent;
+    border: none;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: transform 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+  }
+
+  .card-action-button:hover {
+    transform: translateY(-1px);
+  }
+
+  .card-action-button:focus-visible {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
+
+  .flip-face.front.enhanced .card-action-tab {
+    background: rgba(15, 23, 42, 0.85);
+    border-color: rgba(255, 255, 255, 0.25);
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.5);
+  }
+
+  .flip-face.front.enhanced .card-action-button {
+    color: rgba(248, 250, 252, 0.95);
+  }
+
+  .flip-face.front.enhanced .card-action-button:hover {
+    color: #fca5a5;
+  }
+
+  .dish-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: rgba(73, 71, 91, 0.08);
+    color: #49475b;
+  }
+
+  .dish-tag--category {
+    background: rgba(185, 147, 214, 0.14);
+  }
+
+  .dish-tag--ingredient {
+    background: rgba(142, 0, 139, 0.12);
+  }
+
+  .dish-tag--price {
+    background: #dc2626;
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  .flip-face.front.enhanced .dish-tag {
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: rgba(248, 250, 252, 0.95);
+  }
+
+  .flip-face.front.enhanced .dish-tag--category {
+    background: rgba(165, 180, 252, 0.35);
+    border-color: transparent;
+  }
+
+  .flip-face.front.enhanced .dish-tag--ingredient {
+    background: rgba(244, 114, 182, 0.35);
+    border-color: transparent;
+  }
+
+  .flip-face.front.enhanced .dish-tag--price {
+    background: rgba(248, 113, 113, 0.95);
+    border-color: transparent;
   }
 </style>
 

--- a/app/templates/dishes/_favorite_button.html
+++ b/app/templates/dishes/_favorite_button.html
@@ -3,7 +3,7 @@
   hx-trigger="click"
   hx-swap="outerHTML"
   hx-target="closest .dish-card-wrapper"
-  class="favorite-btn text-[#f08000] transition"
+  class="favorite-btn card-action-button text-[#f08000] transition"
   aria-label="Favorite {{ dish.title }}"
 >
   {% if dish.is_favorited %}

--- a/app/views.py
+++ b/app/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
 from django.db.models import Prefetch
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -709,6 +709,35 @@ def dish_favorite_view(request, dish_id):
         request=request,
     )
     return HttpResponse(html)
+
+
+@login_required
+@require_POST
+def dish_delete_view(request, dish_id):
+    """Delete a dish and remove any associated enhancement assets."""
+
+    dish = get_object_or_404(
+        models.DishIdea.objects.select_related("restaurant"),
+        id=dish_id,
+    )
+
+    is_member = models.Membership.objects.filter(
+        account=dish.restaurant.account, user=request.user
+    ).exists()
+    if not is_member:
+        return HttpResponseForbidden()
+
+    enhancements = list(
+        models.Enhancement.objects.filter(dish=dish).select_related("image_asset")
+    )
+    asset_ids = [enh.image_asset_id for enh in enhancements if enh.image_asset_id]
+
+    dish.delete()
+
+    if asset_ids:
+        models.Asset.objects.filter(id__in=asset_ids).delete()
+
+    return HttpResponse("")
 
 
 @login_required

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
 
     path("dishes/<uuid:dish_id>/favorite/", app_views.dish_favorite_view, name="dish_favorite"),
     path("dishes/variation/<uuid:dish_id>/", app_views.dish_variation_view, name="dish-variation"),
+    path("dishes/<uuid:dish_id>/delete/", app_views.dish_delete_view, name="dish-delete"),
     path("favorites/", app_views.favorites_view, name="favorites"),
     path("menus/", app_views.menus_view, name="menus"),
     path("favorites/remove/<str:type>/<uuid:id>/", app_views.favorite_remove_view, name="favorite-remove"),

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -140,6 +140,78 @@ class ViewSmokeTests(TestCase):
         var_resp = self.client.post(reverse("dish-variation", args=[dish.id]))
         self.assertEqual(var_resp.status_code, 200)
 
+    def test_dish_delete_removes_dish_and_assets(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+        self._create_dishes(concept)
+        dish = models.DishIdea.objects.first()
+
+        asset = models.Asset.objects.create(
+            kind=models.Asset.Kind.IMAGE,
+            storage_key="test/key",
+            public_url="https://example.com/image.jpg",
+        )
+        models.Enhancement.objects.create(
+            dish=dish,
+            triggered_by_user=self.user,
+            status=models.Enhancement.Status.SUCCEEDED,
+            image_asset=asset,
+            model_name="test-model",
+        )
+
+        resp = self.client.post(reverse("dish-delete", args=[dish.id]))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, b"")
+        self.assertFalse(models.DishIdea.objects.filter(id=dish.id).exists())
+        self.assertFalse(models.Asset.objects.filter(id=asset.id).exists())
+
+    def test_dish_delete_requires_membership(self):
+        other_account = models.Account.objects.create(name="Other")
+        other_restaurant = models.Restaurant.objects.create(
+            account=other_account, name="Other R", location_text="Town"
+        )
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=other_restaurant,
+            initiated_by_user=None,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        other_concept = models.Concept.objects.create(
+            restaurant=other_restaurant,
+            ideation_run=concept_run,
+            name="Other Concept",
+            subtitle="Sub",
+            rank_order=0,
+        )
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=other_restaurant,
+            initiated_by_user=None,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=other_concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        other_dish = models.DishIdea.objects.create(
+            restaurant=other_restaurant,
+            ideation_run=dish_run,
+            parent_concept=other_concept,
+            title="Other Dish",
+            description="Desc",
+            ingredient_names=[],
+            category_tags=[],
+        )
+
+        resp = self.client.post(reverse("dish-delete", args=[other_dish.id]))
+        self.assertEqual(resp.status_code, 403)
+        self.assertTrue(models.DishIdea.objects.filter(id=other_dish.id).exists())
+
     def test_favorites_views(self):
         resp = self.client.get(reverse("favorites"))
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- restyle the dish card action area so the favorite/variation controls appear as a floating tab and adjust tag styling for enhanced dishes
- add an HTMX-powered delete button for enhanced dishes along with supporting backend endpoint
- cover the delete flow with tests to ensure enhancements and assets are removed and membership is enforced

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68cb11775fa88332a8ab7c89824af65d