### PR TITLE
Ensure dish menu actions send cookies

### DIFF
--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -381,6 +381,7 @@
 
       fetch(moveUrl, {
         method: "POST",
+        credentials: "same-origin",
         headers: {
           "Content-Type": "application/json",
           "X-CSRFToken": getCsrfToken(),


### PR DESCRIPTION
## Summary
- ensure dish menu fetch requests include credentials so CSRF cookies accompany menu moves

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d167d7e1708332b947604e33eb66a4