### PR TITLE
Redesign hero navigation and page intros

### DIFF
--- a/app/templates/base_logged_in.html
+++ b/app/templates/base_logged_in.html
@@ -47,54 +47,45 @@
   {% else %}
     {% url 'home' as dashboard_url %}
   {% endif %}
-  <header class="bg-white shadow-md">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
-        
-        <!-- Left: Logo -->
-        <div class="flex-shrink-0">
-          <a href="{{ dashboard_url }}" class="text-2xl font-bold text-[#B993D6]">
-            Appertivo
-          </a>
+  <header class="relative border-b border-slate-200 bg-white/80 backdrop-blur">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+      <div class="flex items-start gap-4">
+        <button
+          id="page-menu-toggle"
+          type="button"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-[#14080E]"
+          aria-expanded="false"
+          aria-controls="page-menu"
+        >
+          <span class="sr-only">Toggle navigation</span>
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 7h16M4 12h16M4 17h16" />
+          </svg>
+        </button>
+        <div class="flex-1">
+          {% block page_intro %}{% endblock %}
         </div>
-
-        <!-- Desktop Nav -->
-        <nav class="hidden md:flex space-x-6">
-          <a href="{% url 'concepts' %}" class="hover:text-[#B993D6]">Concepts</a>
-          <a href="{% url 'favorites' %}" class="hover:text-[#B993D6]">Favorites</a>
-          <a href="{% url 'settings' %}" class="hover:text-[#B993D6]">Settings</a>
-        </nav>
-
-        <!-- Right: User dropdown (optional) -->
-        <div class="hidden md:flex items-center space-x-4">
-          <span class="text-sm text-slate-600">{{restaurant}}</span>
-          <a href="{% url 'logout' %}"
-             class="bg-[#f08000] text-white px-3 py-1 rounded-lg hover:bg-[#d96f00]">
-            Logout
-          </a>
-        </div>
-
-        <!-- Mobile toggle -->
-        <div class="md:hidden">
-          <button id="mobile-menu-toggle" class="text-gray-600 focus:outline-none">
-            <!-- Hamburger -->
-            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
-        </div>
+        {% if restaurant %}
+          <div class="hidden sm:flex flex-col items-end text-xs font-medium uppercase tracking-wide text-slate-400">
+            <span>{{ restaurant }}</span>
+          </div>
+        {% endif %}
       </div>
     </div>
 
-    <!-- Mobile Nav -->
-    <div id="mobile-menu" class="hidden md:hidden bg-white border-t border-gray-200">
-      <nav class="px-2 py-3 space-y-1">
-        <a href="{{ dashboard_url }}" class="block px-3 py-2 rounded hover:bg-gray-100">Dashboard</a>
-        <a href="{% url 'concepts' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Concepts</a>
-        <a href="{% url 'favorites' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Favorites</a>
-        <a href="{% url 'settings' %}" class="block px-3 py-2 rounded hover:bg-gray-100">Settings</a>
-        <a href="{% url 'logout' %}" class="block px-3 py-2 rounded hover:bg-gray-100 text-[#f08000]">Logout</a>
+    <div
+      id="page-menu"
+      class="hidden absolute top-full inset-x-0 z-40 border-b border-slate-200 bg-white/95 backdrop-blur shadow-lg"
+    >
+      <nav class="max-w-7xl mx-auto flex flex-col gap-1 px-4 py-4 text-sm font-medium text-slate-600">
+        <a href="{{ dashboard_url }}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Dashboard</a>
+        <a href="{% url 'concepts' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Concepts</a>
+        <a href="{% url 'favorites' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Favorites</a>
+        <a href="{% url 'settings' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Settings</a>
+        <div class="my-2 border-t border-slate-200"></div>
+        <a href="{% url 'logout' %}" class="inline-flex items-center justify-center rounded-lg bg-[#f08000] px-3 py-2 text-white transition hover:bg-[#d96f00]">
+          Logout
+        </a>
       </nav>
     </div>
   </header>
@@ -116,7 +107,43 @@
 <div id="toast-container" class="fixed bottom-4 right-4 space-y-2 z-50"></div>
 
 
-  <!-- Script: toggle mobile menu -->
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const toggle = document.getElementById("page-menu-toggle");
+      const menu = document.getElementById("page-menu");
+      if (!toggle || !menu) {
+        return;
+      }
+
+      const closeMenu = () => {
+        if (menu.classList.contains("hidden")) {
+          return;
+        }
+        menu.classList.add("hidden");
+        toggle.setAttribute("aria-expanded", "false");
+      };
+
+      toggle.addEventListener("click", function (event) {
+        event.stopPropagation();
+        const isOpen = !menu.classList.contains("hidden");
+        if (isOpen) {
+          closeMenu();
+        } else {
+          menu.classList.remove("hidden");
+          toggle.setAttribute("aria-expanded", "true");
+        }
+      });
+
+      document.addEventListener("click", function (event) {
+        if (menu.contains(event.target) || toggle.contains(event.target)) {
+          return;
+        }
+        closeMenu();
+      });
+
+      window.addEventListener("resize", closeMenu);
+    });
+  </script>
 <!-- Script: handle rescrape form -->
 <script>
   document.addEventListener("DOMContentLoaded", function () {

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -1,4 +1,14 @@
 {% extends "base_logged_in.html" %}
+
+{% block page_intro %}
+  <div class="space-y-1">
+    <h1 class="text-xl font-semibold text-[#14080E]">Menu Concept Studio</h1>
+    <p class="text-sm text-slate-600 max-w-2xl">
+      Discover innovative dining experiences crafted for your restaurant. Flip each concept to view details or favorite it to unlock sketch inspiration.
+    </p>
+  </div>
+{% endblock %}
+
 {% block content %}
 {% include "concepts/_card_assets.html" %}
 <style>
@@ -6,18 +16,10 @@
     display: inline-block !important;
   }
 </style>
-<div class="max-w-7xl mx-auto px-4 py-1">
-  <div class="w-full bg-gradient-to-r from-[#B993D6] to-[#58B09C] py-8 px-6 shadow-md rounded mb-4">
-    <div class="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
-      <div class="text-center md:text-left max-w-2xl">
-        <h1 class="hidden sm:block text-3xl md:text-4xl font-extrabold text-white drop-shadow-sm">
-          Menu Concept Studio
-        </h1>
-        <p class="mt-3 text-base md:text-lg text-white/90 leading-relaxed">
-          Discover innovative dining experiences crafted for your restaurant.
-          Flip each concept to view details or favorite it to unlock sketch inspiration.
-        </p>
-      </div>
+<div class="max-w-7xl mx-auto px-4 py-4 space-y-6">
+  <div class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm backdrop-blur">
+    <div class="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between">
+      <p class="text-sm text-slate-600">Refresh the gallery whenever inspiration strikes. We will remix the latest menu insights for you.</p>
       <button
         id="generateBtn"
         hx-get="{% url 'concepts-generate' %}"
@@ -25,11 +27,11 @@
         hx-swap="innerHTML"
         data-overlay="true"
         data-messages='["Cooking up ideas…", "Almost there…", "Plating concepts!"]'
-        class="relative inline-flex items-center gap-2 bg-gradient-to-r from-[#f08000] to-[#FF5C00] text-white font-semibold px-6 py-3 rounded-xl shadow-lg hover:scale-105 transition"
+        class="relative inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-[#f08000] to-[#FF5C00] px-5 py-2.5 text-sm font-semibold text-white shadow transition hover:scale-105"
       >
         <svg
           id="concepts-loading"
-          class="hidden animate-spin h-5 w-5 text-white"
+          class="hidden h-4 w-4 animate-spin text-white"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -42,11 +44,11 @@
     </div>
   </div>
 
-  <div id="concepts-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <div id="concepts-grid" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
     {% include 'concepts/_concepts_grid.html' %}
   </div>
 
-  <div class="mt-8">
+  <div class="pt-2">
     <button
       id="concepts-favorites-btn"
       hx-get="{% url 'concepts-favorites' %}"

--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -1,5 +1,14 @@
 {% extends "base_logged_in.html" %}
 
+{% block page_intro %}
+  <div class="space-y-1">
+    <h1 class="text-xl font-semibold text-[#14080E]">Dish Sketch Lab</h1>
+    <p class="text-sm text-slate-600 max-w-2xl">
+      Build on <span class="font-semibold text-[#14080E]">{{ concept.name }}</span> with plated ideas tailored to your restaurant. Regenerate dishes to test new directions before they hit the menu.
+    </p>
+  </div>
+{% endblock %}
+
 {% block content %}
 <div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
 <div class="relative rounded-3xl overflow-hidden shadow-lg ring-1 ring-slate-200/60" 

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -1,6 +1,15 @@
 {% extends "base_logged_in.html" %}
 {% block title %}Favorites — Appertivo{% endblock %}
 
+{% block page_intro %}
+  <div class="space-y-1">
+    <h1 class="text-xl font-semibold text-[#14080E]">Favorites Studio</h1>
+    <p class="text-sm text-slate-600 max-w-2xl">
+      Revisit the concepts and dishes you saved. Mix and match favorites to shape your next menu drop.
+    </p>
+  </div>
+{% endblock %}
+
 {% block content %}
 {% include "concepts/_card_assets.html" %}
 {% include "dishes/_card_assets.html" %}
@@ -12,21 +21,13 @@
   id="favorites-root"
   class="px-4 py-8 space-y-8"
 >
-  <section class="relative overflow-hidden rounded-3xl border border-[#B993D6]/30 bg-gradient-to-r from-[#B993D6] via-[#FF8300]/80 to-[#58B09C] text-white shadow-lg">
-    <div class="absolute inset-0 bg-black/10 mix-blend-soft-light"></div>
-    <div class="relative space-y-3 px-6 py-8 md:px-8">
-      <div class="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-white/90">
-        <i class="fa-regular fa-star" aria-hidden="true"></i>
-        <span>Favorites Studio</span>
-      </div>
-      <h1 class="text-3xl font-bold md:text-4xl">Your curated ideas & dishes</h1>
-      {% if restaurant %}
-        <p class="max-w-2xl text-sm md:text-base text-white/90">Favorites tailored for <span class="font-semibold">{{ restaurant.name }}</span>. Mix and match concepts with dishes to craft the next menu drop.</p>
-      {% else %}
-        <p class="max-w-2xl text-sm md:text-base text-white/90">Revisit the ideas you saved. Flip concepts, drag dishes, and experiment until the menu feels right.</p>
-      {% endif %}
-    </div>
-  </section>
+  <div class="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur">
+    {% if restaurant %}
+      <p class="text-sm text-slate-600">Favorites tailored for <span class="font-semibold text-[#14080E]">{{ restaurant.name }}</span>. Organize them into menus whenever you are ready.</p>
+    {% else %}
+      <p class="text-sm text-slate-600">Save your favorite ideas to keep them within reach. Use the menu actions below to organize them.</p>
+    {% endif %}
+  </div>
 
   <details open class="favorites-section group rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
     <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-5">


### PR DESCRIPTION
## Summary
- replace the logged-in navigation with a compact hero-style header featuring a global hamburger menu and logout action
- surface per-page intro messaging for concepts, dishes, and favorites via a shared block in the base template
- refine the concepts and favorites layouts so supporting actions live below the new hero header

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d165b38a948332ac5c03815012b398