### PR TITLE
Revamp favorites hub with menus and drag-drop

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -48,6 +48,17 @@
           {% else %}
             <div class="card-action-tab">
               {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name %}
+              {% if context_name == 'favorites' %}
+                <button
+                  type="button"
+                  class="card-action-button text-slate-500 hover:text-slate-700 transition"
+                  data-menu-trigger
+                  title="Assign to menu"
+                >
+                  <i class="fa-solid fa-ellipsis"></i>
+                  <span class="sr-only">Assign {{ dish.title }} to a menu</span>
+                </button>
+              {% endif %}
               <button
                 type="button"
                 class="dish-variation-btn card-action-button text-slate-500 hover:text-slate-700 transition"

--- a/app/templates/favorites/_concept_card.html
+++ b/app/templates/favorites/_concept_card.html
@@ -1,6 +1,6 @@
 <div
   id="favorite-concept-{{ favorite.concept.id }}"
-  class="relative flex min-h-[220px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+  class="favorite-concept-card group relative flex min-h-[220px] flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
 >
   {% with background=favorite.concept.sketch_image_url %}
     <div
@@ -12,26 +12,27 @@
   <div class="concept-card-overlay" aria-hidden="true"></div>
   <div class="relative z-10 flex h-full flex-col gap-4 p-6">
     <div class="flex items-start justify-between gap-3">
-      <div>
+      <div class="space-y-2">
         <h3 class="text-xl font-bold text-[#49475B] drop-shadow-sm">{{ favorite.concept.name }}</h3>
-        <p class="mt-2 text-sm text-slate-600 drop-shadow-sm">{{ favorite.concept.subtitle }}</p>
+        <p class="text-sm text-slate-600/90 drop-shadow-sm">{{ favorite.concept.subtitle }}</p>
         {% if favorite.concept.restaurant %}
-          <p class="mt-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500/80 drop-shadow-sm">
             {{ favorite.concept.restaurant.name }}
           </p>
         {% endif %}
       </div>
       <button
         type="button"
-        class="inline-flex items-center gap-1 rounded-full border border-white/40 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-white"
+        class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/70 text-slate-600 transition hover:bg-white"
         hx-post="{% url 'favorite-remove' 'concept' favorite.concept.id %}"
         hx-trigger="click consume"
         hx-target="#favorite-concept-{{ favorite.concept.id }}"
         hx-swap="outerHTML"
         onclick="event.stopPropagation();"
+        title="Remove concept"
       >
         <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
-        <span>Remove</span>
+        <span class="sr-only">Remove {{ favorite.concept.name }} from favorites</span>
       </button>
     </div>
     <div class="mt-auto flex flex-wrap items-center justify-between gap-3 pt-4">
@@ -40,7 +41,7 @@
       </span>
       <button
         type="button"
-        class="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-105"
+        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-105"
         hx-post="{% url 'dishes-generate' favorite.concept.id %}"
         hx-trigger="click"
         hx-target="#favorites-generated-dishes"

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -3,124 +3,459 @@
 
 {% block content %}
 {% include "dishes/_card_assets.html" %}
