### PR TITLE
Use shared dish card partial on grid

### DIFF
--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -1,53 +1,9 @@
 {# templates/dishes/grid.html #}
 {% include "dishes/_card_assets.html" %}
 
-  {% for dish in dishes %}
-        <div class="flip-scene dish-card-wrapper" id="dish-{{ dish.id }}">
-      <div class="flip-card">
-        <div class="flip-face front bg-white p-6 pb-16 rounded-2xl shadow-md border border-slate-200 transition flex flex-col gap-4 hover:shadow-lg">
-          <div>
-            <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
-            <p class="text-slate-600 mt-2">{{ dish.description }}</p>
-            <div class="mt-3 flex flex-wrap gap-2">
-              {% for tag in dish.category_tags|slice:":3" %}
-                <span class="px-2 py-1 rounded-full bg-[#B993D6]/10 text-[#49475B] text-xs">{{ tag }}</span>
-              {% endfor %}
-              {% with ingredients=dish.ingredient_names %}
-                {% if ingredients %}
-                  {% for tag in ingredients|slice:":3" %}
-                    <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
-                  {% endfor %}
-                {% elif dish.ingredient_overlap %}
-                  {% for tag in dish.ingredient_overlap|slice:":3" %}
-                    <span class="px-2 py-1 rounded-full bg-[#8E008B]/10 text-[#49475B] text-xs">{{ tag }}</span>
-                  {% endfor %}
-                {% endif %}
-              {% endwith %}
-            </div>
-          </div>
-          <div class="dish-card-actions">
-            {% include "dishes/_favorite_button.html" %}
-            <button
-              type="button"
-              class="dish-variation-btn text-slate-500 hover:text-slate-700 transition"
-              hx-post="{% url 'dish-variation' dish.id %}"
-              hx-trigger="click"
-              hx-target="closest .dish-card-wrapper"
-              hx-swap="outerHTML"
-              aria-label="Generate a variation of {{ dish.title }}"
-            >
-              <i class="fa-solid fa-rotate" aria-hidden="true"></i>
-            </button>
-          </div>
-        </div>
-        <div class="flip-face flip-back bg-slate-800 text-white p-6 rounded-2xl flex flex-col items-center justify-center">
-<i class="fa-solid fa-rotate"></i>
-          <p class="text-sm font-medium">Mixing up a fresh variation…</p>
-        </div>
-      </div>
-    </div>
-
-  {% endfor %}
+{% for dish in dishes %}
+  {% include "dishes/_card.html" with dish=dish card_context="grid" %}
+{% endfor %}
 
 
 <script>


### PR DESCRIPTION
## Summary
- render dish cards in the grid with the shared `_card.html` partial so the layout matches generated variations

## Testing
- pytest *(fails: Django settings module not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3c470ebc8332ac441f446b9a0018