### PR TITLE
Prevent card flip on favorite button request

### DIFF
--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -200,6 +200,16 @@ transform: rotateY(180deg);
   });
 
   document.body.addEventListener("htmx:beforeRequest", function (evt) {
+    const triggeringEvent = evt.detail && evt.detail.triggeringEvent;
+    if (
+      triggeringEvent &&
+      triggeringEvent.target &&
+      triggeringEvent.target.closest(".concept-favorite-btn")
+    ) {
+      evt.preventDefault();
+      return;
+    }
+
     const trigger = evt.detail.elt;
     if (
       !trigger ||


### PR DESCRIPTION
## Summary
- stop beforeRequest handlers triggered by clicks inside favorite buttons from flipping concept cards
- leave the existing flipping logic unchanged for other triggers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5875526c8332b8995982a1f57090