### PR TITLE
Add favorites section to concepts page

### DIFF
--- a/app/templates/concepts/_favorites_section.html
+++ b/app/templates/concepts/_favorites_section.html
@@ -1,0 +1,15 @@
+{% if concepts %}
+<div class="mt-10">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-2xl font-semibold text-[#49475B]">Your favorites</h2>
+    <span class="text-sm text-slate-500">Showing {{ concepts|length }} saved concepts</span>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    {% include "concepts/_concepts_grid.html" %}
+  </div>
+</div>
+{% else %}
+<div class="mt-10 text-center text-slate-500">
+  <p>You haven’t saved any concepts yet.</p>
+</div>
+{% endif %}

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -170,6 +170,19 @@ transform: rotateY(180deg);
   <div id="concepts-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
    {% include 'concepts/_concepts_grid.html' %}
   </div>
+
+  <div class="mt-8">
+    <button
+      id="concepts-favorites-btn"
+      hx-get="{% url 'concepts-favorites' %}"
+      hx-target="#concepts-favorites"
+      hx-swap="innerHTML"
+      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-white hover:text-[#49475B]"
+    >
+      <span>See favorites</span>
+    </button>
+    <div id="concepts-favorites" class="mt-6"></div>
+  </div>
 </div>
 <script>
 

--- a/app/views.py
+++ b/app/views.py
@@ -445,6 +445,36 @@ def concept_background_view(request, concept_id):
         {"concept": concept, "image_url": image_url},
     )
 
+
+@login_required
+@require_GET
+def concepts_favorites_view(request):
+    """Return favorited concepts rendered for the concepts page."""
+
+    favorites = (
+        models.FavoriteConcept.objects.filter(user=request.user)
+        .select_related("concept", "concept__restaurant")
+        .order_by("-favorited_at")
+    )
+
+    concepts = []
+    for favorite in favorites:
+        concept = favorite.concept
+        if concept is None:
+            continue
+        if not concept.sketch_image_url:
+            image_url = llm.generate_concept_sketch(concept)
+            concept.sketch_image_url = image_url
+            concept.save(update_fields=["sketch_image_url"])
+        concept.is_favorited_for_user = True
+        concepts.append(concept)
+
+    return render(
+        request,
+        "concepts/_favorites_section.html",
+        {"concepts": concepts},
+    )
+
 def serialize_restaurant_context(restaurant_payload, menu_markdown, concept):
     """Return a slim JSON-serializable context for dish generation."""
     return {

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("restaurants/<uuid:restaurant_id>/upload-menu/",app_views.upload_menu,name="upload_menu",),
     path("concepts/", app_views.concepts_view, name="concepts"),
     path("concepts/generate/", app_views.concepts_generate_view, name="concepts-generate"),
+    path("concepts/favorites/", app_views.concepts_favorites_view, name="concepts-favorites"),
     path("concepts/<uuid:concept_id>/favorite/", app_views.concept_favorite_view, name="concept-favorite"),
     path(
         "concepts/<uuid:concept_id>/background/",


### PR DESCRIPTION
## Summary
- add an HTMX-powered "See favorites" control to the concepts page
- render favorited concepts with existing card styling and ensured sketches
- expose a concepts favorites endpoint and template partial for reuse

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cd9c613a308332b11e0257b8f30dc9