### PR TITLE
Revamp favorites and menus management

### DIFF
--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -11,9 +11,6 @@
 <div
   id="favorites-root"
   class="px-4 py-8 space-y-8"
-  data-menus="{{ menus_payload_json|escapejs }}"
-  data-move-url="{% url 'menu-item-move' %}"
-  data-create-url="{% url 'menu-collection-create' %}"
 >
   <section class="relative overflow-hidden rounded-3xl border border-[#B993D6]/30 bg-gradient-to-r from-[#B993D6] via-[#FF8300]/80 to-[#58B09C] text-white shadow-lg">
     <div class="absolute inset-0 bg-black/10 mix-blend-soft-light"></div>
@@ -76,95 +73,6 @@
   <details open class="favorites-section group rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
     <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-5">
       <div>
-        <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Menus</h2>
-        <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Drag dishes into collections to plan lineups</p>
-      </div>
-      <span class="ml-auto inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-[#B993D6] transition-transform duration-200 group-open:rotate-180">
-        <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
-      </span>
-    </summary>
-    <div class="space-y-6 px-6 pb-6">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <p class="text-sm text-slate-500">Create boards for brunch, dinner, or specials. Collapse finished menus to stay focused.</p>
-        <button
-          type="button"
-          class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-[1.02]"
-          data-action="create-menu"
-        >
-          <i class="fa-solid fa-plus" aria-hidden="true"></i>
-          <span>New menu</span>
-        </button>
-      </div>
-
-      <div id="favorite-menus" class="space-y-4">
-        {% if menus %}
-          {% for menu in menus %}
-            <details
-              class="group/menu menu-card rounded-3xl border border-slate-200 bg-white shadow-sm"
-              data-menu-card
-              data-menu-id="{{ menu.id }}"
-              data-rename-url="{% url 'menu-collection-rename' menu.id %}"
-              data-delete-url="{% url 'menu-collection-delete' menu.id %}"
-              open
-            >
-              <summary class="flex cursor-pointer list-none items-center justify-between gap-4 rounded-3xl px-6 py-5">
-                <div>
-                  <h3 class="text-lg font-semibold text-[#49475B]">{{ menu.name }}</h3>
-                  <p class="text-xs uppercase tracking-wide text-slate-400">{{ menu.menu_items|length }} dish{{ menu.menu_items|length|pluralize }}</p>
-                </div>
-                <div class="flex items-center gap-3">
-                  <button type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100" data-action="rename-menu" title="Rename menu">
-                    <i class="fa-regular fa-pen-to-square" aria-hidden="true"></i>
-                    <span class="sr-only">Rename menu</span>
-                  </button>
-                  <button type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-red-100 text-red-500 transition hover:bg-red-50" data-action="delete-menu" title="Delete menu">
-                    <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
-                    <span class="sr-only">Delete menu</span>
-                  </button>
-                </div>
-              </summary>
-              <div class="px-6 pb-6">
-                <div
-                  class="menu-dropzone rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4"
-                  data-menu-dropzone
-                  data-menu-id="{{ menu.id }}"
-                >
-                  {% if menu.menu_items %}
-                    <div class="grid grid-cols-1 gap-4" data-menu-dishes>
-                      {% for item in menu.menu_items %}
-                        <div
-                          id="favorite-dish-{{ item.dish.id }}"
-                          class="favorite-dish-card"
-                          draggable="true"
-                          data-dish-card
-                          data-dish-id="{{ item.dish.id }}"
-                          data-current-menu="{{ menu.id }}"
-                        >
-                          {% include "dishes/_card.html" with dish=item.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id=menu.id %}
-                        </div>
-                      {% endfor %}
-                    </div>
-                  {% else %}
-                    <div class="flex h-32 items-center justify-center rounded-xl bg-white/80 text-sm text-slate-400" data-menu-empty>
-                      Drag a dish here or tap the … button on a card to add it to {{ menu.name }}.
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-            </details>
-          {% endfor %}
-        {% else %}
-          <div class="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-500">
-            Create your first menu to start grouping dishes together. You can always rename or delete it later.
-          </div>
-        {% endif %}
-      </div>
-    </div>
-  </details>
-
-  <details open class="favorites-section group rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
-    <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-5">
-      <div>
         <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Unassigned favorites</h2>
         <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Keep dishes here until they belong somewhere</p>
       </div>
