### PR TITLE
Create dedicated dishes page for generated dishes

### DIFF
--- a/app/templates/concepts/_concepts_grid.html
+++ b/app/templates/concepts/_concepts_grid.html
@@ -1,7 +1,13 @@
 {% for concept in concepts %}
 <div class="flip-scene relative">
-  <div class="flip-card cursor-pointer" id="concept-{{ concept.id }}" hx-post="{% url 'dishes-generate' concept.id %}"
-    hx-target="#concepts-grid" hx-swap="innerHTML" hx-trigger="click">
+  <div
+    class="flip-card cursor-pointer"
+    id="concept-{{ concept.id }}"
+    onclick="window.location.href='{% url 'dishes-generate' concept.id %}';"
+    role="link"
+    tabindex="0"
+    onkeydown="if(event.key==='Enter' || event.key===' '){ event.preventDefault(); window.location.href='{% url 'dishes-generate' concept.id %}'; }"
+  >
     <div
       class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg relative overflow-hidden">
       {% with background=concept.sketch_image_url %}

--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -2,7 +2,7 @@
   {% with start_loader=trigger_loader|default:False %}
     <button
       type="button"
-      onclick="event.stopPropagation();"
+      onclick="event.preventDefault(); event.stopPropagation();"
       hx-trigger="click consume"
       hx-post="{% url 'concept-favorite' concept.id %}"
       hx-target="this"

--- a/app/templates/concepts/_favorites_section.html
+++ b/app/templates/concepts/_favorites_section.html
@@ -2,8 +2,14 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for concept in concepts %}
       <div class="flip-scene relative">
-        <div class="flip-card cursor-pointer" id="concept-{{ concept.id }}" hx-post="{% url 'dishes-generate' concept.id %}"
-             hx-target="#concepts-grid" hx-swap="innerHTML" hx-trigger="click">
+        <div
+          class="flip-card cursor-pointer"
+          id="concept-{{ concept.id }}"
+          onclick="window.location.href='{% url 'dishes-generate' concept.id %}';"
+          role="link"
+          tabindex="0"
+          onkeydown="if(event.key==='Enter' || event.key===' '){ event.preventDefault(); window.location.href='{% url 'dishes-generate' concept.id %}'; }"
+        >
           <div class="flip-face front bg-white p-6 rounded-2xl shadow-md border border-slate-200 transition cursor-pointer hover:shadow-lg relative overflow-hidden">
             {% with background=concept.sketch_image_url %}
               <div id="concept-{{ concept.id }}-background"

