### PR TITLE
Fix favorite button click handler

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -1,6 +1,6 @@
 <button
   type="button"
-  hx-on::click="event.stopPropagation()"
+  hx-on:click="event.stopPropagation()"
   hx-post="{% url 'concept-favorite' concept.id %}"
   hx-target="this"
   hx-swap="outerHTML"


### PR DESCRIPTION
## Summary
- update the favorite button template to stop click propagation using the correct htmx attribute

## Testing
- pytest *(fails: settings are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb315a9f008332ad1d5b4449ab631c