### PR TITLE
Ensure favorite concepts expose favorited flag in dashboard

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1112,11 +1112,14 @@ def favorites_view(request):
         .select_related("account")
         .first()
     )
-    favorite_concepts = (
+    favorite_concepts = list(
         models.FavoriteConcept.objects.filter(user=request.user)
         .select_related("concept", "concept__restaurant")
         .order_by("-favorited_at")
     )
+    for favorite in favorite_concepts:
+        if favorite.concept:
+            favorite.concept.is_favorited_for_user = True
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(user=request.user)
         .select_related("dish__parent_concept", "dish__restaurant")

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -275,6 +275,11 @@ class ViewSmokeTests(TestCase):
 
         resp = self.client.get(reverse("favorites"))
         self.assertEqual(resp.status_code, 200)
+        favorite_concepts = resp.context["favorite_concepts"]
+        self.assertTrue(favorite_concepts)
+        self.assertTrue(
+            getattr(favorite_concepts[0].concept, "is_favorited_for_user", False)
+        )
         menus = resp.context["menus"]
         self.assertEqual(len(menus), 1)
         self.assertEqual(menus[0].name, "Dinner")


### PR DESCRIPTION
## Summary
- ensure favorite concepts loaded for the dashboard expose `is_favorited_for_user`
- add a regression test to confirm the context includes the favorited marker

## Testing
- PYTHONPATH=/workspace/Appertivo3 DJANGO_SETTINGS_MODULE=specials.settings python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_favorites_views

------
https://chatgpt.com/codex/tasks/task_e_68d1473cfb588332ad00b63337af9249