-<section class="bg-gradient-to-r from-[#2E005D] via-[#5C008B] to-[#8E008B] text-white py-10 px-6 rounded-xl shadow mb-8">
-  <h1 class="text-3xl font-bold">Favorites Hub</h1>
-  {% if restaurant %}
-    <p class="text-slate-200 mt-2">Curated picks for {{ restaurant.name }}.</p>
-  {% else %}
-    <p class="text-slate-200 mt-2">Curated picks from your recent sessions.</p>
-  {% endif %}
-  <p class="text-slate-100 mt-4 max-w-2xl">Quickly revisit the concepts and dishes that inspired you. Everything you star lives here so it’s easy to plan your next menu update.</p>
-</section>
-
-<style>
-  .concept-card-background {
-    position: absolute;
-    inset: 0;
-    background-size: cover;
-    background-position: center;
-    filter: grayscale(100%);
-    opacity: 0;
-    transition: opacity 0.4s ease;
-    pointer-events: none;
-    z-index: 1;
-  }
-
-  .concept-card-background--loading {
-    background: radial-gradient(circle at center, rgba(226, 232, 240, 0.8), rgba(226, 232, 240, 0.4));
-    opacity: 1;
-  }
-
-  .concept-card-background--loaded {
-    opacity: 1;
-  }
-
-  .concept-card-overlay {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.95));
-    pointer-events: none;
-    z-index: 5;
-  }
-
-  #favorites-dishes-loading {
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  #favorites-dishes-loading.htmx-request {
-    display: flex !important;
-  }
-</style>
-
-<div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
-  <!-- Concepts column -->
-  <div class="xl:col-span-2 space-y-6">
-    <div class="bg-white rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-4">
-        <div>
-          <h2 class="text-xl font-semibold text-[#49475B]">Saved Concepts</h2>
-          <p class="text-sm text-slate-500">Ideas you marked for later.</p>
-        </div>
-        <a href="{% url 'concepts' %}" class="text-sm text-[#5C008B] font-medium hover:underline">Explore concepts</a>
-      </div>
-      {% if favorite_concepts %}
-        <div id="favorite-concepts-grid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {% for favorite in favorite_concepts %}
-            {% include "favorites/_concept_card.html" %}
-          {% endfor %}
-        </div>
-        <div id="favorites-dishes-loading" class="mt-6 text-sm font-medium text-slate-500" style="display: none;">
-          <i class="fa-solid fa-spinner fa-spin"></i>
-          <span>Generating dishes…</span>
-        </div>
-        <div id="favorites-generated-dishes" class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4"></div>
-      {% else %}
-        <p class="text-slate-600">You haven't saved any concepts yet. Visit the concepts tab to start collecting ideas.</p>
-      {% endif %}
-    </div>
-
-    <div class="bg-white rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-4">
-        <div>
-          <h2 class="text-xl font-semibold text-[#49475B]">Favorite Dishes</h2>
-          <p class="text-sm text-slate-500">Dishes worth featuring on your next menu.</p>
-        </div>
-        <a href="{% url 'menus' %}" class="text-sm text-[#5C008B] font-medium hover:underline">Build menus</a>
-      </div>
-      {% if favorite_dishes %}
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {% for favorite in favorite_dishes %}
-            {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' %}
-          {% endfor %}
-        </div>
-      {% else %}
-        <p class="text-slate-600">No dishes in your favorites yet. Generate dishes from a concept to start building a list.</p>
-      {% endif %}
-    </div>
-  </div>
-
-  <!-- Quick actions -->
-  <div class="space-y-6">
-    <div class="bg-white rounded-xl shadow p-6 space-y-4">
-      <h2 class="text-xl font-semibold text-[#49475B]">Quick Actions</h2>
-      <p class="text-sm text-slate-500">Jump back into the tools you use most.</p>
-      <div class="space-y-3">
-        <a href="{% url 'concepts' %}" class="block px-4 py-3 rounded-lg bg-gradient-to-r from-[#FF8300] to-[#FF5C00] text-white font-semibold text-center transition hover:scale-105">Generate new concepts</a>
-        <a href="{% url 'settings' %}" class="block px-4 py-3 rounded-lg border border-[#5C008B]/40 text-[#5C008B] font-semibold text-center hover:bg-[#5C008B]/5">Update restaurant settings</a>
-        <a href="{% url 'menus' %}" class="block px-4 py-3 rounded-lg border border-slate-200 text-slate-700 font-semibold text-center hover:bg-slate-100">Manage menus</a>
-      </div>
-    </div>
-
-    <div class="bg-gradient-to-r from-[#FF8300]/20 to-[#FF5C00]/20 rounded-xl shadow p-6 space-y-2">
-      <h2 class="text-lg font-semibold text-[#5C008B]">Need something fresh?</h2>
-      <p class="text-sm text-slate-700">Kick off a new ideation run whenever you’re ready for more inspiration.</p>
+<div
+  id="favorites-root"
+  class="space-y-12"
+  data-menus="{{ menus_payload_json|escapejs }}"
+  data-move-url="{% url 'menu-item-move' %}"
+  data-create-url="{% url 'menu-collection-create' %}"
+>
+  <section class="bg-gradient-to-r from-[#2E005D] via-[#5C008B] to-[#8E008B] text-white py-10 px-6 rounded-3xl shadow-lg">
+    <div class="max-w-4xl space-y-4">
+      <h1 class="text-3xl font-bold">Favorites Hub</h1>
       {% if restaurant %}
-        <a href="{% url 'concepts-generate' %}" class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#5C008B] text-white font-semibold hover:bg-[#2E005D]">Start a concept run</a>
+        <p class="text-slate-200">Curated picks for {{ restaurant.name }}.</p>
       {% else %}
-        <a href="{% url 'concepts-generate' %}" class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#5C008B] text-white font-semibold hover:bg-[#2E005D]">Start exploring</a>
+        <p class="text-slate-200">Curated picks from your recent sessions.</p>
+      {% endif %}
+      <p class="text-slate-100/90">Save concepts to quickly spin up more ideas and organize dishes into menus.</p>
+    </div>
+  </section>
+
+  <section class="space-y-5">
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-semibold text-[#49475B]">Favorited Concepts</h2>
+        <p class="text-sm text-slate-500">Tap back into the ideas you liked most.</p>
+      </div>
+      <a href="{% url 'concepts' %}" class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-md ring-1 ring-white/40 transition hover:bg-white/20">
+        <i class="fa-solid fa-compass" aria-hidden="true"></i>
+        <span>Explore concepts</span>
+      </a>
+    </div>
+
+    {% if favorite_concepts %}
+      <div id="favorite-concepts-grid" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5">
+        {% for favorite in favorite_concepts %}
+          {% include "favorites/_concept_card.html" %}
+        {% endfor %}
+      </div>
+      <div id="favorites-dishes-loading" class="mt-6 hidden items-center gap-2 text-sm font-medium text-slate-500">
+        <i class="fa-solid fa-spinner fa-spin"></i>
+        <span>Generating dishes…</span>
+      </div>
+      <div id="favorites-generated-dishes" class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-5"></div>
+    {% else %}
+      <div class="rounded-2xl border border-dashed border-white/60 bg-white/10 p-6 text-sm text-white/90">
+        Save a concept to see it here. Favoriting gives you quick access to spin up more dishes later.
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="space-y-5">
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-semibold text-[#49475B]">Menus</h2>
+        <p class="text-sm text-slate-500">Drag dishes into a menu to start shaping a lineup. Collapse menus you’re not working on to keep things tidy.</p>
+      </div>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-105"
+        data-action="create-menu"
+      >
+        <i class="fa-solid fa-plus" aria-hidden="true"></i>
+        <span>New menu</span>
+      </button>
+    </div>
+
+    <div id="favorite-menus" class="space-y-4">
+      {% if menus %}
+        {% for menu in menus %}
+          <details
+            class="menu-card rounded-3xl border border-slate-200 bg-white shadow-sm"
+            data-menu-card
+            data-menu-id="{{ menu.id }}"
+            data-rename-url="{% url 'menu-collection-rename' menu.id %}"
+            data-delete-url="{% url 'menu-collection-delete' menu.id %}"
+            open
+          >
+            <summary class="cursor-pointer list-none rounded-3xl px-6 py-5">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-lg font-semibold text-[#49475B]">{{ menu.name }}</h3>
+                  <p class="text-xs uppercase tracking-wide text-slate-400">{{ menu.menu_items|length }} dish{{ menu.menu_items|length|pluralize }}</p>
+                </div>
+                <div class="flex items-center gap-3">
+                  <button type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100" data-action="rename-menu" title="Rename menu">
+                    <i class="fa-regular fa-pen-to-square" aria-hidden="true"></i>
+                    <span class="sr-only">Rename menu</span>
+                  </button>
+                  <button type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-red-100 text-red-500 transition hover:bg-red-50" data-action="delete-menu" title="Delete menu">
+                    <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
+                    <span class="sr-only">Delete menu</span>
+                  </button>
+                </div>
+              </div>
+            </summary>
+            <div class="px-6 pb-6">
+              <div class="menu-dropzone rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4"
+                data-menu-dropzone
+                data-menu-id="{{ menu.id }}"
+              >
+                {% if menu.menu_items %}
+                  <div class="grid grid-cols-1 gap-4" data-menu-dishes>
+                    {% for item in menu.menu_items %}
+                      <div
+                        id="favorite-dish-{{ item.dish.id }}"
+                        class="favorite-dish-card"
+                        draggable="true"
+                        data-dish-card
+                        data-dish-id="{{ item.dish.id }}"
+                        data-current-menu="{{ menu.id }}"
+                      >
+                        {% include "dishes/_card.html" with dish=item.dish card_context='favorites' %}
+                      </div>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  <div class="flex h-32 items-center justify-center rounded-xl bg-white/80 text-sm text-slate-400" data-menu-empty>
+                    Drag a dish here or tap the … button on a card to add it to {{ menu.name }}.
+                  </div>
+                {% endif %}
+              </div>
+            </div>
+          </details>
+        {% endfor %}
+      {% else %}
+        <div class="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-500">
+          Create your first menu to start grouping dishes together. You can always rename or delete it later.
+        </div>
       {% endif %}
     </div>
+  </section>
+
+  <section class="space-y-5">
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-semibold text-[#49475B]">Uncategorized favorites</h2>
+        <p class="text-sm text-slate-500">Dishes saved for inspiration. Drag onto a menu or use the action menu to assign.</p>
+      </div>
+    </div>
+
+    <div
+      class="menu-dropzone rounded-3xl border border-dashed border-slate-200 bg-white p-4"
+      data-menu-dropzone
+      data-menu-id=""
+      id="favorites-uncategorized"
+    >
+      {% if uncategorized_favorites %}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4" data-menu-dishes>
+          {% for favorite in uncategorized_favorites %}
+            <div
+              id="favorite-dish-{{ favorite.dish.id }}"
+              class="favorite-dish-card"
+              draggable="true"
+              data-dish-card
+              data-dish-id="{{ favorite.dish.id }}"
+              data-current-menu=""
+            >
+              {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' %}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="flex h-32 items-center justify-center rounded-xl bg-slate-50 text-sm text-slate-400" data-menu-empty>
+          Assigning dishes to menus removes them from this list. Drag one back here to keep it uncategorized.
+        </div>
+      {% endif %}
+    </div>
+  </section>
+</div>
+
+<div id="favorites-menu-sheet" class="favorites-menu-sheet hidden">
+  <div class="favorites-menu-sheet__backdrop" data-sheet-close></div>
+  <div class="favorites-menu-sheet__panel">
+    <div class="flex items-center justify-between gap-4">
+      <h3 class="text-lg font-semibold text-[#49475B]">Assign to menu</h3>
+      <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-500" data-sheet-close>
+        <i class="fa-solid fa-xmark"></i>
+        <span class="sr-only">Close</span>
+      </button>
+    </div>
+    <div class="mt-4 space-y-2" data-sheet-list></div>
   </div>
 </div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const root = document.getElementById('favorites-root');
+    if (!root) return;
+
+    function getCsrfToken(){
+      const input = document.querySelector('[name="csrfmiddlewaretoken"]');
+      if (input) return input.value;
+      const match = document.cookie.match(/csrftoken=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    }
+
+    const csrf = getCsrfToken();
+    const menuData = (() => {
+      try {
+        return JSON.parse(root.dataset.menus || '[]');
+      } catch (err) {
+        console.warn('Unable to parse menus payload', err);
+        return [];
+      }
+    })();
+
+    const moveUrl = root.dataset.moveUrl;
+    const createUrl = root.dataset.createUrl;
+    const sheet = document.getElementById('favorites-menu-sheet');
+    const sheetList = sheet?.querySelector('[data-sheet-list]');
+
+    function getCard(el){
+      return el.closest('[data-dish-card]');
+    }
+
+    function updateEmptyStates(zone){
+      if (!zone) return;
+      const hasCard = zone.querySelector('[data-dish-card]');
+      zone.querySelectorAll('[data-menu-empty]').forEach((empty) => {
+        empty.style.display = hasCard ? 'none' : '';
+      });
+    }
+
+    function ensureList(zone){
+      let list = zone.querySelector('[data-menu-dishes]');
+      if (list) return list;
+      list = document.createElement('div');
+      list.dataset.menuDishes = '1';
+      list.className = zone.dataset.menuId ? 'grid grid-cols-1 gap-4' : 'grid grid-cols-1 md:grid-cols-2 gap-4';
+      const empty = zone.querySelector('[data-menu-empty]');
+      if (empty) {
+        empty.before(list);
+      } else {
+        zone.appendChild(list);
+      }
+      return list;
+    }
+
+    function moveCard(card, zone){
+      if (!(card && zone)) return;
+      const list = ensureList(zone);
+      list.appendChild(card);
+      updateEmptyStates(zone);
+    }
+
+    function sendMove(payload){
+      return fetch(moveUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrf,
+        },
+        body: JSON.stringify(payload),
+      }).then((res) => {
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      });
+    }
+
+    function zoneFor(menuId){
+      if (!menuId) return document.getElementById('favorites-uncategorized');
+      return root.querySelector(`[data-menu-dropzone][data-menu-id="${CSS.escape(menuId)}"]`);
+    }
+
+    function handleDrop(event){
+      event.preventDefault();
+      const zone = event.currentTarget;
+      const dishId = event.dataTransfer.getData('text/plain');
+      if (!dishId) return;
+      const card = document.getElementById(`favorite-dish-${dishId}`);
+      if (!card) return;
+      const sourceMenuId = card.dataset.currentMenu || '';
+      const targetMenuId = zone.dataset.menuId || '';
+      if (sourceMenuId === targetMenuId) return;
+
+      sendMove({dish_id: dishId, target_menu_id: targetMenuId, source_menu_id: sourceMenuId}).then(() => {
+        const sourceZone = zoneFor(sourceMenuId);
+        card.dataset.currentMenu = targetMenuId;
+        moveCard(card, zone);
+        updateEmptyStates(sourceZone);
+      }).catch(() => {
+        zone.classList.remove('is-drop-target');
+      });
+    }
+
+    root.querySelectorAll('[data-dish-card]').forEach((card) => {
+      card.addEventListener('dragstart', (event) => {
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', card.dataset.dishId);
+        card.classList.add('is-dragging');
+      });
+      card.addEventListener('dragend', () => {
+        card.classList.remove('is-dragging');
+        root.querySelectorAll('[data-menu-dropzone]').forEach((zone) => zone.classList.remove('is-drop-target'));
+      });
+    });
+
+    root.querySelectorAll('[data-menu-dropzone]').forEach((zone) => {
+      zone.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        zone.classList.add('is-drop-target');
+      });
+      zone.addEventListener('dragleave', () => zone.classList.remove('is-drop-target'));
+      zone.addEventListener('drop', handleDrop);
+    });
+
+    function openSheet(dishId, currentMenuId){
+      if (!(sheet && sheetList)) return;
+      sheet.dataset.dishId = dishId;
+      sheet.dataset.currentMenuId = currentMenuId || '';
+      sheetList.innerHTML = '';
+
+      if (!menuData.length){
+        const empty = document.createElement('p');
+        empty.className = 'text-sm text-slate-500';
+        empty.textContent = 'Create a menu first to assign dishes.';
+        sheetList.appendChild(empty);
+      } else {
+        menuData.forEach((menu) => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-left text-sm font-medium text-[#49475B] shadow-sm transition hover:bg-slate-50';
+          btn.textContent = menu.name;
+          btn.dataset.menuId = menu.id;
+          if (menu.id === currentMenuId){
+            btn.classList.add('bg-slate-100');
+          }
+          btn.addEventListener('click', () => assignFromSheet(menu.id));
+          sheetList.appendChild(btn);
+        });
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'w-full rounded-xl border border-dashed border-slate-300 px-4 py-3 text-left text-sm font-medium text-slate-500 transition hover:bg-slate-100';
+        remove.textContent = 'Remove from menus';
+        remove.addEventListener('click', () => assignFromSheet(''));
+        sheetList.appendChild(remove);
+      }
+
+      sheet.classList.remove('hidden');
+      requestAnimationFrame(() => sheet.classList.add('visible'));
+    }
+
+    function closeSheet(){
+      if (!sheet) return;
+      sheet.classList.remove('visible');
+      setTimeout(() => sheet.classList.add('hidden'), 150);
+    }
+
+    function assignFromSheet(targetMenuId){
+      if (!sheet) return;
+      const dishId = sheet.dataset.dishId;
+      const sourceMenuId = sheet.dataset.currentMenuId || '';
+      if (!dishId) return;
+      const zone = zoneFor(targetMenuId);
+      const card = document.getElementById(`favorite-dish-${dishId}`);
+      if (!(zone && card)) return;
+      if (sourceMenuId === targetMenuId) {
+        closeSheet();
+        return;
+      }
+
+      sendMove({dish_id: dishId, target_menu_id: targetMenuId, source_menu_id: sourceMenuId}).then(() => {
+        const sourceZone = zoneFor(sourceMenuId);
+        card.dataset.currentMenu = targetMenuId || '';
+        moveCard(card, zone);
+        updateEmptyStates(sourceZone);
+        updateEmptyStates(zone);
+        closeSheet();
+      });
+    }
+
+    sheet?.querySelectorAll('[data-sheet-close]').forEach((btn) => btn.addEventListener('click', closeSheet));
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') closeSheet();
+    });
+
+    root.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-menu-trigger]');
+      if (!trigger) return;
+      const card = getCard(trigger);
+      if (!card) return;
+      openSheet(card.dataset.dishId, card.dataset.currentMenu || '');
+    });
+
+    const createBtn = root.querySelector('[data-action="create-menu"]');
+    createBtn?.addEventListener('click', () => {
+      const name = prompt('Name your menu', 'New Menu');
+      const formData = new FormData();
+      if (name) formData.append('name', name);
+      fetch(createUrl, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': csrf,
+        },
+        body: formData,
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error('Unable to create menu');
+          return res.json();
+        })
+        .then((data) => {
+          menuData.push({id: data.id, name: data.name});
+          window.location.reload();
+        });
+    });
+
+    root.querySelectorAll('[data-menu-card]').forEach((card) => {
+      const renameUrl = card.dataset.renameUrl;
+      const deleteUrl = card.dataset.deleteUrl;
+      const nameEl = card.querySelector('h3');
+
+      card.querySelector('[data-action="rename-menu"]').addEventListener('click', () => {
+        const currentName = nameEl?.textContent?.trim() || 'Menu';
+        const newName = prompt('Rename menu', currentName);
+        if (newName === null) return;
+        const formData = new FormData();
+        formData.append('name', newName);
+        fetch(renameUrl, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': csrf,
+          },
+          body: formData,
+        })
+          .then((res) => {
+            if (!res.ok) throw new Error('Unable to rename menu');
+            return res.json();
+          })
+          .then((data) => {
+            if (nameEl) nameEl.textContent = data.name;
+            const entry = menuData.find((m) => m.id === data.id);
+            if (entry) entry.name = data.name;
+          });
+      });
+
+      card.querySelector('[data-action="delete-menu"]').addEventListener('click', () => {
+        if (!confirm('Delete this menu?')) return;
+        fetch(deleteUrl, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': csrf,
+          },
+        })
+          .then((res) => {
+            if (!res.ok) throw new Error('Unable to delete menu');
+            return res.json();
+          })
+          .then(() => {
+            const idx = menuData.findIndex((m) => m.id === card.dataset.menuId);
+            if (idx >= 0) menuData.splice(idx, 1);
+            card.remove();
+          });
+      });
+    });
+  });
+</script>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
-from django.db.models import Prefetch
+from django.db.models import Max, Prefetch
 from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -959,14 +959,55 @@ def favorites_view(request):
         .order_by("-favorited_at")
     )
 
