### PR TITLE
Show enhanced dish styling on favorites

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1150,6 +1150,7 @@ def favorites_view(request):
                 menu_dishes.append(item.dish)
 
     all_dishes = [fav.dish for fav in favorite_dishes] + menu_dishes
+    decorate_dishes_with_enhancements(all_dishes)
     for dish in all_dishes:
         dish.is_favorited = True
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -266,6 +266,21 @@ class ViewSmokeTests(TestCase):
         models.FavoriteDish.objects.create(
             user=self.user, dish=dish, favorited_at=timezone.now()
         )
+        asset = models.Asset.objects.create(
+            kind=models.Asset.Kind.IMAGE,
+            storage_key="enhanced/fav",
+            public_url="https://example.com/enhanced.jpg",
+        )
+        models.Enhancement.objects.create(
+            dish=dish,
+            status=models.Enhancement.Status.SUCCEEDED,
+            image_asset=asset,
+            suggested_price_cents=2500,
+            currency="USD",
+            model_name="enhanced",
+            started_at=timezone.now(),
+            finished_at=timezone.now(),
+        )
         menu = models.MenuCollection.objects.create(
             restaurant=self.restaurant,
             created_by_user=self.user,
@@ -286,6 +301,12 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(len(menus[0].menu_items), 1)
         self.assertEqual(str(menus[0].menu_items[0].dish.id), str(dish.id))
         self.assertEqual(resp.context["uncategorized_favorites"], [])
+        favorite_dishes = resp.context["favorite_dishes"]
+        self.assertTrue(favorite_dishes)
+        enhanced = favorite_dishes[0].dish
+        self.assertTrue(getattr(enhanced, "is_enhanced", False))
+        self.assertEqual(enhanced.enhancement_image_url, asset.public_url)
+        self.assertEqual(enhanced.enhancement_price_display, "$25.00")
 
         rem_resp = self.client.post(
             reverse("favorite-remove", args=["concept", concept.id]),


### PR DESCRIPTION
## Summary
- decorate favorited dishes on the dashboard with their latest enhancement assets so hearts and imagery stay in sync
- extend the favorites view smoke test to cover enhanced metadata on favorited dishes

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_favorites_views

------
https://chatgpt.com/codex/tasks/task_e_68d14ca501d883328ca92f58d83f576a