### PR TITLE
Generate concept backgrounds on favorite

### DIFF
--- a/app/templates/concepts/_concept_background.html
+++ b/app/templates/concepts/_concept_background.html
@@ -1,1 +1,7 @@
-<div class="concept-card-background concept-card-background--loaded" style="background-image: url('{{ image_url }}');" aria-hidden="true"></div>
+<div
+  id="concept-{{ concept.id }}-background"
+  class="concept-card-background {% if image_url %}concept-card-background--loaded{% else %}concept-card-background--loading{% endif %}"
+  {% if image_url %}style="background-image: url('{{ image_url }}');"{% endif %}
+  aria-hidden="true"
+  hx-swap-oob="true"
+></div>

--- a/app/templates/concepts/_concepts_grid.html
+++ b/app/templates/concepts/_concepts_grid.html
@@ -5,14 +5,14 @@
         hx-trigger="click">
         <div
           class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg relative overflow-hidden">
-          <div class="concept-card-background concept-card-background--loading" aria-hidden="true"
-            hx-get="{% url 'concept-background' concept.id %}" hx-trigger="load" hx-target="this" hx-swap="outerHTML">
+          <div id="concept-{{ concept.id }}-background" class="concept-card-background concept-card-background--loading"
+            aria-hidden="true">
           </div>
           <div class="concept-card-overlay" aria-hidden="true"></div>
           <div class="relative z-10 flex flex-col h-full">
             <h2 class="text-xl font-bold text-[#49475B] drop-shadow-sm">{{ concept.name }}</h2>
             <p class="subtitle mt-2 text-slate-700 drop-shadow-sm">{{ concept.subtitle }}</p>
-            <div class="mt-4 flex justify-between items-center">
+            <div class="mt-auto pt-6 flex justify-end">
               {% include "concepts/_favorite_button.html" %}
             </div>
           </div>

--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -4,7 +4,13 @@
   hx-post="{% url 'concept-favorite' concept.id %}"
   hx-target="this"
   hx-swap="outerHTML"
-  class="text-xl transition duration-200 {% if favorited %}text-red-500{% else %}text-slate-400{% endif %}">
-  {% if favorited %}♥{% else %}♡{% endif %}
+  class="concept-favorite-btn inline-flex items-center justify-center w-10 h-10 rounded-full border border-slate-200 bg-white/80 text-xl text-[#f08000] shadow-sm transition hover:scale-[1.02]"
+  aria-label="{% if favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
+>
+  {% if favorited %}
+    ❤️
+  {% else %}
+    🤍
+  {% endif %}
 </button>
 

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -115,7 +115,14 @@ transform: rotateY(180deg);
 </div>
 <script>
   document.body.addEventListener("htmx:beforeRequest", function (evt) {
-    const card = evt.detail.elt.closest(".flip-card");
+    const trigger = evt.detail.elt;
+    if (!trigger) {
+      return;
+    }
+    if (trigger.classList.contains("concept-favorite-btn")) {
+      return;
+    }
+    const card = trigger.closest(".flip-card");
     if (card) {
       card.classList.add("flipped");
     }

--- a/app/views.py
+++ b/app/views.py
@@ -376,12 +376,21 @@ def concept_favorite_view(request, concept_id):
         fav.delete()
         favorited = False
 
-    html = render_to_string(
+    image_url = None
+    if favorited:
+        image_url = llm.generate_concept_sketch(concept)
+
+    button_html = render_to_string(
         "concepts/_favorite_button.html",
         {"concept": concept, "favorited": favorited},
         request=request,
     )
-    return HttpResponse(html)
+    background_html = render_to_string(
+        "concepts/_concept_background.html",
+        {"concept": concept, "image_url": image_url},
+        request=request,
+    )
+    return HttpResponse(button_html + background_html)
 
 
 @login_required
@@ -394,7 +403,7 @@ def concept_background_view(request, concept_id):
     return render(
         request,
         "concepts/_concept_background.html",
-        {"image_url": image_url},
+        {"concept": concept, "image_url": image_url},
     )
 
 def serialize_restaurant_context(restaurant_payload, menu_markdown, concept):

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -109,7 +109,11 @@ class ViewSmokeTests(TestCase):
         self._create_concepts()
         concept = models.Concept.objects.first()
         resp = self.client.post(reverse("concept-favorite", args=[concept.id]))
-        self.assertTrue(resp.json()["favorited"])
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(
+            models.FavoriteConcept.objects.filter(user=self.user, concept=concept).exists()
+        )
+        self.assertIn("hx-swap-oob=\"true\"", resp.content.decode())
 
     def test_concepts_page_marks_existing_favorites(self):
         self._create_concepts()

--- a/tests/test_concept_background.py
+++ b/tests/test_concept_background.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from app import llm, models
 
@@ -50,3 +53,67 @@ class ConceptBackgroundViewTests(TestCase):
         content = response.content.decode()
         self.assertIn("concept-card-background concept-card-background--loaded", content)
         self.assertIn(llm.DEFAULT_CONCEPT_IMAGE_URL, content)
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class ConceptFavoriteBackgroundTests(TestCase):
+    """Ensure concept background images generate when favorited."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user("user2@example.com", password="pw")
+        self.account = models.Account.objects.create(name="Another Account")
+        models.Membership.objects.create(
+            account=self.account,
+            user=self.user,
+            role=models.Membership.Role.OWNER,
+        )
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="Favorite Restaurant",
+            location_text="Sample City",
+        )
+        models.RestaurantSettings.objects.create(restaurant=self.restaurant)
+        self.client.login(username="user2@example.com", password="pw")
+
+        run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="mock",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=run,
+            name="Sunset Garden",
+            subtitle="Botanical cocktails on a rooftop terrace.",
+            rank_order=1,
+        )
+
+    def test_generates_background_after_favoriting(self) -> None:
+        with mock.patch("app.llm.generate_concept_sketch", return_value="https://example.com/sketch.png") as mock_generate:
+            response = self.client.post(reverse("concept-favorite", args=[self.concept.id]))
+
+        mock_generate.assert_called_once_with(self.concept)
+        content = response.content.decode()
+        self.assertIn("concept-card-background--loaded", content)
+        self.assertIn("https://example.com/sketch.png", content)
+        self.assertIn("hx-swap-oob=\"true\"", content)
+
+    def test_unfavorite_restores_placeholder_background(self) -> None:
+        models.FavoriteConcept.objects.create(
+            user=self.user,
+            concept=self.concept,
+            favorited_at=timezone.now(),
+        )
+
+        with mock.patch("app.llm.generate_concept_sketch") as mock_generate:
+            response = self.client.post(reverse("concept-favorite", args=[self.concept.id]))
+
+        mock_generate.assert_not_called()
+        content = response.content.decode()
+        self.assertIn("concept-card-background--loading", content)
+        self.assertNotIn("background-image", content)


### PR DESCRIPTION
## Summary
- align the concept card favorite control to the bottom-right corner and match the dish card styling for consistency
- trigger concept background sketch generation only when favoriting and update cards via out-of-band swaps instead of load-time requests
- extend the concept favorite tests to cover background updates and adjust the favorite view response accordingly

## Testing
- pytest *(fails: Django settings/plugin configuration missing in the provided environment)*
- python manage.py test *(discovers 0 tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb251c5ba88332ad071f062afe1370