-    decorate_dishes_with_enhancements([fav.dish for fav in favorite_dishes])
-    for fav in favorite_dishes:
-        fav.dish.is_favorited = True
+    menus = []
+    menu_dishes = []
+    if restaurant:
+        menus = list(
+            models.MenuCollection.objects.filter(restaurant=restaurant)
+            .prefetch_related(
+                Prefetch(
+                    "menuitem_set",
+                    queryset=models.MenuItem.objects.select_related(
+                        "dish",
+                        "dish__parent_concept",
+                        "dish__restaurant",
+                    ).order_by("position", "created_at"),
+                )
+            )
+            .order_by("created_at")
+        )
+        for menu in menus:
+            items = list(menu.menuitem_set.all())
+            menu.menu_items = items
+            for item in items:
+                menu_dishes.append(item.dish)
+
+    all_dishes = [fav.dish for fav in favorite_dishes] + menu_dishes
+    if all_dishes:
+        decorate_dishes_with_enhancements(all_dishes)
+    for dish in all_dishes:
+        dish.is_favorited = True
+
+    menu_dish_ids = {item.dish_id for menu in menus for item in getattr(menu, "menu_items", [])}
+    uncategorized_favorites = [
+        fav for fav in favorite_dishes if fav.dish_id not in menu_dish_ids
+    ]
+
+    menus_payload = [
+        {
+            "id": str(menu.id),
+            "name": menu.name,
+        }
+        for menu in menus
+    ]
 
     ctx = {
         "restaurant": restaurant,
         "favorite_concepts": favorite_concepts,
         "favorite_dishes": favorite_dishes,
+        "menus": menus,
+        "uncategorized_favorites": uncategorized_favorites,
+        "menus_payload_json": json.dumps(menus_payload),
     }
     return render(request, "favorites/dashboard.html", ctx)
 
