### PR TITLE
Refine dish card layout and loading interactions

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -1,8 +1,8 @@
 {# Full dish card (lookbook-first) #}
 {% with context_name=card_context|default:'grid' %}
-{% with HSM="min-h-[280px]" HMD="md:min-h-[340px]" HLG="lg:min-h-[400px]" %}
+{% with HSM="min-h-[260px]" HMD="md:min-h-[320px]" HLG="lg:min-h-[360px]" %}
 
-<div class="dish-card-wrapper" id="dish-{{ dish.id }}">
+<div class="dish-card-wrapper" id="dish-{{ dish.id }}" data-dish-card>
   <div class="flip-scene h-full">
     <div class="flip-card h-full">
 
@@ -25,7 +25,7 @@
           {% endif %}
         {% else %}
           <!-- No image? Show a clean, centered info front -->
-          <div class="relative flex flex-col items-center justify-center text-center p-5 {{HSM}} {{HMD}} {{HLG}}">
+          <div class="relative flex flex-col items-center justify-center text-center p-4 {{HSM}} {{HMD}} {{HLG}}">
             <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
             {% if dish.description %}
               <p class="mt-2 text-slate-600 text-sm md:text-base line-clamp-4">{{ dish.description }}</p>
@@ -43,7 +43,7 @@
         {% endif %}
 
         <!-- Action pill (always shown on FRONT) -->
-        <div class="absolute bottom-2 right-2 flex items-center gap-2 bg-white/95 border border-slate-200 rounded-full shadow px-2 py-1">
+        <div class="absolute bottom-2 right-2 flex items-center gap-2 bg-white/95 border border-slate-200 rounded-full shadow px-2 py-1" data-no-flip>
           {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn text-[#f08000]' %}
           <button
             type="button"
@@ -61,17 +61,17 @@
       </div>
 
       {# ---------------- BACK (DETAILS) ---------------- #}
-      <div class="flip-face flip-back bg-white text-slate-800 rounded-2xl shadow-md border border-slate-200 p-5 flex flex-col {{HSM}} {{HMD}} {{HLG}}">
+      <div class="flip-face flip-back bg-white text-slate-800 rounded-2xl shadow-md border border-slate-200 p-4 flex flex-col gap-4 {{HSM}} {{HMD}} {{HLG}}">
         <!-- Title & Description -->
-        <div class="flex-1">
+        <div class="flex-1 text-center space-y-3">
           <h3 class="text-lg md:text-xl font-bold text-[#49475B] text-center">{{ dish.title }}</h3>
           {% if dish.description %}
-            <p class="mt-2 text-slate-600 text-sm md:text-base text-center line-clamp-6">{{ dish.description }}</p>
+            <p class="text-slate-600 text-sm md:text-base text-center line-clamp-6">{{ dish.description }}</p>
           {% endif %}
         </div>
 
         <!-- Tags -->
-        <div class="mt-4 flex flex-wrap justify-center gap-2">
+        <div class="flex flex-wrap justify-center gap-2">
           {% if dish.enhancement_price_display %}
             <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-semibold bg-white text-[#49475B] border border-slate-200 shadow-sm">
               {{ dish.enhancement_price_display }}
@@ -90,7 +90,7 @@
         </div>
 
         <!-- Actions (again, on BACK) -->
-        <div class="mt-auto flex justify-end gap-3 pt-4 border-t border-slate-200">
+        <div class="mt-auto flex justify-end gap-2 pt-3 border-t border-slate-200" data-no-flip>
           {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button' %}
           <button
             type="button"
@@ -114,6 +114,14 @@
           >
             🗑️
           </button>
+        </div>
+      </div>
+
+      {# ---------------- LOADING FACE ---------------- #}
+      <div class="flip-loading-face">
+        <div class="loading-card">
+          <div class="loading-spinner" aria-hidden="true"></div>
+          <p class="loading-copy">Cooking up your enhancement…</p>
         </div>
       </div>
 

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -1,5 +1,14 @@
 {# Shared styles and scripts for dish cards #}
 <style>
+  .dish-card-wrapper {
+    margin: 0.75rem 0;
+    padding: 0 0.75rem;
+  }
+
+  .dish-card-wrapper .flip-scene {
+    height: 100%;
+  }
+
   .flip-scene {
     perspective: 1200px;
   }
@@ -7,12 +16,13 @@
   .flip-card {
     position: relative;
     width: 100%;
-    min-height: 340px;
+    min-height: 320px;
     transition: transform 0.6s;
     transform-style: preserve-3d;
   }
 
-  .flip-card.flipped {
+  .flip-card.show-back,
+  .flip-card.loading {
     transform: rotateY(180deg);
   }
 
@@ -36,40 +46,6 @@
     transform: rotateY(180deg);
   }
 
-  .flip-face.front.enhanced {
-    background-size: cover;
-    background-position: center;
-    color: white;
-  }
-
-  .flip-face.front.enhanced::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-  }
-
-  .flip-face.front .card-inner {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 100%;
-    z-index: 1;
-  }
-
-  .flip-face.front.enhanced .card-inner h3 {
-    color: #fff;
-  }
-
-  .flip-face.front.enhanced .card-inner p {
-    color: rgba(255, 255, 255, 0.85);
-  }
-
-  .flip-face.front.enhanced .card-inner .text-slate-600 {
-    color: rgba(255, 255, 255, 0.85);
-  }
-
   .clamp-3 {
     display: -webkit-box;
     -webkit-line-clamp: 3;
@@ -79,15 +55,6 @@
 
   .dish-card-wrapper .flip-face.front {
     box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
-  }
-
-  .flip-face.front.enhanced {
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
-  }
-
-  .flip-face.flip-back {
-    background: #1e293b;
-    color: #fff;
   }
 
   .card-footer {
@@ -115,8 +82,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2.25rem;
+    height: 2.25rem;
     border-radius: 9999px;
     background: transparent;
     border: none;
@@ -133,20 +100,6 @@
   .card-action-button:focus-visible {
     outline: 2px solid #6366f1;
     outline-offset: 2px;
-  }
-
-  .flip-face.front.enhanced .card-action-tab {
-    background: rgba(15, 23, 42, 0.85);
-    border-color: rgba(255, 255, 255, 0.25);
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.5);
-  }
-
-  .flip-face.front.enhanced .card-action-button {
-    color: rgba(248, 250, 252, 0.95);
-  }
-
-  .flip-face.front.enhanced .card-action-button:hover {
-    color: #fca5a5;
   }
 
   .dish-tag {
@@ -176,27 +129,6 @@
     letter-spacing: 0.01em;
   }
 
-  .flip-face.front.enhanced .dish-tag {
-    background: rgba(15, 23, 42, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    color: rgba(248, 250, 252, 0.95);
-  }
-
-  .flip-face.front.enhanced .dish-tag--category {
-    background: rgba(165, 180, 252, 0.35);
-    border-color: transparent;
-  }
-
-  .flip-face.front.enhanced .dish-tag--ingredient {
-    background: rgba(244, 114, 182, 0.35);
-    border-color: transparent;
-  }
-
-  .flip-face.front.enhanced .dish-tag--price {
-    background: rgba(248, 113, 113, 0.95);
-    border-color: transparent;
-  }
-
   .masonry-grid {
     column-gap: 1.25rem;
   }
@@ -217,48 +149,122 @@
       column-count: 3;
     }
   }
+
+  .flip-loading-face {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    text-align: center;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, #b993d6, #58b09c);
+    color: #ffffff;
+    transform: rotateY(180deg);
+    backface-visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .flip-card.loading .flip-loading-face {
+    opacity: 1;
+  }
+
+  .flip-card.loading .flip-face {
+    opacity: 0;
+  }
+
+  .loading-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .loading-spinner {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+    animation: dish-card-spin 1s linear infinite;
+  }
+
+  .loading-copy {
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  @keyframes dish-card-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 </style>
 
 <script>
   if (!window.__dishCardEnhancements) {
     window.__dishCardEnhancements = true;
 
-    const shouldFlip = (elt) =>
+    const shouldShowLoading = (elt) =>
       elt && (elt.classList.contains("dish-variation-btn") || elt.classList.contains("favorite-btn"));
 
     document.body.addEventListener("htmx:beforeRequest", function (evt) {
       const trigger = evt.detail.elt;
-      if (shouldFlip(trigger)) {
+      if (shouldShowLoading(trigger)) {
         const card = trigger.closest(".flip-card");
         if (card) {
-          card.classList.add("flipped");
+          card.classList.remove("show-back");
+          card.classList.add("loading");
         }
       }
     });
 
     document.body.addEventListener("htmx:responseError", function (evt) {
       const trigger = evt.detail.elt;
-      if (shouldFlip(trigger)) {
+      if (shouldShowLoading(trigger)) {
         const card = trigger.closest(".flip-card");
         if (card) {
-          card.classList.remove("flipped");
+          card.classList.remove("loading");
         }
       }
     });
 
     document.body.addEventListener("htmx:afterSwap", function (evt) {
       const trigger = evt.detail.elt;
-      if (shouldFlip(trigger)) {
+      if (shouldShowLoading(trigger)) {
         const target = evt.detail.target;
         if (target) {
           const card = target.classList.contains("flip-card")
             ? target
             : target.querySelector(".flip-card");
           if (card) {
-            card.classList.remove("flipped");
+            card.classList.remove("loading");
+            card.classList.remove("show-back");
           }
         }
       }
+    });
+
+    document.body.addEventListener("click", function (evt) {
+      const card = evt.target.closest(".flip-card");
+      if (!card) {
+        return;
+      }
+
+      if (card.classList.contains("loading")) {
+        return;
+      }
+
+      const actionable = evt.target.closest("button, a, [data-no-flip]");
+      if (actionable) {
+        return;
+      }
+
+      card.classList.toggle("show-back");
     });
   }
 </script>

--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -4,31 +4,3 @@
 {% for dish in dishes %}
   {% include "dishes/_card.html" with dish=dish card_context="grid" %}
 {% endfor %}
-
-
-<script>
-  if (!window.__dishVariationHandlers) {
-    window.__dishVariationHandlers = true;
-
-    document.body.addEventListener("htmx:beforeRequest", function (evt) {
-      const trigger = evt.detail.elt;
-      if (trigger && trigger.classList.contains("dish-variation-btn")) {
-        const card = trigger.closest(".flip-card");
-        if (card) {
-          card.classList.add("flipped");
-        }
-      }
-    });
-
-    document.body.addEventListener("htmx:responseError", function (evt) {
-      const trigger = evt.detail.elt;
-      if (trigger && trigger.classList.contains("dish-variation-btn")) {
-        const card = trigger.closest(".flip-card");
-        if (card) {
-          card.classList.remove("flipped");
-        }
-      }
-    });
-  }
-</script>
-


### PR DESCRIPTION
## Summary
- tighten the dish card layout while adding a dedicated loading face and spinner
- adjust card actions and spacing so controls stay visible on both sides
- simplify the dish grid template by relying on the shared card assets

## Testing
- pytest *(fails: Django settings module not configured in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68d063a6fed08332aa6b674f19d7ade4