@@ -173,51 +81,28 @@
       </span>
     </summary>
     <div class="space-y-4 px-6 pb-6">
-      <p class="text-sm text-slate-500">Drag dishes into a menu or keep them on deck for future inspiration.</p>
+      <p class="text-sm text-slate-500">Use the … menu on any dish to assign it to a menu. Once assigned, it disappears from this list.</p>
 
       <div
-        class="menu-dropzone rounded-3xl border border-dashed border-slate-200 bg-white p-4"
-        data-menu-dropzone
-        data-menu-id=""
+        class="rounded-3xl border border-dashed border-slate-200 bg-white p-4"
         id="favorites-uncategorized"
       >
-        {% if uncategorized_favorites %}
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2" data-menu-dishes>
-            {% for favorite in uncategorized_favorites %}
-              <div
-                id="favorite-dish-{{ favorite.dish.id }}"
-                class="favorite-dish-card"
-                draggable="true"
-                data-dish-card
-                data-dish-id="{{ favorite.dish.id }}"
-                data-current-menu=""
-              >
-                {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' %}
-              </div>
-            {% endfor %}
-          </div>
-        {% else %}
-          <div class="flex h-32 items-center justify-center rounded-xl bg-slate-50 text-sm text-slate-400" data-menu-empty>
-            Assigning dishes to menus removes them from this list. Drag one back here to keep it uncategorized.
-          </div>
-        {% endif %}
+        <div data-uncategorized-list class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {% for favorite in uncategorized_favorites %}
+            <div id="favorite-dish-{{ favorite.dish.id }}" class="favorite-dish-card">
+              {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' %}
+            </div>
+          {% endfor %}
+        </div>
+        <div
+          id="uncategorized-empty"
+          class="flex h-32 items-center justify-center rounded-xl bg-slate-50 text-sm text-slate-400 {% if uncategorized_favorites %}hidden{% endif %}"
+        >
+          Assigning dishes to menus removes them from this list. Remove a dish from a menu to bring it back here.
+        </div>
       </div>
     </div>
   </details>
-</div>
-
-<div id="favorites-menu-sheet" class="favorites-menu-sheet hidden">
-  <div class="favorites-menu-sheet__backdrop" data-sheet-close></div>
-  <div class="favorites-menu-sheet__panel">
-    <div class="flex items-center justify-between gap-4">
-      <h3 class="text-lg font-semibold text-[#49475B]">Assign to menu</h3>
-      <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-500" data-sheet-close>
-        <i class="fa-solid fa-xmark"></i>
-        <span class="sr-only">Close</span>
-      </button>
-    </div>
-    <div class="mt-4 space-y-2" data-sheet-list></div>
-  </div>
 </div>
 
 <script>
@@ -225,289 +110,30 @@
     const root = document.getElementById('favorites-root');
     if (!root) return;
 
-    function getCsrfToken(){
-      const input = document.querySelector('[name="csrfmiddlewaretoken"]');
-      if (input) return input.value;
-      const match = document.cookie.match(/csrftoken=([^;]+)/);
-      return match ? decodeURIComponent(match[1]) : '';
-    }
+    const list = root.querySelector('[data-uncategorized-list]');
+    const emptyState = document.getElementById('uncategorized-empty');
 
-    const csrf = getCsrfToken();
-    const menuData = (() => {
-      try {
-        return JSON.parse(root.dataset.menus || '[]');
-      } catch (err) {
-        console.warn('Unable to parse menus payload', err);
-        return [];
-      }
-    })();
+    const updateEmptyState = () => {
+      if (!list || !emptyState) return;
+      const hasItems = list.querySelector('[data-dish-card], .favorite-dish-card');
+      emptyState.classList.toggle('hidden', Boolean(hasItems));
+    };
 
-    const moveUrl = root.dataset.moveUrl;
-    const createUrl = root.dataset.createUrl;
-    const sheet = document.getElementById('favorites-menu-sheet');
-    const sheetList = sheet?.querySelector('[data-sheet-list]');
-
-    function getCard(el){
-      return el.closest('[data-dish-card]');
-    }
-
-    function updateEmptyStates(zone){
-      if (!zone) return;
-      const hasCard = zone.querySelector('[data-dish-card]');
-      zone.querySelectorAll('[data-menu-empty]').forEach((empty) => {
-        empty.style.display = hasCard ? 'none' : '';
-      });
-    }
-
-    function ensureList(zone){
-      let list = zone.querySelector('[data-menu-dishes]');
-      if (list) return list;
-      list = document.createElement('div');
-      list.dataset.menuDishes = '1';
-      list.className = zone.dataset.menuId ? 'grid grid-cols-1 gap-4' : 'grid grid-cols-1 md:grid-cols-2 gap-4';
-      const empty = zone.querySelector('[data-menu-empty]');
-      if (empty) {
-        empty.before(list);
-      } else {
-        zone.appendChild(list);
-      }
-      return list;
-    }
-
-    function moveCard(card, zone){
-      if (!(card && zone)) return;
-      const list = ensureList(zone);
-      list.appendChild(card);
-      updateEmptyStates(zone);
-    }
-
-    function sendMove(payload){
-      return fetch(moveUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrf,
-        },
-        body: JSON.stringify(payload),
-      }).then((res) => {
-        if (!res.ok) throw new Error('Request failed');
-        return res.json();
-      });
-    }
-
-    function zoneFor(menuId){
-      if (!menuId) return document.getElementById('favorites-uncategorized');
-      return root.querySelector(`[data-menu-dropzone][data-menu-id="${CSS.escape(menuId)}"]`);
-    }
-
-    function handleDrop(event){
-      event.preventDefault();
-      const zone = event.currentTarget;
-      const dishId = event.dataTransfer.getData('text/plain');
-      if (!dishId) return;
-      const card = document.getElementById(`favorite-dish-${dishId}`);
-      if (!card) return;
-      const sourceMenuId = card.dataset.currentMenu || '';
-      const targetMenuId = zone.dataset.menuId || '';
-      if (sourceMenuId === targetMenuId) return;
-
-      sendMove({dish_id: dishId, target_menu_id: targetMenuId, source_menu_id: sourceMenuId}).then(() => {
-        const sourceZone = zoneFor(sourceMenuId);
-        card.dataset.currentMenu = targetMenuId;
-        moveCard(card, zone);
-        updateEmptyStates(sourceZone);
-      }).catch(() => {
-        zone.classList.remove('is-drop-target');
-      });
-    }
-
-    root.querySelectorAll('[data-dish-card]').forEach((card) => {
-      card.addEventListener('dragstart', (event) => {
-        event.dataTransfer.effectAllowed = 'move';
-        event.dataTransfer.setData('text/plain', card.dataset.dishId);
-        card.classList.add('is-dragging');
-      });
-      card.addEventListener('dragend', () => {
-        card.classList.remove('is-dragging');
-        root.querySelectorAll('[data-menu-dropzone]').forEach((zone) => zone.classList.remove('is-drop-target'));
-      });
-    });
-
-    root.querySelectorAll('[data-menu-dropzone]').forEach((zone) => {
-      zone.addEventListener('dragover', (event) => {
-        event.preventDefault();
-        zone.classList.add('is-drop-target');
-      });
-      zone.addEventListener('dragleave', () => zone.classList.remove('is-drop-target'));
-      zone.addEventListener('drop', handleDrop);
-    });
-
-    function openSheet(dishId, currentMenuId){
-      if (!(sheet && sheetList)) return;
-      sheet.dataset.dishId = dishId;
-      sheet.dataset.currentMenuId = currentMenuId || '';
-      sheetList.innerHTML = '';
-
-      if (!menuData.length){
-        const empty = document.createElement('p');
-        empty.className = 'text-sm text-slate-500';
-        empty.textContent = 'Create a menu first to assign dishes.';
-        sheetList.appendChild(empty);
-      } else {
-        menuData.forEach((menu) => {
-          const btn = document.createElement('button');
-          btn.type = 'button';
-          btn.className = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-left text-sm font-medium text-[#49475B] shadow-sm transition hover:bg-slate-50';
-          btn.textContent = menu.name;
-          btn.dataset.menuId = menu.id;
-          if (menu.id === currentMenuId){
-            btn.classList.add('bg-slate-100');
-          }
-          btn.addEventListener('click', () => assignFromSheet(menu.id));
-          sheetList.appendChild(btn);
-        });
-        const remove = document.createElement('button');
-        remove.type = 'button';
-        remove.className = 'w-full rounded-xl border border-dashed border-slate-300 px-4 py-3 text-left text-sm font-medium text-slate-500 transition hover:bg-slate-100';
-        remove.textContent = 'Remove from menus';
-        remove.addEventListener('click', () => assignFromSheet(''));
-        sheetList.appendChild(remove);
-      }
-
-      sheet.classList.remove('hidden');
-      requestAnimationFrame(() => sheet.classList.add('visible'));
-    }
-
-    function closeSheet(){
-      if (!sheet) return;
-      sheet.classList.remove('visible');
-      setTimeout(() => sheet.classList.add('hidden'), 150);
-    }
-
-    function assignFromSheet(targetMenuId){
-      if (!sheet) return;
-      const dishId = sheet.dataset.dishId;
-      const sourceMenuId = sheet.dataset.currentMenuId || '';
-      if (!dishId) return;
-      const zone = zoneFor(targetMenuId);
-      const card = document.getElementById(`favorite-dish-${dishId}`);
-      if (!(zone && card)) return;
-      if (sourceMenuId === targetMenuId) {
-        closeSheet();
-        return;
-      }
-
-      sendMove({dish_id: dishId, target_menu_id: targetMenuId, source_menu_id: sourceMenuId}).then(() => {
-        const sourceZone = zoneFor(sourceMenuId);
-        card.dataset.currentMenu = targetMenuId || '';
-        moveCard(card, zone);
-        updateEmptyStates(sourceZone);
-        updateEmptyStates(zone);
-        closeSheet();
-      });
-    }
-
-    sheet?.querySelectorAll('[data-sheet-close]').forEach((btn) => btn.addEventListener('click', closeSheet));
-    document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') closeSheet();
-    });
-
-    root.addEventListener('click', (event) => {
-      const trigger = event.target.closest('[data-menu-trigger]');
-      if (!trigger) return;
-      const card = getCard(trigger);
-      if (!card) return;
-      openSheet(card.dataset.dishId, card.dataset.currentMenu || '');
-    });
+    updateEmptyState();
 
     root.addEventListener('dish-menu-moved', (event) => {
       const detail = event.detail || {};
       const dishId = detail.dishId;
       if (!dishId) return;
-      const sourceMenuId = detail.sourceMenuId || '';
       const targetMenuId = detail.targetMenuId || '';
-      if (sourceMenuId === targetMenuId) return;
-
+      if (!targetMenuId) {
+        updateEmptyState();
+        return;
+      }
       const wrapper = document.getElementById(`favorite-dish-${dishId}`);
       if (!wrapper) return;
-      const targetZone = zoneFor(targetMenuId);
-      if (!targetZone) return;
-
-      wrapper.dataset.currentMenu = targetMenuId;
-      moveCard(wrapper, targetZone);
-      updateEmptyStates(zoneFor(sourceMenuId));
-      updateEmptyStates(targetZone);
-    });
-
-    const createBtn = root.querySelector('[data-action="create-menu"]');
-    createBtn?.addEventListener('click', () => {
-      const name = prompt('Name your menu', 'New Menu');
-      const formData = new FormData();
-      if (name) formData.append('name', name);
-      fetch(createUrl, {
-        method: 'POST',
-        headers: {
-          'X-CSRFToken': csrf,
-        },
-        body: formData,
-      })
-        .then((res) => {
-          if (!res.ok) throw new Error('Unable to create menu');
-          return res.json();
-        })
-        .then((data) => {
-          menuData.push({id: data.id, name: data.name});
-          window.location.reload();
-        });
-    });
-
-    root.querySelectorAll('[data-menu-card]').forEach((card) => {
-      const renameUrl = card.dataset.renameUrl;
-      const deleteUrl = card.dataset.deleteUrl;
-      const nameEl = card.querySelector('h3');
-
-      card.querySelector('[data-action="rename-menu"]').addEventListener('click', () => {
-        const currentName = nameEl?.textContent?.trim() || 'Menu';
-        const newName = prompt('Rename menu', currentName);
-        if (newName === null) return;
-        const formData = new FormData();
-        formData.append('name', newName);
-        fetch(renameUrl, {
-          method: 'POST',
-          headers: {
-            'X-CSRFToken': csrf,
-          },
-          body: formData,
-        })
-          .then((res) => {
-            if (!res.ok) throw new Error('Unable to rename menu');
-            return res.json();
-          })
-          .then((data) => {
-            if (nameEl) nameEl.textContent = data.name;
-            const entry = menuData.find((m) => m.id === data.id);
-            if (entry) entry.name = data.name;
-          });
-      });
-
-      card.querySelector('[data-action="delete-menu"]').addEventListener('click', () => {
-        if (!confirm('Delete this menu?')) return;
-        fetch(deleteUrl, {
-          method: 'POST',
-          headers: {
-            'X-CSRFToken': csrf,
-          },
-        })
-          .then((res) => {
-            if (!res.ok) throw new Error('Unable to delete menu');
-            return res.json();
-          })
-          .then(() => {
-            const idx = menuData.findIndex((m) => m.id === card.dataset.menuId);
-            if (idx >= 0) menuData.splice(idx, 1);
-            card.remove();
-          });
-      });
+      wrapper.remove();
+      updateEmptyState();
     });
   });
 </script>