@@ -991,22 +1032,132 @@ def favorite_remove_view(request, type, id):
     return JsonResponse({"removed": True})
 
 
+@login_required
+@require_POST
 def menu_collection_create_view(request):
     """Create a new menu collection."""
     name = request.POST.get("name", "Menu")
-    restaurant = models.Restaurant.objects.first()
+    restaurant = (
+        models.Restaurant.objects.filter(account__membership__user=request.user)
+        .select_related("account")
+        .first()
+    )
+    if not restaurant:
+        return JsonResponse({"error": "restaurant_missing"}, status=400)
     menu = models.MenuCollection.objects.create(
         restaurant=restaurant, created_by_user=request.user, name=name
     )
     return JsonResponse({"id": str(menu.id), "name": menu.name})
 
 
+@login_required
+@require_POST
 def menu_item_add_view(request, dish_id, collection_id):
     """Add a dish to a menu collection."""
     dish = get_object_or_404(models.DishIdea, id=dish_id)
-    menu = get_object_or_404(models.MenuCollection, id=collection_id)
-    models.MenuItem.objects.create(menu=menu, dish=dish, position=1)
+    menu = get_object_or_404(
+        models.MenuCollection,
+        id=collection_id,
+        restaurant__account__membership__user=request.user,
+    )
+    next_position = (
+        models.MenuItem.objects.filter(menu=menu).aggregate(Max("position"))["position__max"]
+        or 0
+    )
+    models.MenuItem.objects.get_or_create(
+        menu=menu, dish=dish, defaults={"position": next_position + 1}
+    )
     return JsonResponse({"added": True})
