### PR TITLE
Improve dish favorite UX and hide actions when enhanced

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -10,47 +10,48 @@
   data-current-menu="{{ current_menu }}"
   data-move-url="{{ move_url }}"
 >
-  {% if not dish.is_favorited %}
-    <article class="h-full rounded-2xl border border-slate-200 bg-white p-4 shadow-md flex flex-col gap-4">
-      <header class="space-y-3">
-        <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
-        {% if dish.description %}
-          <p class="text-slate-600 text-sm md:text-base line-clamp-4">{{ dish.description }}</p>
-        {% endif %}
-      </header>
+  <div class="flip-scene h-full">
+    <div class="flip-card h-full {% if not dish.is_favorited %}no-flip{% endif %}">
+      {% if not dish.is_favorited %}
+        <div class="flip-face front">
+          <article class="h-full rounded-2xl border border-slate-200 bg-white p-4 shadow-md flex flex-col gap-4">
+            <header class="space-y-3">
+              <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
+              {% if dish.description %}
+                <p class="text-slate-600 text-sm md:text-base line-clamp-4">{{ dish.description }}</p>
+              {% endif %}
+            </header>
 
-      <div class="flex flex-wrap gap-2">
-        {% for tag in dish.category_tags %}
-          <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
-            {{ tag }}
-          </span>
-        {% endfor %}
-        {% for tag in dish.ingredient_overlap %}
-          <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
-            {{ tag }}
-          </span>
-        {% endfor %}
-      </div>
+            <div class="flex flex-wrap gap-2">
+              {% for tag in dish.category_tags %}
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+              {% for tag in dish.ingredient_overlap %}
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+            </div>
 
-      <footer class="mt-auto flex justify-end gap-2">
-        {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
-        <button
-          type="button"
-          class="dish-variation-btn card-action-button bg-white/90 text-slate-600 hover:text-slate-800"
-          hx-post="{% url 'dish-variation' dish.id %}"
-          hx-trigger="click"
-          hx-target="closest .dish-card-wrapper"
-          hx-swap="outerHTML"
-          aria-label="Generate a variation of {{ dish.title }}"
-        >
-          <i class="fa-solid fa-arrows-rotate"></i>
-        </button>
-      </footer>
-    </article>
-  {% else %}
-    <div class="flip-scene h-full">
-      <div class="flip-card h-full">
-
+            <footer class="mt-auto flex justify-end gap-2">
+              {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
+              <button
+                type="button"
+                class="dish-variation-btn card-action-button bg-white/90 text-slate-600 hover:text-slate-800"
+                hx-post="{% url 'dish-variation' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Generate a variation of {{ dish.title }}"
+              >
+                <i class="fa-solid fa-arrows-rotate"></i>
+              </button>
+            </footer>
+          </article>
+        </div>
+      {% else %}
         {# ---------------- FRONT ---------------- #}
         <div class="flip-face front relative rounded-2xl overflow-hidden shadow-md border border-slate-200 bg-white">
           {% if dish.enhancement_image_url %}
@@ -88,18 +89,6 @@
           {% endif %}
 
           <div class="absolute bottom-2 right-2 flex items-center gap-2" data-no-flip>
-            {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90' %}
-            <button
-              type="button"
-              class="dish-variation-btn card-action-button bg-white/90 text-slate-600 hover:text-slate-800"
-              hx-post="{% url 'dish-variation' dish.id %}"
-              hx-trigger="click"
-              hx-target="closest .dish-card-wrapper"
-              hx-swap="outerHTML"
-              aria-label="Generate a variation of {{ dish.title }}"
-            >
-              <i class="fa-solid fa-arrows-rotate"></i>
-            </button>
             <div class="dish-menu-control" data-menu-control data-no-flip>
               <button
                 type="button"
@@ -194,18 +183,17 @@
             </button>
           </div>
         </div>
+      {% endif %}
 
-        {# ---------------- LOADING FACE ---------------- #}
-        <div class="flip-loading-face">
-          <div class="loading-card">
-            <div class="loading-spinner" aria-hidden="true"></div>
-            <p class="loading-copy">Cooking up your enhancement…</p>
-          </div>
+      {# ---------------- LOADING FACE ---------------- #}
+      <div class="flip-loading-face">
+        <div class="loading-card">
+          <div class="loading-spinner" aria-hidden="true"></div>
+          <p class="loading-copy">Cooking up your enhancement…</p>
         </div>
-
       </div>
     </div>
-  {% endif %}
+  </div>
 </div>
 
 {% endwith %}

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -517,6 +517,10 @@
         return;
       }
 
+      if (card.classList.contains("no-flip")) {
+        return;
+      }
+
       const actionable = evt.target.closest("button, a, [data-no-flip]");
       if (actionable) {
         return;


### PR DESCRIPTION
## Summary
- wrap dish cards in a flip-card shell even before enhancement so the favorite request can show the loading face
- remove the favorite heart and variation button from enhanced cards, leaving only the menu control actions
- prevent non-enhanced cards from flipping while still reusing the loading animation hook

## Testing
- pytest *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ed9baccc8332a8d77531353d8c17