### PR TITLE
Ensure dish menu actions use freshest CSRF cookie

### DIFF
--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -306,8 +306,14 @@
       if (input) {
         return input.value;
       }
-      const match = document.cookie.match(/csrftoken=([^;]+)/);
-      return match ? decodeURIComponent(match[1]) : "";
+      const cookies = document.cookie ? document.cookie.split(";") : [];
+      for (let i = cookies.length - 1; i >= 0; i -= 1) {
+        const cookie = cookies[i].trim();
+        if (cookie.startsWith("csrftoken=")) {
+          return decodeURIComponent(cookie.slice("csrftoken=".length));
+        }
+      }
+      return "";
     };
 
     const closeMenuPanel = (panel) => {
@@ -381,6 +387,7 @@
 
       fetch(moveUrl, {
         method: "POST",
+        credentials: "same-origin",
         headers: {
           "Content-Type": "application/json",
           "X-CSRFToken": getCsrfToken(),

--- a/app/templates/menus/main.html
+++ b/app/templates/menus/main.html
@@ -136,8 +136,14 @@
       if (input) {
         return input.value;
       }
-      const match = document.cookie.match(/csrftoken=([^;]+)/);
-      return match ? decodeURIComponent(match[1]) : '';
+      const cookies = document.cookie ? document.cookie.split(';') : [];
+      for (let i = cookies.length - 1; i >= 0; i -= 1) {
+        const cookie = cookies[i].trim();
+        if (cookie.startsWith('csrftoken=')) {
+          return decodeURIComponent(cookie.slice('csrftoken='.length));
+        }
+      }
+      return '';
     };
 
     const updateMenuSummary = (section) => {


### PR DESCRIPTION
## Summary
- update our CSRF token helper to read the most recent csrftoken cookie value when no hidden input is present
- reuse the improved helper everywhere dish and menu scripts perform fetches so menu add/remove requests authenticate reliably

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d167d7e1708332b947604e33eb66a4