### PR TITLE
Fix concept favorite button after concept generation

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -1,6 +1,6 @@
 <button
   type="button"
-  onclick="event.stopPropagation();"
+  hx-on::click="event.stopPropagation()"
   hx-post="{% url 'concept-favorite' concept.id %}"
   hx-target="this"
   hx-swap="outerHTML"


### PR DESCRIPTION
## Summary
- stop the concept favorite button click from bubbling using `hx-on::click`
- ensure the heart button continues to work after new concepts are generated by HTMX

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68cb1dbec3488332b5411215e36fffb4