### PR TITLE
Fix concept favorite button interactions

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -1,6 +1,7 @@
 <button
   type="button"
-  hx-on:click="event.stopPropagation()"
+  onclick="event.stopPropagation();"
+  hx-trigger="click consume"
   hx-post="{% url 'concept-favorite' concept.id %}"
   hx-target="this"
   hx-swap="outerHTML"

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -115,7 +115,12 @@ transform: rotateY(180deg);
 </div>
 <script>
   document.body.addEventListener("htmx:beforeRequest", function (evt) {
-    const card = evt.detail.elt.closest(".flip-card");
+    const trigger = evt.detail.elt;
+    if (!trigger || trigger.classList.contains("concept-favorite-btn")) {
+      return;
+    }
+
+    const card = trigger.closest(".flip-card");
     if (card) {
       card.classList.add("flipped");
     }


### PR DESCRIPTION
## Summary
- prevent concept favorite heart clicks from bubbling into the concept card request
- ensure concept cards only flip when generating dishes, not when toggling favorites

## Testing
- pytest tests/test_concept_background.py tests/test_appertivo_views.py *(fails: Django settings not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3626c4788332a5ff3971d055b04e