--- a/app/templates/menus/main.html
+++ b/app/templates/menus/main.html
@@ -1,6 +1,332 @@
-<!DOCTYPE html>
-<html>
-<body>
-<h1>Menus</h1>
-</body>
-</html>
+{% extends "base_logged_in.html" %}
+{% block title %}Menus — Appertivo{% endblock %}
+
+{% block content %}
+{% include "dishes/_card_assets.html" %}
+<div id="menus-root" class="px-4 py-8 space-y-8">
+  <section class="relative overflow-hidden rounded-3xl border border-[#58B09C]/40 bg-gradient-to-r from-[#58B09C] via-[#B993D6]/90 to-[#FF8300] text-white shadow-lg">
+    <div class="absolute inset-0 bg-black/10 mix-blend-soft-light"></div>
+    <div class="relative space-y-4 px-6 py-8 md:px-10">
+      <div class="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-white/90">
+        <i class="fa-solid fa-utensils" aria-hidden="true"></i>
+        <span>Menu Studio</span>
+      </div>
+      <h1 class="text-3xl font-bold md:text-4xl">Plan and polish your menus</h1>
+      {% if restaurant %}
+        <p class="max-w-2xl text-sm md:text-base text-white/90">Curate lineups for <span class="font-semibold">{{ restaurant.name }}</span>. Add dishes, regroup them, and keep track of what's ready to serve.</p>
+      {% else %}
+        <p class="max-w-2xl text-sm md:text-base text-white/90">Create collections for brunch, dinner, or seasonal specials. Assign dishes with the … menu on each card.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
+    <div class="space-y-6 px-6 py-6 md:px-8">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Add a new menu</h2>
+          <p class="text-sm text-slate-500">Name your menu and start assigning dishes using the … controls on each card.</p>
+        </div>
+        <form
+          method="post"
+          action="{% url 'menu-collection-create' %}"
+          data-menu-create-form
+          class="flex w-full flex-col gap-3 rounded-2xl bg-slate-50 p-4 md:w-auto md:flex-row md:items-center md:rounded-full md:bg-white md:px-5 md:py-3 md:shadow-sm"
+        >
+          {% csrf_token %}
+          <input
+            type="text"
+            name="name"
+            placeholder="New menu name"
+            class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-[#49475B] shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40 md:w-64"
+          />
+          <button
+            type="submit"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow transition hover:scale-[1.02]"
+          >
+            <i class="fa-solid fa-plus" aria-hidden="true"></i>
+            <span>Create menu</span>
+          </button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <section class="space-y-6" data-menu-list>
+    {% for menu in menus %}
+      <article
+        class="rounded-3xl border border-slate-200/80 bg-white/95 shadow-sm backdrop-blur"
+        data-menu-section="{{ menu.id }}"
+      >
+        <div class="flex flex-col gap-4 border-b border-slate-100 px-6 py-5 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-lg font-semibold text-[#49475B]" data-menu-title>{{ menu.name }}</h2>
+            <p class="text-xs font-medium uppercase tracking-wide text-slate-400" data-menu-count>
+              {{ menu.menu_items|length }} dish{{ menu.menu_items|length|pluralize }}
+            </p>
+          </div>
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100"
+              data-action="rename-menu"
+              data-menu-id="{{ menu.id }}"
+              data-rename-url="{% url 'menu-collection-rename' menu.id %}"
+              title="Rename menu"
+            >
+              <i class="fa-regular fa-pen-to-square" aria-hidden="true"></i>
+              <span class="sr-only">Rename menu</span>
+            </button>
+            <button
+              type="button"
+              class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-red-100 text-red-500 transition hover:bg-red-50"
+              data-action="delete-menu"
+              data-menu-id="{{ menu.id }}"
+              data-delete-url="{% url 'menu-collection-delete' menu.id %}"
+              title="Delete menu"
+            >
+              <i class="fa-regular fa-trash-can" aria-hidden="true"></i>
+              <span class="sr-only">Delete menu</span>
+            </button>
+          </div>
+        </div>
+        <div class="space-y-4 px-6 py-6" data-menu-body>
+          <div data-menu-dishes class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {% for item in menu.menu_items %}
+              <div
+                id="favorite-dish-{{ item.dish.id }}"
+                class="favorite-dish-card"
+                data-menu-dish
+                data-dish-id="{{ item.dish.id }}"
+                data-menu-id="{{ menu.id }}"
+              >
+                {% include "dishes/_card.html" with dish=item.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id=menu.id %}
+              </div>
+            {% endfor %}
+          </div>
+          <div
+            class="flex min-h-[120px] items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50 text-sm text-slate-500 {% if menu.menu_items %}hidden{% endif %}"
+            data-menu-empty
+          >
+            No dishes here yet. Use the … menu on a dish to add it to {{ menu.name }}.
+          </div>
+        </div>
+      </article>
+    {% endfor %}
+  </section>
+
+  <div
+    data-menus-empty
+    class="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-500 {% if menus %}hidden{% endif %}"
+  >
+    Create a menu to start organizing your favorite dishes. They'll appear here once assigned.
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const root = document.getElementById('menus-root');
+    if (!root) return;
+
+    const createForm = root.querySelector('[data-menu-create-form]');
+    const emptyState = root.querySelector('[data-menus-empty]');
+
+    const getCsrfToken = () => {
+      const input = document.querySelector('[name="csrfmiddlewaretoken"]');
+      if (input) {
+        return input.value;
+      }
+      const match = document.cookie.match(/csrftoken=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    };
+
+    const updateMenuSummary = (section) => {
+      if (!section) return;
+      const list = section.querySelector('[data-menu-dishes]');
+      const countLabel = section.querySelector('[data-menu-count]');
+      const empty = section.querySelector('[data-menu-empty]');
+      const items = list ? list.querySelectorAll('[data-menu-dish]').length : 0;
+      if (countLabel) {
+        countLabel.textContent = `${items} dish${items === 1 ? '' : 'es'}`;
+      }
+      if (empty) {
+        empty.classList.toggle('hidden', items > 0);
+      }
+    };
+
+    const ensureList = (section) => {
+      let list = section.querySelector('[data-menu-dishes]');
+      if (list) return list;
+      list = document.createElement('div');
+      list.dataset.menuDishes = '1';
+      list.className = 'grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3';
+      const empty = section.querySelector('[data-menu-empty]');
+      if (empty) {
+        empty.before(list);
+      } else {
+        section.appendChild(list);
+      }
+      return list;
+    };
+
+    const updateEmptyState = () => {
+      if (!emptyState) return;
+      const hasMenus = Boolean(root.querySelector('[data-menu-section]'));
+      emptyState.classList.toggle('hidden', hasMenus);
+    };
+
+    createForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const form = event.currentTarget;
+      const formData = new FormData(form);
+      fetch(form.action, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': getCsrfToken(),
+        },
+        body: formData,
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error('Unable to create menu');
+          return res.json();
+        })
+        .then(() => {
+          window.location.reload();
+        })
+        .catch(() => {
+          alert('Unable to create menu right now. Please try again.');
+        });
+    });
+
+    const updateMenuOptions = (menuId, newName) => {
+      document
+        .querySelectorAll(`[data-menu-option][data-menu-id="${CSS.escape(menuId)}"]`)
+        .forEach((option) => {
+          const label = `Add to ${newName}`;
+          option.dataset.label = label;
+          option.textContent = label;
+        });
+    };
+
+    const removeMenuOptions = (menuId) => {
+      document
+        .querySelectorAll(`[data-menu-option][data-menu-id="${CSS.escape(menuId)}"]`)
+        .forEach((option) => option.remove());
+    };
+
+    root.addEventListener('click', (event) => {
+      const renameBtn = event.target.closest('[data-action="rename-menu"]');
+      if (renameBtn) {
+        const section = renameBtn.closest('[data-menu-section]');
+        const url = renameBtn.dataset.renameUrl;
+        const currentName =
+          section?.querySelector('[data-menu-title]')?.textContent?.trim() || 'Menu';
+        const newName = prompt('Rename menu', currentName);
+        if (newName === null) return;
+        const formData = new FormData();
+        formData.append('name', newName);
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': getCsrfToken(),
+          },
+          body: formData,
+        })
+          .then((res) => {
+            if (!res.ok) throw new Error('Unable to rename menu');
+            return res.json();
+          })
+          .then((data) => {
+            if (section) {
+              const title = section.querySelector('[data-menu-title]');
+              if (title) title.textContent = data.name;
+              updateMenuOptions(data.id, data.name);
+            }
+          })
+          .catch(() => {
+            alert('Unable to rename this menu. Please try again.');
+          });
+        return;
+      }
+
+      const deleteBtn = event.target.closest('[data-action="delete-menu"]');
+      if (deleteBtn) {
+        if (!confirm('Delete this menu?')) return;
+        const section = deleteBtn.closest('[data-menu-section]');
+        const url = deleteBtn.dataset.deleteUrl;
+        const menuId = deleteBtn.dataset.menuId;
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': getCsrfToken(),
+          },
+        })
+          .then((res) => {
+            if (!res.ok) throw new Error('Unable to delete menu');
+            return res.json();
+          })
+          .then(() => {
+            section?.remove();
+            removeMenuOptions(menuId || '');
+            updateEmptyState();
+          })
+          .catch(() => {
+            alert('Unable to delete this menu. Please try again.');
+          });
+      }
+    });
+
+    root.addEventListener('dish-menu-moved', (event) => {
+      const detail = event.detail || {};
+      const dishId = detail.dishId;
+      if (!dishId) return;
+      const sourceMenuId = detail.sourceMenuId || '';
+      const targetMenuId = detail.targetMenuId || '';
+      const card = root.querySelector(
+        `[data-menu-dish][data-dish-id="${CSS.escape(dishId)}"]`
+      );
+      if (!card) return;
+
+      if (sourceMenuId && sourceMenuId !== targetMenuId) {
+        const sourceSection = root.querySelector(
+          `[data-menu-section="${CSS.escape(sourceMenuId)}"]`
+        );
+        if (sourceSection) {
+          const list = sourceSection.querySelector('[data-menu-dishes]');
+          if (list && list.contains(card)) {
+            if (targetMenuId) {
+              const targetSection = root.querySelector(
+                `[data-menu-section="${CSS.escape(targetMenuId)}"]`
+              );
+              const targetList = targetSection ? ensureList(targetSection) : null;
+              if (targetList) {
+                targetList.appendChild(card);
+                card.dataset.menuId = targetMenuId;
+                const cardInner = card.querySelector('[data-dish-card]');
+                if (cardInner) {
+                  cardInner.dataset.currentMenu = targetMenuId;
+                }
+                updateMenuSummary(targetSection);
+              } else {
+                card.remove();
+              }
+            } else {
+              card.remove();
+            }
+          }
+          updateMenuSummary(sourceSection);
+        }
+      }
+
+      if (!targetMenuId) {
+        card.remove();
+      }
+
+      updateEmptyState();
+    });
+
+    root.querySelectorAll('[data-menu-section]').forEach(updateMenuSummary);
+    updateEmptyState();
+  });
+</script>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -264,7 +264,54 @@ def dashboard_redirect(request):
 @login_required
 def menus_view(request):
     """Render menus page."""
