### PR TITLE
Fix concept card flip positioning

### DIFF
--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -10,14 +10,15 @@ width: 100%;
 min-height: 220px;
 transition: transform 0.6s;
 transform-style: preserve-3d;
+transform-origin: center;
+will-change: transform;
 }
 .flip-card.flipped {
 transform: rotateY(180deg);
 }
 .flip-face {
-position: relative;
-top: 0;
-left: 0;
+position: absolute;
+inset: 0;
 width: 100%;
 height: 100%;
 backface-visibility: hidden;


### PR DESCRIPTION
## Summary
- ensure concept flip cards maintain their grid position by keeping both faces absolutely positioned
- add transform origin hints to stabilise the flip animation

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d065e4afe083328faa333ea8998619