+
+
+@login_required
+@require_POST
+def menu_collection_update_view(request, collection_id):
+    """Rename a menu collection."""
+    menu = get_object_or_404(
+        models.MenuCollection,
+        id=collection_id,
+        restaurant__account__membership__user=request.user,
+    )
+    new_name = (request.POST.get("name") or "").strip() or "Menu"
+    menu.name = new_name
+    menu.save(update_fields=["name"])
+    return JsonResponse({"id": str(menu.id), "name": menu.name})
+
+
+@login_required
+@require_POST
+def menu_collection_delete_view(request, collection_id):
+    """Delete a menu collection."""
+    menu = get_object_or_404(
+        models.MenuCollection,
+        id=collection_id,
+        restaurant__account__membership__user=request.user,
+    )
+    menu.delete()
+    return JsonResponse({"deleted": True})
+
+
+@login_required
+@require_POST
+def menu_item_move_view(request):
+    """Move a dish between menu collections or into uncategorized."""
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "invalid_json"}, status=400)
+
+    dish_id = payload.get("dish_id")
+    target_menu_id = payload.get("target_menu_id") or None
+    source_menu_id = payload.get("source_menu_id") or None
+
+    if not dish_id:
+        return JsonResponse({"error": "dish_required"}, status=400)
+
+    restaurant = (
+        models.Restaurant.objects.filter(account__membership__user=request.user)
+        .select_related("account")
+        .first()
+    )
+    if not restaurant:
+        return JsonResponse({"error": "restaurant_missing"}, status=400)
+
+    dish = get_object_or_404(models.DishIdea, id=dish_id)
+
+    def _remove_from_menu(menu_id):
+        if not menu_id:
+            return
+        models.MenuItem.objects.filter(
+            menu_id=menu_id,
+            dish=dish,
+            menu__restaurant=restaurant,
+        ).delete()
+
+    # Remove from the source menu if provided
+    _remove_from_menu(source_menu_id)
+
+    created = False
+    if target_menu_id:
+        menu = get_object_or_404(
+            models.MenuCollection,
+            id=target_menu_id,
+            restaurant=restaurant,
+        )
+        next_position = (
+            models.MenuItem.objects.filter(menu=menu).aggregate(Max("position"))["position__max"]
+            or 0
+        )
+        menu_item, created = models.MenuItem.objects.get_or_create(
+            menu=menu,
+            dish=dish,
+            defaults={"position": next_position + 1},
+        )
+        if not created:
+            # Ensure position is at end when moving existing record
+            menu_item.position = next_position + 1
+            menu_item.save(update_fields=["position"])
+
+    return JsonResponse({"moved": True, "created": created})
 
 
 @login_required

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -37,6 +37,9 @@ urlpatterns = [
     path("favorites/remove/<str:type>/<uuid:id>/", app_views.favorite_remove_view, name="favorite-remove"),
     path("menus/create/", app_views.menu_collection_create_view, name="menu-collection-create"),
     path("menus/add/<uuid:dish_id>/<uuid:collection_id>/", app_views.menu_item_add_view, name="menu-item-add"),
+    path("menus/<uuid:collection_id>/rename/", app_views.menu_collection_update_view, name="menu-collection-rename"),
+    path("menus/<uuid:collection_id>/delete/", app_views.menu_collection_delete_view, name="menu-collection-delete"),
+    path("menus/item/move/", app_views.menu_item_move_view, name="menu-item-move"),
     ##settings page
     path("settings/", app_views.settings_view, name="settings"),
     path("settings/info/", app_views.update_restaurant_info, name="update_restaurant_info"),

--- a/static/style.css
+++ b/static/style.css
@@ -294,3 +294,98 @@ body {
         box-shadow: none !important;
     }
 }