-    return render(request, "menus/main.html")
+    restaurant = (
+        models.Restaurant.objects.filter(account__membership__user=request.user)
+        .select_related("account")
+        .first()
+    )
+
+    menus: List[models.MenuCollection] = []
+    if restaurant:
+        menus = list(
+            models.MenuCollection.objects.filter(restaurant=restaurant)
+            .prefetch_related(
+                Prefetch(
+                    "menuitem_set",
+                    queryset=models.MenuItem.objects.select_related(
+                        "dish",
+                        "dish__parent_concept",
+                        "dish__restaurant",
+                    ).order_by("position", "created_at"),
+                )
+            )
+            .order_by("created_at")
+        )
+        for menu in menus:
+            items = list(menu.menuitem_set.all())
+            menu.menu_items = items
+
+    all_dishes = [
+        item.dish for menu in menus for item in getattr(menu, "menu_items", [])
+    ]
+    decorate_dishes_with_enhancements(all_dishes)
+    for dish in all_dishes:
+        dish.is_favorited = True
+
+    menu_options = [
+        {
+            "id": str(menu.id),
+            "name": menu.name,
+        }
+        for menu in menus
+    ]
+
+    ctx = {
+        "restaurant": restaurant,
+        "menus": menus,
+        "menu_options": menu_options,
+        "menu_move_url": reverse("menu-item-move"),
+    }
+    return render(request, "menus/main.html", ctx)
 
 
 def onboarding_view(request):
