### PR TITLE
Allow multiple menu URLs and process menu content from settings

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -34,7 +34,13 @@ class RestaurantAdmin(admin.ModelAdmin):
 
     fieldsets = (
         ("Core Info", {
-            "fields": ("account", "name", "location_text", "primary_menu_url")
+            "fields": (
+                "account",
+                "name",
+                "location_text",
+                "primary_menu_url",
+                "menu_urls",
+            )
         }),
         ("Outscraper Data", {
             "fields": (

--- a/app/migrations/0004_restaurant_menu_urls.py
+++ b/app/migrations/0004_restaurant_menu_urls.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def copy_primary_to_menu_urls(apps, schema_editor):
+    Restaurant = apps.get_model("app", "Restaurant")
+    for restaurant in Restaurant.objects.all():
+        urls = []
+        if restaurant.primary_menu_url:
+            urls.append(restaurant.primary_menu_url)
+        restaurant.menu_urls = urls
+        restaurant.save(update_fields=["menu_urls"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0003_concept_subtitle_alter_concept_name"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="restaurant",
+            name="menu_urls",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.RunPython(copy_primary_to_menu_urls, migrations.RunPython.noop),
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 """Database models for the app."""
 
 import uuid
+from typing import Iterable, List
 
 from django.conf import settings
 from django.db import models
@@ -51,6 +52,7 @@ class Restaurant(TimestampedModel):
     name = models.TextField()
     location_text = models.TextField()
     primary_menu_url = models.TextField(null=True, blank=True)
+    menu_urls = models.JSONField(default=list, blank=True)
 
     # Outscraper context fields
     phone = models.TextField(null=True, blank=True)
@@ -76,6 +78,27 @@ class Restaurant(TimestampedModel):
 
     def __str__(self):
         return self.name
+
+    def set_menu_urls(self, urls: Iterable[str]) -> None:
+        """Store a unique, ordered list of menu URLs."""
+
+        cleaned: List[str] = []
+        for url in urls:
+            normalized = (url or "").strip()
+            if not normalized:
+                continue
+            if normalized not in cleaned:
+                cleaned.append(normalized)
+
+        self.menu_urls = cleaned
+        self.primary_menu_url = cleaned[0] if cleaned else None
+
+    def add_menu_url(self, url: str) -> None:
+        """Append a URL to the stored list if missing."""
+
+        current = list(self.menu_urls or [])
+        current.insert(0, url)
+        self.set_menu_urls(current)
 
 class OutscraperPayload(TimestampedModel):
     """Tracks Outscraper requests for a restaurant."""

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -48,7 +48,7 @@ def run_outscraper_search(payload_id: str) -> dict:
         restaurant.location_text = business.get("full_address", restaurant.location_text)
         menu_url = business.get("menu_link") or business.get("menu_url")
         if menu_url:
-            restaurant.primary_menu_url = menu_url
+            restaurant.add_menu_url(menu_url)
         restaurant.phone = business.get("phone")
         restaurant.website = business.get("site")
         restaurant.google_place_id = business.get("place_id")
@@ -179,8 +179,8 @@ def scrape_menu(self, menu_version_id: str) -> str:
             restaurant = mv.restaurant
             restaurant.active_menu_version = mv
             if mv.source_url and not restaurant.primary_menu_url:
-                restaurant.primary_menu_url = mv.source_url
-            restaurant.save(update_fields=["active_menu_version", "primary_menu_url"])
+                restaurant.add_menu_url(mv.source_url)
+            restaurant.save(update_fields=["active_menu_version", "primary_menu_url", "menu_urls"])
         logger.info("Restaurant %s active_menu_version set to %s", restaurant.id, mv.id)
     except Exception as exc:
         logger.error("Failed to update restaurant %s with menu version %s: %s",

--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -45,24 +45,39 @@
         class="space-y-3 md:flex md:items-end md:space-y-0 md:space-x-4"
       >
         {% csrf_token %}
+        <input type="hidden" name="form_type" value="urls">
         <div class="flex-1">
-          <label for="menu_url" class="block text-sm font-medium text-gray-600">Primary menu URL</label>
-          <input
-            id="menu_url"
-            type="url"
-            name="menu_url"
-            value="{{ restaurant.primary_menu_url }}"
-            placeholder="https://example.com/menu"
+          <label for="menu_urls" class="block text-sm font-medium text-gray-600">Menu URLs</label>
+          <textarea
+            id="menu_urls"
+            name="menu_urls"
+            rows="3"
+            placeholder="https://example.com/menu-one
+https://example.com/menu-two"
             class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none"
-          >
+          >{{ restaurant.menu_urls|join:'\n' }}</textarea>
+          <p class="mt-1 text-xs text-slate-500">Enter one URL per line. We'll use the first as the primary menu link.</p>
         </div>
         <button
           type="submit"
           class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#f08000] text-white font-semibold shadow transition hover:bg-[#d96f00]"
         >
-          Save Menu URL
+          Save Menu URLs
         </button>
       </form>
+
+      {% if restaurant.menu_urls %}
+        <div class="text-sm text-slate-600 space-y-1">
+          <p class="font-medium text-gray-600">Saved menu links</p>
+          <ul class="space-y-1">
+            {% for url in restaurant.menu_urls %}
+              <li>
+                <a href="{{ url }}" target="_blank" rel="noopener" class="text-[#5C008B] hover:underline">{{ url }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
 
       <div class="flex flex-wrap items-center gap-3">
         <form
@@ -88,7 +103,7 @@
         </form>
         {% if restaurant.primary_menu_url %}
           <a href="{{ restaurant.primary_menu_url }}" target="_blank" rel="noopener"
-             class="text-sm text-[#5C008B] font-medium hover:underline">Open current menu</a>
+             class="text-sm text-[#5C008B] font-medium hover:underline">Open primary menu</a>
         {% endif %}
       </div>
     {% else %}
@@ -145,6 +160,43 @@
       <h2 class="text-xl font-bold text-[#49475B]">Menu content</h2>
       <p class="text-sm text-slate-500">Latest menu markdown from your uploads or scrapes.</p>
     </div>
+    <form
+      action="{% url 'update_restaurant_info' %}"
+      method="post"
+      enctype="multipart/form-data"
+      class="space-y-3"
+    >
+      {% csrf_token %}
+      <input type="hidden" name="form_type" value="content">
+      <div>
+        <label for="menu_text" class="block text-sm font-medium text-gray-600">Paste menu Markdown</label>
+        <textarea
+          id="menu_text"
+          name="menu_text"
+          rows="6"
+          placeholder="Appetizers\n- Charcuterie Board"
+          class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none"
+        ></textarea>
+        <p class="mt-1 text-xs text-slate-500">Paste your menu content here to replace the current version.</p>
+      </div>
+      <div class="flex flex-col md:flex-row md:items-center md:gap-4">
+        <label class="text-sm font-medium text-gray-600" for="menu_pdf">Or upload a PDF</label>
+        <input
+          type="file"
+          id="menu_pdf"
+          name="menu_pdf"
+          accept="application/pdf"
+          class="mt-1 w-full md:w-auto"
+        >
+        <p class="text-xs text-slate-500 md:flex-1">We'll convert the PDF to Markdown using OpenAI.</p>
+      </div>
+      <button
+        type="submit"
+        class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#f08000] text-white font-semibold shadow transition hover:bg-[#d96f00]"
+      >
+        Save Menu Content
+      </button>
+    </form>
     <div class="max-h-80 overflow-y-auto bg-slate-50 border border-slate-200 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap">
       {% if active_menu_version and active_menu_version.raw_markdown %}
         {{ active_menu_version.raw_markdown|linebreaksbr }}

--- a/app/views.py
+++ b/app/views.py
@@ -1,21 +1,25 @@
 """Application views."""
 
 import json, logging, os, uuid
+from typing import Iterable, List, Optional
+
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
 from django.db.models import Prefetch
 from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
-from . import models
-from django.template.loader import render_to_string
 from pydantic import BaseModel
-from typing import Iterable, List, Optional
+
+from . import models
 
 from openai import OpenAI
 from dotenv import load_dotenv
@@ -104,6 +108,7 @@ def signup_view(request):
                     name=restaurant_name,
                     location_text=location,
                     primary_menu_url=menu_url,
+                    menu_urls=[menu_url] if menu_url else [],
                 )
 
                 if menu_url:
@@ -1010,9 +1015,25 @@ def update_restaurant_info(request):
     if not restaurant:
         return redirect("settings")
 
-    menu_url = (request.POST.get("menu_url") or "").strip() or None
-    restaurant.primary_menu_url = menu_url
-    restaurant.save(update_fields=["primary_menu_url"])
+    form_type = request.POST.get("form_type") or "urls"
+
+    if form_type == "content":
+        menu_text = (request.POST.get("menu_text") or "").strip()
+        menu_pdf = request.FILES.get("menu_pdf")
+        if menu_text or menu_pdf:
+            _process_menu_submission(restaurant, None, menu_text, menu_pdf)
+        return redirect("settings")
+
+    raw_urls = request.POST.get("menu_urls")
+    if raw_urls is None:
+        menu_url = (request.POST.get("menu_url") or "").strip()
+        urls = [menu_url] if menu_url else []
+    else:
+        normalized = raw_urls.replace("\r", "\n").replace(",", "\n")
+        urls = [line.strip() for line in normalized.split("\n") if line.strip()]
+
+    restaurant.set_menu_urls(urls)
+    restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
 
     ingredient_names = [
         name.strip()
@@ -1137,8 +1158,64 @@ def show_menu_modal(request, restaurant_id):
     return render(request, "_partials/menu_modal.html", {"restaurant": restaurant})
 
 
-from django.core.files.storage import default_storage
-from django.core.files.base import ContentFile
+def _process_menu_submission(
+    restaurant: models.Restaurant,
+    menu_url: Optional[str],
+    menu_text: Optional[str],
+    menu_pdf,
+):
+    """Create a menu version from URL, pasted text, or uploaded PDF."""
+
+    if menu_url:
+        restaurant.add_menu_url(menu_url)
+        mv = models.MenuVersion.objects.create(
+            restaurant=restaurant,
+            source_url=menu_url,
+            source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
+            raw_markdown="",
+            status=models.MenuVersion.Status.QUEUED,
+        )
+        restaurant.active_menu_version = mv
+        restaurant.save(
+            update_fields=["menu_urls", "primary_menu_url", "active_menu_version"]
+        )
+        transaction.on_commit(lambda mv_id=str(mv.id): scrape_menu.delay(mv_id))
+        return mv
+
+    if menu_text:
+        mv = models.MenuVersion.objects.create(
+            restaurant=restaurant,
+            source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
+            raw_markdown=menu_text,
+            status=models.MenuVersion.Status.SUCCEEDED,
+        )
+        restaurant.active_menu_version = mv
+        restaurant.save(update_fields=["active_menu_version"])
+        return mv
+
+    if menu_pdf:
+        path = default_storage.save(
+            f"menus/{restaurant.id}/{menu_pdf.name}",
+            ContentFile(menu_pdf.read()),
+        )
+        mv = models.MenuVersion.objects.create(
+            restaurant=restaurant,
+            source_url=path,
+            source_kind=models.MenuVersion.SourceKind.IMAGE_OCR,
+            raw_markdown="",
+            status=models.MenuVersion.Status.QUEUED,
+        )
+        restaurant.active_menu_version = mv
+        restaurant.save(update_fields=["active_menu_version"])
+        transaction.on_commit(
+            lambda mv_id=str(mv.id), storage_path=path: parse_pdf_menu.delay(
+                mv_id, storage_path
+            )
+        )
+        return mv
+
+    return None
+
 
 def upload_menu(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
@@ -1148,44 +1225,6 @@ def upload_menu(request, restaurant_id):
         menu_text = (request.POST.get("menu_text") or "").strip()
         menu_pdf = request.FILES.get("menu_pdf")
 
-        if menu_url:
-            restaurant.primary_menu_url = menu_url
-            restaurant.save(update_fields=["primary_menu_url"])
-            mv = models.MenuVersion.objects.create(
-                restaurant=restaurant,
-                source_url=menu_url,
-                source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
-                raw_markdown="",
-                status=models.MenuVersion.Status.QUEUED,
-            )
-            transaction.on_commit(lambda mv_id=str(mv.id): scrape_menu.delay(mv_id))
-
-        elif menu_text:
-            mv = models.MenuVersion.objects.create(
-                restaurant=restaurant,
-                source_kind=models.MenuVersion.SourceKind.PASTED_TEXT,
-                raw_markdown=menu_text,
-                status=models.MenuVersion.Status.SUCCEEDED,
-            )
-            restaurant.active_menu_version = mv
-            restaurant.save(update_fields=["active_menu_version"])
-
-        elif menu_pdf:
-            path = default_storage.save(
-                f"menus/{restaurant.id}/{menu_pdf.name}",
-                ContentFile(menu_pdf.read()),
-            )
-            mv = models.MenuVersion.objects.create(
-                restaurant=restaurant,
-                source_url=path,
-                source_kind=models.MenuVersion.SourceKind.IMAGE_OCR,
-                raw_markdown="",
-                status=models.MenuVersion.Status.QUEUED,
-            )
-            transaction.on_commit(
-                lambda mv_id=str(mv.id), storage_path=path: parse_pdf_menu.delay(
-                    mv_id, storage_path
-                )
-            )
+        _process_menu_submission(restaurant, menu_url, menu_text, menu_pdf)
 
     return restaurant_status(request, restaurant_id)

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -276,14 +277,34 @@ class ViewSmokeTests(TestCase):
 
         update_resp = self.client.post(
             reverse("update_restaurant_info"),
-            {"menu_url": "https://example.com/new-menu"},
+            {
+                "form_type": "urls",
+                "menu_urls": "https://example.com/new-menu\nhttps://example.com/archive",
+            },
         )
         self.assertEqual(update_resp.status_code, 302)
         self.restaurant.refresh_from_db()
         self.assertEqual(self.restaurant.primary_menu_url, "https://example.com/new-menu")
+        self.assertEqual(
+            self.restaurant.menu_urls,
+            ["https://example.com/new-menu", "https://example.com/archive"],
+        )
 
-        self.restaurant.primary_menu_url = "https://example.com/menu"
-        self.restaurant.save(update_fields=["primary_menu_url"])
+        content_resp = self.client.post(
+            reverse("update_restaurant_info"),
+            {"form_type": "content", "menu_text": "Updated Menu"},
+        )
+        self.assertEqual(content_resp.status_code, 302)
+        self.restaurant.refresh_from_db()
+        latest_version = self.restaurant.active_menu_version
+        self.assertIsNotNone(latest_version)
+        self.assertEqual(latest_version.raw_markdown, "Updated Menu")
+        self.assertEqual(
+            latest_version.source_kind, models.MenuVersion.SourceKind.PASTED_TEXT
+        )
+
+        self.restaurant.set_menu_urls(["https://example.com/menu"])
+        self.restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
         with patch("app.views.scrape_menu.delay") as mock_delay:
             rescrape = self.client.post(
                 reverse("settings-rescrape-menu", args=[self.restaurant.id])
@@ -306,15 +327,15 @@ class ViewSmokeTests(TestCase):
         )
 
     def test_dashboard_prompts_for_menu_when_missing(self):
-        self.restaurant.primary_menu_url = None
-        self.restaurant.save(update_fields=["primary_menu_url"])
+        self.restaurant.set_menu_urls([])
+        self.restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
 
         response = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
         self.assertContains(response, "show_menu_modal")
 
     def test_dashboard_does_not_prompt_when_menu_exists(self):
-        self.restaurant.primary_menu_url = "https://example.com/menu"
-        self.restaurant.save(update_fields=["primary_menu_url"])
+        self.restaurant.set_menu_urls(["https://example.com/menu"])
+        self.restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
 
         response = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
         self.assertNotIn("show_menu_modal", response.content.decode())
@@ -325,8 +346,8 @@ class ViewSmokeTests(TestCase):
         self.assertNotIn("_auth_user_id", self.client.session)
 
     def test_rescrape_menu_requires_url(self):
-        self.restaurant.primary_menu_url = None
-        self.restaurant.save(update_fields=["primary_menu_url"])
+        self.restaurant.set_menu_urls([])
+        self.restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
         with patch("app.views.scrape_menu.delay") as mock_delay:
             resp = self.client.post(
                 reverse("settings-rescrape-menu", args=[self.restaurant.id])
@@ -335,6 +356,24 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(resp.json()["error"], "missing_menu_url")
         self.assertFalse(models.MenuVersion.objects.exists())
         mock_delay.assert_not_called()
+
+    @patch("app.views.parse_pdf_menu.delay")
+    def test_settings_pdf_upload_queues_processing(self, mock_parse):
+        pdf_file = SimpleUploadedFile(
+            "menu.pdf", b"%PDF-1.4 test", content_type="application/pdf"
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            resp = self.client.post(
+                reverse("update_restaurant_info"),
+                {"form_type": "content", "menu_pdf": pdf_file},
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        mv = models.MenuVersion.objects.latest("created_at")
+        self.assertEqual(mv.status, models.MenuVersion.Status.QUEUED)
+        self.assertEqual(mv.source_kind, models.MenuVersion.SourceKind.IMAGE_OCR)
+        mock_parse.assert_called_once()
 
     def test_billing_views(self):
         resp = self.client.get(reverse("billing"))

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -166,6 +166,7 @@ class TaskExecutionTests(TestCase):
         self.assertEqual(payload.status, models.OutscraperPayload.Status.SUCCEEDED)
         self.assertEqual(payload.discovered_menu_url, "http://example.com/menu")
         self.assertEqual(self.restaurant.primary_menu_url, "http://example.com/menu")
+        self.assertEqual(self.restaurant.menu_urls, ["http://example.com/menu"])
         self.assertEqual(models.MenuVersion.objects.count(), 1)
         menu_version = models.MenuVersion.objects.get()
         self.assertEqual(menu_version.status, models.MenuVersion.Status.QUEUED)

--- a/tests/test_restaurant_status.py
+++ b/tests/test_restaurant_status.py
@@ -78,6 +78,7 @@ class RestaurantStatusViewTests(TestCase):
         self.assertContains(response, "We’re building your AI menu assistant")
         self.restaurant.refresh_from_db()
         self.assertEqual(self.restaurant.primary_menu_url, "http://example.com/menu")
+        self.assertEqual(self.restaurant.menu_urls, ["http://example.com/menu"])
 
     def test_upload_menu_with_text_marks_ready(self):
         url = reverse("upload_menu", args=[self.restaurant.id])

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -50,6 +50,7 @@ class SignupViewTests(TestCase):
         self.assertEqual(restaurant.name, "Tasty Place")
         self.assertEqual(restaurant.location_text, "City, State")
         self.assertIsNone(restaurant.primary_menu_url)
+        self.assertEqual(restaurant.menu_urls, [])
         self.assertEqual(body["redirect_url"], reverse("dashboard", args=[restaurant.id]))
 
         payload_obj = models.OutscraperPayload.objects.get()
@@ -111,6 +112,7 @@ class SignupViewTests(TestCase):
         mock_outscraper.delay.assert_not_called()
         restaurant.refresh_from_db()
         self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
+        self.assertEqual(restaurant.menu_urls, ["http://example.com/menu"])
 
     def test_form_signup_with_existing_email_shows_error(self):
         """Duplicate email addresses should not trigger a server error."""


### PR DESCRIPTION
## Summary
- store restaurant menu links in a JSON list while keeping the first URL as the primary link, including a data migration and helper methods
- expand the settings page so operators can manage multiple menu URLs and either paste menu markdown or upload a PDF for OpenAI processing
- ensure background tasks and views persist the new data and update the active menu version while adding focused tests for the new flows

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_settings_views tests.test_appertivo_views.ViewSmokeTests.test_settings_pdf_upload_queues_processing tests.test_restaurant_status.RestaurantStatusViewTests.test_upload_menu_with_url_queues_scrape tests.test_llm_views_tasks.TaskExecutionTests.test_run_outscraper_search_updates_payload tests.test_signup.SignupViewTests.test_api_signup_creates_records_and_returns_redirect tests.test_signup.SignupViewTests.test_form_signup_with_menu_url_scrapes_immediately


------
https://chatgpt.com/codex/tasks/task_e_68cb40d298148332bdc4e52ce434bab8