### PR TITLE
Adjust dish cards for pre/post favorite layouts

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -1,76 +1,146 @@
-{# Full dish card, lookbook style #}
+{# Full dish card #}
 {% with context_name=card_context|default:'grid' %}
 <div class="dish-card-wrapper" id="dish-{{ dish.id }}">
-  <div class="rounded-2xl overflow-hidden shadow-md border border-slate-200 bg-white flex flex-col">
-    
-    {# Top: Dish Image (enhancement if available) #}
-    <div class="dish-image w-full aspect-[4/3] bg-slate-100 relative">
-      {% if dish.enhancement_image_url %}
-        <img 
-          src="{{ dish.enhancement_image_url }}" 
-          alt="{{ dish.title }}" 
-          class="w-full h-full object-cover"
-        />
-      {% else %}
-        <div class="w-full h-full flex items-center justify-center text-slate-400">
-          <i class="fa-solid fa-utensils text-3xl"></i>
-        </div>
-      {% endif %}
-    </div>
-
-    {# Body: Title + Description #}
-    <div class="p-4 flex-1 flex flex-col">
-      <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
-      {% if dish.description %}
-        <p class="text-slate-600 mt-2 text-sm clamp-3">{{ dish.description }}</p>
-      {% endif %}
-    </div>
-
-    {# Footer: Tags + Actions #}
-    <div class="p-4 border-t border-slate-200 flex flex-col gap-3">
-      <div class="flex flex-wrap gap-2">
-        {% if dish.enhancement_price_display %}
-          <span class="dish-tag dish-tag--price">
-            {{ dish.enhancement_price_display }}
-          </span>
-        {% endif %}
-        {% for tag in dish.category_tags %}
-          <span class="dish-tag dish-tag--category">{{ tag }}</span>
-        {% endfor %}
-        {% for tag in dish.ingredient_overlap %}
-          <span class="dish-tag dish-tag--ingredient">{{ tag }}</span>
-        {% endfor %}
-      </div>
-
-      <div class="flex justify-end gap-3">
-        {% if dish.is_enhanced %}
-          <button
-            type="button"
-            class="dish-delete-btn text-red-500 hover:text-red-700"
-            hx-post="{% url 'dish-delete' dish.id %}"
-            hx-trigger="click"
-            hx-target="closest .dish-card-wrapper"
-            hx-swap="outerHTML"
-            aria-label="Delete {{ dish.title }}"
-          >
-            🗑️
-          </button>
+  {% if dish.is_favorited %}
+    <div class="rounded-2xl overflow-hidden shadow-md border border-slate-200 bg-white flex flex-col">
+      <div class="dish-image w-full aspect-[4/3] bg-slate-100 relative">
+        {% if dish.enhancement_image_url %}
+          <img
+            src="{{ dish.enhancement_image_url }}"
+            alt="{{ dish.title }}"
+            class="w-full h-full object-cover"
+          />
         {% else %}
-          {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name %}
-          <button
-            type="button"
-            class="dish-variation-btn text-slate-500 hover:text-slate-700"
-            hx-post="{% url 'dish-variation' dish.id %}"
-            hx-trigger="click"
-            hx-target="closest .dish-card-wrapper"
-            hx-swap="outerHTML"
-            aria-label="Generate a variation of {{ dish.title }}"
-          >
-            <i class="fa-solid fa-arrows-rotate"></i>
-          </button>
+          <div class="w-full h-full flex items-center justify-center text-slate-400">
+            <i class="fa-solid fa-utensils text-3xl"></i>
+          </div>
         {% endif %}
       </div>
+
+      <div class="p-4 flex-1 flex flex-col gap-4">
+        <div>
+          <h3 class="text-lg font-bold text-[#49475B]">{{ dish.title }}</h3>
+          {% if dish.description %}
+            <p class="text-slate-600 mt-2 text-sm clamp-3">{{ dish.description }}</p>
+          {% endif %}
+        </div>
+
+        <div class="mt-auto flex flex-col gap-3">
+          <div class="flex flex-wrap gap-2">
+            {% if dish.enhancement_price_display %}
+              <span class="dish-tag dish-tag--price">
+                {{ dish.enhancement_price_display }}
+              </span>
+            {% endif %}
+            {% for tag in dish.category_tags %}
+              <span class="dish-tag dish-tag--category">{{ tag }}</span>
+            {% endfor %}
+            {% for tag in dish.ingredient_overlap %}
+              <span class="dish-tag dish-tag--ingredient">{{ tag }}</span>
+            {% endfor %}
+          </div>
+
+          <div class="flex justify-end gap-3">
+            {% if dish.is_enhanced %}
+              <button
+                type="button"
+                class="dish-delete-btn card-action-button text-red-500 hover:text-red-600"
+                hx-post="{% url 'dish-delete' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Delete {{ dish.title }}"
+              >
+                🗑️
+              </button>
+            {% else %}
+              {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button' %}
+              <button
+                type="button"
+                class="dish-variation-btn card-action-button text-slate-500 hover:text-slate-700"
+                hx-post="{% url 'dish-variation' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Generate a variation of {{ dish.title }}"
+              >
+                <i class="fa-solid fa-arrows-rotate"></i>
+              </button>
+            {% endif %}
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
+  {% else %}
+    <div class="flip-scene">
+      <div class="flip-card">
+        <div
+          class="flip-face front {% if dish.enhancement_image_url %}enhanced{% else %}bg-white{% endif %}"
+          {% if dish.enhancement_image_url %}style="background-image: url('{{ dish.enhancement_image_url }}');"{% endif %}
+        >
+          <div class="card-inner p-6">
+            <div class="flex-1 flex flex-col items-center justify-center text-center gap-3">
+              <div>
+                <h3 class="text-xl font-semibold text-[#49475B]">{{ dish.title }}</h3>
+                {% if dish.description %}
+                  <p class="text-slate-600 text-sm clamp-3 mt-2">{{ dish.description }}</p>
+                {% endif %}
+              </div>
+              <div class="flex flex-wrap justify-center gap-2">
+                {% if dish.enhancement_price_display %}
+                  <span class="dish-tag dish-tag--price">
+                    {{ dish.enhancement_price_display }}
+                  </span>
+                {% endif %}
+                {% for tag in dish.category_tags %}
+                  <span class="dish-tag dish-tag--category">{{ tag }}</span>
+                {% endfor %}
+                {% for tag in dish.ingredient_overlap %}
+                  <span class="dish-tag dish-tag--ingredient">{{ tag }}</span>
+                {% endfor %}
+              </div>
+            </div>
+
+            <div class="card-footer mt-6">
+              <div class="card-action-tab">
+                {% if dish.is_enhanced %}
+                  <button
+                    type="button"
+                    class="dish-delete-btn card-action-button text-red-500 hover:text-red-600"
+                    hx-post="{% url 'dish-delete' dish.id %}"
+                    hx-trigger="click"
+                    hx-target="closest .dish-card-wrapper"
+                    hx-swap="outerHTML"
+                    aria-label="Delete {{ dish.title }}"
+                  >
+                    🗑️
+                  </button>
+                {% else %}
+                  {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button' %}
+                  <button
+                    type="button"
+                    class="dish-variation-btn card-action-button text-slate-500 hover:text-slate-700"
+                    hx-post="{% url 'dish-variation' dish.id %}"
+                    hx-trigger="click"
+                    hx-target="closest .dish-card-wrapper"
+                    hx-swap="outerHTML"
+                    aria-label="Generate a variation of {{ dish.title }}"
+                  >
+                    <i class="fa-solid fa-arrows-rotate"></i>
+                  </button>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flip-face flip-back">
+          <div class="h-full w-full flex flex-col items-center justify-center gap-3">
+            <i class="fa-solid fa-utensils text-3xl"></i>
+            <p class="text-sm font-medium">Working on it…</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
 </div>
 {% endwith %}

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -85,6 +85,11 @@
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
   }
 
+  .flip-face.flip-back {
+    background: #1e293b;
+    color: #fff;
+  }
+
   .card-footer {
     position: relative;
     display: flex;
@@ -190,6 +195,27 @@
   .flip-face.front.enhanced .dish-tag--price {
     background: rgba(248, 113, 113, 0.95);
     border-color: transparent;
+  }
+
+  .masonry-grid {
+    column-gap: 1.25rem;
+  }
+
+  .masonry-grid .dish-card-wrapper {
+    break-inside: avoid;
+    margin-bottom: 1.25rem;
+  }
+
+  @media (min-width: 768px) {
+    .masonry-grid {
+      column-count: 2;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .masonry-grid {
+      column-count: 3;
+    }
   }
 </style>
 

--- a/app/templates/dishes/_favorite_button.html
+++ b/app/templates/dishes/_favorite_button.html
@@ -1,14 +1,26 @@
+{% with base_class=btn_class|default:'favorite-btn card-action-button' %}
 <button
   hx-post="{% url 'dish_favorite' dish.id %}?context={{ card_context|default:'grid' }}"
   hx-trigger="click"
   hx-swap="outerHTML"
   hx-target="closest .dish-card-wrapper"
-  class="favorite-btn card-action-button text-[#f08000] transition"
-  aria-label="Favorite {{ dish.title }}"
+  class="{{ base_class }} transition {% if dish.is_favorited %}text-red-500{% else %}text-slate-500 hover:text-red-400{% endif %}"
+  aria-label="{% if dish.is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ dish.title }}"
+  aria-pressed="{{ dish.is_favorited|yesno:'true,false' }}"
 >
-  {% if dish.is_favorited %}
-    ❤️
-  {% else %}
-    🤍
-  {% endif %}
+  <span aria-hidden="true">
+    {% if dish.is_favorited %}
+      ❤️
+    {% else %}
+      🤍
+    {% endif %}
+  </span>
+  <span class="sr-only">
+    {% if dish.is_favorited %}
+      Unfavorite {{ dish.title }}
+    {% else %}
+      Favorite {{ dish.title }}
+    {% endif %}
+  </span>
 </button>
+{% endwith %}

--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -32,7 +32,7 @@
     </div>
   </div>
 
-  <div id="dishes-grid" class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+  <div id="dishes-grid" class="masonry-grid">
     {% include "dishes/grid.html" %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Restore the original flip-card layout for non-favorited dishes with actions locked to the footer tab
- Keep the media-forward card for favorited dishes, adding shared button styling and accessible favorite toggles
- Introduce a masonry layout for the dishes grid so cards flow like a Pinterest board

## Testing
- pytest *(fails: Django settings module is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03e97cfa88332961f20734af8fd0b