### PR TITLE
Add lazy-loaded concept background sketches

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -13,9 +13,11 @@ import logging
 import os
 import uuid
 from typing import Dict, List, Optional
-from google import genai
-from google.genai import types
-import requests
+try:  # pragma: no cover - optional dependency
+    from google import genai
+except ImportError:  # pragma: no cover - optional dependency
+    genai = None
+
 from openai import OpenAI
 
 from dotenv import load_dotenv
@@ -30,8 +32,9 @@ _openai_api_key = os.getenv("OPENAI_API_KEY")
 _gemini_api_key = os.getenv("GEMINI_API_KEY")
 logger.info(_gemini_api_key)
 client = OpenAI(api_key=_openai_api_key) if _openai_api_key else None
-gemini_client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+gemini_client = genai.Client(api_key=_gemini_api_key) if genai and _gemini_api_key else None
 DEFAULT_IMAGE_URL = "https://placehold.co/800x600?text=Dish"
+DEFAULT_CONCEPT_IMAGE_URL = "https://placehold.co/1200x800?text=Concept"
 DEFAULT_PRICE_CENTS = 1500
 
 
@@ -55,24 +58,34 @@ def _gemini_image_prompt(title: str, description: str) -> str:
         "Use a hero restaurant plating style, natural lighting, and a soft focus background.\n"
         f"Title: {title}\nDescription: {description}"
     )
-    
-def _call_gemini_for_image(title: str, description: str) -> str:
-    """Return a data URL for the generated image using the Gemini SDK."""
 
-    if not _gemini_api_key:
-        return DEFAULT_IMAGE_URL
+
+def _gemini_concept_sketch_prompt(name: str, subtitle: str) -> str:
+    """Describe a lightweight concept sketch request for Gemini."""
+
+    subtitle_text = subtitle or ""
+    return (
+        "Create a monochrome pencil sketch that could serve as background art for a "
+        "restaurant concept card. Keep the lines clean with minimal shading so the image "
+        "stays lightweight, but output it at a high-definition resolution. Avoid text, "
+        "logos, or color.\n"
+        f"Concept name: {name}\n"
+        f"Concept subtitle: {subtitle_text}"
+    )
+
+
+def _fetch_gemini_image(prompt: str, default_url: str) -> str:
+    """Return inline image data for the given prompt or a fallback URL."""
+
+    if not _gemini_api_key or not gemini_client:
+        return default_url
 
     try:
-        # Build the prompt
-        prompt = _gemini_image_prompt(title, description)
-
-        # Call the image preview model
         response = gemini_client.models.generate_content(
             model="gemini-2.5-flash-image-preview",
             contents=[prompt],
         )
 
-        # Look for inline image data
         if response.candidates and response.candidates[0].content.parts:
             for part in response.candidates[0].content.parts:
                 if part.inline_data is not None:
@@ -85,7 +98,21 @@ def _call_gemini_for_image(title: str, description: str) -> str:
     except Exception as exc:
         logger.warning("Gemini image generation failed: %s", exc, exc_info=True)
 
-    return DEFAULT_IMAGE_URL
+    return default_url
+
+
+def _call_gemini_for_image(title: str, description: str) -> str:
+    """Return a data URL for the generated dish image using the Gemini SDK."""
+
+    prompt = _gemini_image_prompt(title, description)
+    return _fetch_gemini_image(prompt, DEFAULT_IMAGE_URL)
+
+
+def _call_gemini_for_concept_sketch(name: str, subtitle: str) -> str:
+    """Return a Gemini generated concept sketch or a placeholder image."""
+
+    prompt = _gemini_concept_sketch_prompt(name, subtitle)
+    return _fetch_gemini_image(prompt, DEFAULT_CONCEPT_IMAGE_URL)
 
 
 def _format_menu_snapshot(restaurant: models.Restaurant) -> Dict[str, Optional[str]]:
@@ -189,3 +216,9 @@ def enhance_dish(dish: models.DishIdea, restaurant: models.Restaurant) -> Dict[s
         "snapshot": snapshot,
         "reference": str(uuid.uuid4()),
     }
+
+
+def generate_concept_sketch(concept: models.Concept) -> str:
+    """Return a concept background sketch for the provided concept."""
+
+    return _call_gemini_for_concept_sketch(concept.name, concept.subtitle)

--- a/app/templates/concepts/_concept_background.html
+++ b/app/templates/concepts/_concept_background.html
@@ -1,0 +1,1 @@
+<div class="concept-card-background concept-card-background--loaded" style="background-image: url('{{ image_url }}');" aria-hidden="true"></div>

--- a/app/templates/concepts/_concepts_grid.html
+++ b/app/templates/concepts/_concepts_grid.html
@@ -4,11 +4,17 @@
         hx-post="{% url 'dishes-generate' concept.id %}" hx-target="#concepts-grid" hx-swap="innerHTML"
         hx-trigger="click">
         <div