--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -1,0 +1,39 @@
+{% extends "base_logged_in.html" %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
+  <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <div>
+      <a href="{% url 'concepts' %}" class="text-sm font-medium text-[#f08000] hover:text-[#d96e00] transition">&larr; Back to concepts</a>
+      <h1 class="mt-2 text-3xl font-bold text-[#49475B]">{{ concept.name }}</h1>
+      {% if concept.subtitle %}
+        <p class="mt-2 max-w-2xl text-base text-slate-600">{{ concept.subtitle }}</p>
+      {% endif %}
+      {% if concept.tags %}
+        <div class="mt-3 flex flex-wrap gap-2">
+          {% for tag in concept.tags %}
+            <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-5 py-2.5 text-sm font-semibold text-white shadow transition hover:scale-105"
+        hx-post="{% url 'dishes-generate' concept.id %}"
+        hx-trigger="click"
+        hx-target="#dishes-grid"
+        hx-swap="innerHTML"
+      >
+        <i class="fa-solid fa-wand-magic-sparkles" aria-hidden="true"></i>
+        <span>Generate new dishes</span>
+      </button>
+    </div>
+  </div>
+
+  <div id="dishes-grid" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+    {% include "dishes/grid.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/favorites/_concept_card.html
+++ b/app/templates/favorites/_concept_card.html
@@ -1,6 +1,10 @@
 <div
   id="favorite-concept-{{ favorite.concept.id }}"
   class="favorite-concept-card group relative flex min-h-[180px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm hover:shadow-md transition-shadow"
+  onclick="window.location.href='{% url 'dishes-generate' favorite.concept.id %}';"
+  role="link"
+  tabindex="0"
+  onkeydown="if(event.key==='Enter' || event.key===' '){ event.preventDefault(); window.location.href='{% url 'dishes-generate' favorite.concept.id %}'; }"
 >
   {% with background=favorite.concept.sketch_image_url %}
     <div
@@ -28,7 +32,7 @@
         hx-trigger="click consume"
         hx-target="#favorite-concept-{{ favorite.concept.id }}"
         hx-swap="outerHTML"
-        onclick="event.stopPropagation();"
+        onclick="event.preventDefault(); event.stopPropagation();"
         title="Remove concept"
       >
         <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
@@ -36,18 +40,14 @@
       </button>
     </div>
     <div class="mt-auto flex justify-end pt-4">
-      <button
-        type="button"
+      <a
+        href="{% url 'dishes-generate' favorite.concept.id %}"
         class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-105"
-        hx-post="{% url 'dishes-generate' favorite.concept.id %}"
-        hx-trigger="click"
-        hx-target="#favorites-generated-dishes"
-        hx-swap="innerHTML"
-        hx-indicator="#favorites-dishes-loading"
+        onclick="event.stopPropagation();"
       >
         <i class="fa-solid fa-wand-magic-sparkles" aria-hidden="true"></i>
         <span>Get ideas</span>
-      </button>
+      </a>
     </div>
   </div>
 </div>

--- a/app/views.py
+++ b/app/views.py
@@ -668,6 +668,8 @@ def dishes_generate_view(request, concept_id):
 
     context = serialize_restaurant_context(restaurant_payload, menu_markdown, concept)
 
+    is_htmx = request.headers.get("HX-Request") == "true"
+
     previous_dishes: List[str] = []
     if request.user.is_authenticated:
         previous_dishes = _get_session_list(request.session, "generated_dishes")
@@ -794,7 +796,8 @@ def dishes_generate_view(request, concept_id):
         ideation_run.status = models.IdeationRun.Status.FAILED
         ideation_run.error_message = str(e)
         ideation_run.save(update_fields=["status", "error_message"])
-    return render(request, "dishes/grid.html", {"concept": concept, "dishes": dishes})
+    template_name = "dishes/grid.html" if is_htmx else "dishes/page.html"
+    return render(request, template_name, {"concept": concept, "dishes": dishes})
 
 
 def dishes_grid_view(request, concept_id):

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -233,8 +233,9 @@ class SessionHistoryTests(TestCase):
         session["generated_dishes"] = ["Sunrise Salad"]
         session.save()
 
-        response = self.client.post(reverse("dishes-generate", args=[self.concept.id]))
+        response = self.client.get(reverse("dishes-generate", args=[self.concept.id]))
         self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dishes/page.html")
 
         _, kwargs = mock_client.responses.create.call_args
         input_messages = kwargs.get("input", [])
@@ -255,6 +256,31 @@ class SessionHistoryTests(TestCase):
         stored_dishes = session.get("generated_dishes")
         self.assertIn("Sunrise Salad", stored_dishes)
         self.assertIn("Dish 1", stored_dishes)
+
+    @patch("app.views.client")
+    def test_dish_generation_htmx_returns_partial(self, mock_client):
+        dishes_payload = {
+            "dishes": [
+                {
+                    "title": f"Dish {i}",
+                    "description": "Tasty",
+                    "ingredient_overlap": [],
+                    "category_tags": ["tag"],
+                }
+                for i in range(1, 10)
+            ]
+        }
+        mock_client.responses.create.return_value = self._fake_response(dishes_payload)
+
+        self.client.login(username="owner@example.com", password="safe-pass")
+
+        response = self.client.post(
+            reverse("dishes-generate", args=[self.concept.id]),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dishes/grid.html")
 
 
 @override_settings(SECURE_SSL_REDIRECT=False)


### PR DESCRIPTION
## Summary
- add a full dishes page template to show generated dishes alongside concept details
- update concept and favorites cards plus dish generation view to navigate to the new page while still supporting HTMX refreshes
- adjust tests to cover the new page response and HTMX partial behaviour

## Testing
- python manage.py test tests.test_llm_views_tasks

------
https://chatgpt.com/codex/tasks/task_e_68cda7eff2e48332b15052732cbe97f4