+
+/* Favorites view custom styles */
+.concept-card-background {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    filter: grayscale(100%);
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.concept-card-background--loading {
+    background: radial-gradient(circle at center, rgba(226, 232, 240, 0.85), rgba(226, 232, 240, 0.4));
+    opacity: 1;
+}
+
+.concept-card-background--loaded {
+    opacity: 1;
+}
+
+.concept-card-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.95));
+    pointer-events: none;
+    z-index: 5;
+}
+
+.favorite-dish-card {
+    cursor: grab;
+}
+
+.favorite-dish-card:active {
+    cursor: grabbing;
+}
+
+.favorite-dish-card.is-dragging {
+    opacity: 0.55;
+}
+
+.menu-dropzone.is-drop-target {
+    border-color: #5C008B;
+    background: rgba(92, 0, 139, 0.08);
+}
+
+.favorites-menu-sheet {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.favorites-menu-sheet.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.favorites-menu-sheet__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.favorites-menu-sheet__panel {
+    position: relative;
+    width: min(420px, 100%);
+    background: white;
+    border-radius: 1.75rem 1.75rem 0 0;
+    padding: 1.75rem;
+    box-shadow: 0 -10px 30px rgba(15, 23, 42, 0.15);
+    max-height: 70vh;
+    overflow-y: auto;
+    transform: translateY(12px);
+    transition: transform 0.2s ease;
+}
+
+.favorites-menu-sheet.visible .favorites-menu-sheet__panel {
+    transform: translateY(0);
+}
+
+.favorites-menu-sheet.hidden {
+    display: none;
+}
+
+#favorites-dishes-loading.htmx-request {
+    display: flex !important;
+}

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -219,18 +220,20 @@ class ViewSmokeTests(TestCase):
     def test_favorites_views(self):
         resp = self.client.get(reverse("favorites"))
         self.assertEqual(resp.status_code, 200)