-          class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg">
-          <h2 class="text-xl font-bold text-[#49475B]">{{ concept.name }}</h2>
-          <p class="subtitle">{{ concept.subtitle }}</p>
-          <div class="mt-4 flex justify-between items-center">
-            {% include "concepts/_favorite_button.html" %}
+          class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg relative overflow-hidden">
+          <div class="concept-card-background concept-card-background--loading" aria-hidden="true"
+            hx-get="{% url 'concept-background' concept.id %}" hx-trigger="load" hx-target="this" hx-swap="outerHTML">
+          </div>
+          <div class="concept-card-overlay" aria-hidden="true"></div>
+          <div class="relative z-10 flex flex-col h-full">
+            <h2 class="text-xl font-bold text-[#49475B] drop-shadow-sm">{{ concept.name }}</h2>
+            <p class="subtitle mt-2 text-slate-700 drop-shadow-sm">{{ concept.subtitle }}</p>
+            <div class="mt-4 flex justify-between items-center">
+              {% include "concepts/_favorite_button.html" %}
+            </div>
           </div>
         </div>
         <div class="flip-face flip-back bg-slate-800 text-white p-6 rounded-2xl">

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -36,6 +36,31 @@ border: 1px solid #e2e8f0;
 cursor: pointer;
 transform: rotateY(0deg);
 }
+.concept-card-background {
+position: absolute;
+inset: 0;
+background-size: cover;
+background-position: center;
+filter: grayscale(100%);
+opacity: 0;
+transition: opacity 0.4s ease;
+z-index: 1;
+pointer-events: none;
+}
+.concept-card-background--loading {
+background: radial-gradient(circle at center, rgba(226,232,240,0.8), rgba(226,232,240,0.4));
+opacity: 1;
+}
+.concept-card-background--loaded {
+opacity: 0.35;
+}
+.concept-card-overlay {
+position: absolute;
+inset: 0;
+background: linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.95));
+z-index: 5;
+pointer-events: none;
+}
 /* Back */
 .flip-face.flip-back {
 background: #1e293b;

--- a/app/views.py
+++ b/app/views.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.http import require_http_methods, require_POST
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from . import models
 from django.template.loader import render_to_string
 from pydantic import BaseModel
@@ -382,6 +382,20 @@ def concept_favorite_view(request, concept_id):
         request=request,
     )
     return HttpResponse(html)
+
+
+@login_required
+@require_GET
+def concept_background_view(request, concept_id):
+    """Return the lazy-loaded background sketch for a concept card."""
+
+    concept = get_object_or_404(models.Concept, id=concept_id)
+    image_url = llm.generate_concept_sketch(concept)
+    return render(
+        request,
+        "concepts/_concept_background.html",
+        {"image_url": image_url},
+    )
 
 def serialize_restaurant_context(restaurant_payload, menu_markdown, concept):
     """Return a slim JSON-serializable context for dish generation."""

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
     path("concepts/", app_views.concepts_view, name="concepts"),
     path("concepts/generate/", app_views.concepts_generate_view, name="concepts-generate"),
     path("concepts/<uuid:concept_id>/favorite/", app_views.concept_favorite_view, name="concept-favorite"),
+    path(
+        "concepts/<uuid:concept_id>/background/",
+        app_views.concept_background_view,
+        name="concept-background",
+    ),
     path("dishes/<uuid:concept_id>/generate/", app_views.dishes_generate_view, name="dishes-generate"),
 
     path("dishes/<uuid:dish_id>/favorite/", app_views.dish_favorite_view, name="dish_favorite"),

--- a/tests/test_concept_background.py
+++ b/tests/test_concept_background.py
@@ -1,0 +1,52 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from app import llm, models
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class ConceptBackgroundViewTests(TestCase):
+    """Verify the lazy concept background view returns a usable image URL."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user("user@example.com", password="pw")
+        self.account = models.Account.objects.create(name="Account")
+        models.Membership.objects.create(
+            account=self.account,
+            user=self.user,
+            role=models.Membership.Role.OWNER,
+        )
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="Test Restaurant",
+            location_text="Test City",
+        )
+        models.RestaurantSettings.objects.create(restaurant=self.restaurant)
+        self.client.login(username="user@example.com", password="pw")
+
+        self.run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="mock",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=self.run,
+            name="Evening Jazz",
+            subtitle="Warm vibes with live music.",
+            rank_order=1,
+        )
+
+    def test_returns_placeholder_image_without_gemini_key(self) -> None:
+        url = reverse("concept-background", args=[self.concept.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("concept-card-background concept-card-background--loaded", content)
+        self.assertIn(llm.DEFAULT_CONCEPT_IMAGE_URL, content)


### PR DESCRIPTION
## Summary
- add an HTMX-driven background loader to concept cards so sketches appear as Gemini requests finish
- provide a Gemini helper and view endpoint that return lightweight pencil sketch images with fallbacks
- cover the new background endpoint with a focused test case

## Testing
- python manage.py test tests.test_concept_background

------
https://chatgpt.com/codex/tasks/task_e_68cb1d9698c08332aa433d0d30d415f5