@@ -1188,7 +1235,6 @@ def favorites_view(request):
         "favorite_dishes": favorite_dishes,
         "menus": menus,
         "uncategorized_favorites": uncategorized_favorites,
-        "menus_payload_json": json.dumps(menus_payload),
         "menu_options": menus_payload,
         "menu_move_url": reverse("menu-item-move"),
     }

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -342,6 +342,62 @@ class ViewSmokeTests(TestCase):
         concept.refresh_from_db()
         self.assertIsNone(concept.sketch_image_url)
 
+    def test_menus_page_lists_menus(self):
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=concept_run,
+            name="Seasonal",
+            rank_order=1,
+        )
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        dish = models.DishIdea.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=dish_run,
+            parent_concept=concept,
+            title="Seasonal Dish",
+            description="Desc",
+            ingredient_names=[],
+            category_tags=[],
+        )
+        menu = models.MenuCollection.objects.create(
+            restaurant=self.restaurant,
+            created_by_user=self.user,
+            name="Tasting",
+        )
+        models.MenuItem.objects.create(menu=menu, dish=dish, position=1)
+
+        resp = self.client.get(reverse("menus"))
+        self.assertEqual(resp.status_code, 200)
+        menus = resp.context["menus"]
+        self.assertEqual(len(menus), 1)
+        self.assertEqual(menus[0].name, menu.name)
+        self.assertEqual(len(menus[0].menu_items), 1)
+        self.assertEqual(
+            resp.context["menu_options"],
+            [{"id": str(menu.id), "name": menu.name}],
+        )
+        self.assertEqual(resp.context["menu_move_url"], reverse("menu-item-move"))
+
     def test_menu_collection_and_item(self):
         create_resp = self.client.post(
             reverse("menu-collection-create"), {"name": "Menu"}


### PR DESCRIPTION
## Summary
- streamline the favorites page by removing the in-page menus section and simplifying the unassigned dishes list
- build a full menus dashboard with creation controls, responsive layout, and client-side helpers for rename/delete/move interactions
- load menu data in the Django view and cover the menus page with a regression test

## Testing
- `pytest` *(fails: environment missing Django settings configuration)*
- `DJANGO_SETTINGS_MODULE=django_htmx.settings pytest` *(fails: settings module unavailable in environment)*
- `PYTHONPATH=/workspace/Appertivo3 DJANGO_SETTINGS_MODULE=specials.settings pytest` *(fails: app registry not ready during collection)*
- `python manage.py test tests.test_appertivo_views` *(fails: external service dependencies such as OpenAI client in concepts_generate_view)*

------
https://chatgpt.com/codex/tasks/task_e_68d15eed18308332b6e890220468ff4d