+
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
         concept = models.Concept.objects.create(
             restaurant=self.restaurant,
-            ideation_run=models.IdeationRun.objects.create(
-                restaurant=self.restaurant,
-                initiated_by_user=self.user,
-                type=models.IdeationRun.RunType.CONCEPTS,
-                model_name="m",
-                temperature=0,
-                classic_creative=50,
-                context_snapshot={},
-                status=models.IdeationRun.Status.SUCCEEDED,
-            ),
+            ideation_run=concept_run,
             name="Fav",
             rank_order=1,
         )
@@ -239,6 +242,46 @@ class ViewSmokeTests(TestCase):
         )
         concept.sketch_image_url = "https://example.com/favorite.png"
         concept.save(update_fields=["sketch_image_url"])
+
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        dish = models.DishIdea.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=dish_run,
+            parent_concept=concept,
+            title="Favorite Dish",
+            description="Desc",
+            ingredient_names=[],
+            category_tags=[],
+        )
+        models.FavoriteDish.objects.create(
+            user=self.user, dish=dish, favorited_at=timezone.now()
+        )
+        menu = models.MenuCollection.objects.create(
+            restaurant=self.restaurant,
+            created_by_user=self.user,
+            name="Dinner",
+        )
+        models.MenuItem.objects.create(menu=menu, dish=dish, position=1)
+
+        resp = self.client.get(reverse("favorites"))
+        self.assertEqual(resp.status_code, 200)
+        menus = resp.context["menus"]
+        self.assertEqual(len(menus), 1)
+        self.assertEqual(menus[0].name, "Dinner")
+        self.assertEqual(len(menus[0].menu_items), 1)
+        self.assertEqual(str(menus[0].menu_items[0].dish.id), str(dish.id))
+        self.assertEqual(resp.context["uncategorized_favorites"], [])
+
         rem_resp = self.client.post(
             reverse("favorite-remove", args=["concept", concept.id]),
             HTTP_HX_REQUEST="true",
@@ -262,6 +305,63 @@ class ViewSmokeTests(TestCase):
             reverse("menu-item-add", args=[dish.id, collection_id])
         )
         self.assertEqual(add_resp.status_code, 200)
+        self.assertTrue(
+            models.MenuItem.objects.filter(menu_id=collection_id, dish=dish).exists()
+        )
+
+        second_resp = self.client.post(
+            reverse("menu-collection-create"), {"name": "Second"}
+        )
+        self.assertEqual(second_resp.status_code, 200)
+        second_id = second_resp.json()["id"]
+
+        move_resp = self.client.post(
+            reverse("menu-item-move"),
+            data=json.dumps(
+                {
+                    "dish_id": str(dish.id),
+                    "source_menu_id": collection_id,
+                    "target_menu_id": second_id,
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(move_resp.status_code, 200)
+        self.assertTrue(
+            models.MenuItem.objects.filter(menu_id=second_id, dish=dish).exists()
+        )
+        self.assertFalse(
+            models.MenuItem.objects.filter(menu_id=collection_id, dish=dish).exists()
+        )
+
+        remove_resp = self.client.post(
+            reverse("menu-item-move"),
+            data=json.dumps(
+                {
+                    "dish_id": str(dish.id),
+                    "source_menu_id": second_id,
+                    "target_menu_id": "",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(remove_resp.status_code, 200)
+        self.assertFalse(
+            models.MenuItem.objects.filter(menu_id=second_id, dish=dish).exists()
+        )
+
+        rename_resp = self.client.post(
+            reverse("menu-collection-rename", args=[second_id]),
+            {"name": "Updated"},
+        )
+        self.assertEqual(rename_resp.status_code, 200)
+        self.assertEqual(rename_resp.json()["name"], "Updated")
+
+        delete_resp = self.client.post(
+            reverse("menu-collection-delete", args=[second_id])
+        )
+        self.assertEqual(delete_resp.status_code, 200)
+        self.assertFalse(models.MenuCollection.objects.filter(id=second_id).exists())
 
     def test_settings_views(self):
         self.restaurant.context_json = {"story": "Farm-to-table"}


### PR DESCRIPTION
## Summary
- redesign the favorites dashboard with dedicated concept, menu, and uncategorized sections plus a mobile-friendly assignment sheet
- load menu collections in the favorites view and expose endpoints to create, rename, delete, and move menu items
- refresh concept and dish cards, styles, and tests to support drag and drop menu organization

## Testing
- python manage.py test
- python manage.py test tests

------
https://chatgpt.com/codex/tasks/task_e_68cb42e76a148332bad7424837ff1a13