### PR TITLE
Pin favorited concept and dish cards to top of grids

### DIFF
--- a/app/templates/concepts/_card.html
+++ b/app/templates/concepts/_card.html
@@ -3,6 +3,7 @@
   id="concept-card-{{ concept.id }}"
   class="concept-card-wrapper"
   data-concept-card
+  data-favorited="{% if concept.is_favorited_for_user %}true{% else %}false{% endif %}"
 >
   <div class="flip-scene h-full">
     <div

--- a/app/templates/concepts/_card_assets.html
+++ b/app/templates/concepts/_card_assets.html
@@ -106,6 +106,66 @@
   if (!window.__conceptCardEnhancements) {
     window.__conceptCardEnhancements = true;
 
+    const conceptGridId = "concepts-grid";
+    const conceptGridSelector = "#concepts-grid";
+    const conceptCardSelector = "[data-concept-card]";
+
+    const reorderConceptCards = () => {
+      const grid = document.querySelector(conceptGridSelector);
+      if (!grid) {
+        return;
+      }
+      const cards = Array.from(grid.querySelectorAll(conceptCardSelector));
+      if (cards.length < 2) {
+        return;
+      }
+      const favorites = [];
+      const others = [];
+      cards.forEach((card) => {
+        if (card.dataset && card.dataset.favorited === "true") {
+          favorites.push(card);
+        } else {
+          others.push(card);
+        }
+      });
+      const orderedCards = favorites.concat(others);
+      orderedCards.forEach((card) => {
+        grid.appendChild(card);
+      });
+    };
+
+    const scheduleConceptReorder = () => {
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(reorderConceptCards);
+      } else {
+        setTimeout(reorderConceptCards, 0);
+      }
+    };
+
+    const conceptTargetNeedsReorder = (target) => {
+      if (!target) {
+        return false;
+      }
+      if (target.id === conceptGridId) {
+        return true;
+      }
+      if (typeof target.matches === "function" && target.matches(conceptCardSelector)) {
+        return true;
+      }
+      if (typeof target.closest === "function") {
+        const grid = target.closest(conceptGridSelector);
+        if (grid) {
+          return true;
+        }
+      }
+      if (typeof target.querySelector === "function" && target.querySelector(conceptCardSelector)) {
+        return true;
+      }
+      return false;
+    };
+
+    document.addEventListener("DOMContentLoaded", reorderConceptCards);
+
     const findConceptCard = (elt) => {
       if (!elt) {
         return null;
@@ -148,22 +208,29 @@
 
     document.body.addEventListener('htmx:afterSwap', function (evt) {
       const trigger = evt.detail && evt.detail.elt;
-      if (!shouldShowConceptLoading(trigger)) {
-        return;
-      }
       const target = evt.detail && evt.detail.target;
-      if (!target) {
-        return;
+
+      if (shouldShowConceptLoading(trigger)) {
+        if (!target) {
+          const card = findConceptCard(trigger);
+          if (card) {
+            card.classList.remove('loading');
+          }
+        } else if (
+          (typeof target.matches === 'function' && target.matches(conceptCardSelector)) ||
+          (typeof target.querySelector === 'function' && target.querySelector(conceptCardSelector))
+        ) {
+          // Replaced with a fresh card, no need to toggle loading.
+        } else {
+          const card = findConceptCard(trigger);
+          if (card) {
+            card.classList.remove('loading');
+          }
+        }
       }
-      if (
-        target.matches('[data-concept-card]') ||
-        target.querySelector('[data-concept-card]')
-      ) {
-        return;
-      }
-      const card = findConceptCard(trigger);
-      if (card) {
-        card.classList.remove('loading');
+
+      if (conceptTargetNeedsReorder(target)) {
+        scheduleConceptReorder();
       }
     });
 

--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -9,6 +9,7 @@
   data-dish-id="{{ dish.id }}"
   data-current-menu="{{ current_menu }}"
   data-move-url="{{ move_url }}"
+  data-favorited="{% if dish.is_favorited %}true{% else %}false{% endif %}"
 >
   <div class="flip-scene h-full">
     <div class="flip-card h-full {% if not dish.is_favorited %}no-flip{% endif %}">

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -296,6 +296,66 @@
   if (!window.__dishCardEnhancements) {
     window.__dishCardEnhancements = true;
 
+    const dishGridId = "dishes-grid";
+    const dishGridSelector = "#dishes-grid";
+    const dishCardSelector = "[data-dish-card]";
+
+    const reorderDishCards = () => {
+      const grid = document.querySelector(dishGridSelector);
+      if (!grid) {
+        return;
+      }
+      const cards = Array.from(grid.querySelectorAll(dishCardSelector));
+      if (cards.length < 2) {
+        return;
+      }
+      const favorites = [];
+      const others = [];
+      cards.forEach((card) => {
+        if (card.dataset && card.dataset.favorited === "true") {
+          favorites.push(card);
+        } else {
+          others.push(card);
+        }
+      });
+      const orderedCards = favorites.concat(others);
+      orderedCards.forEach((card) => {
+        grid.appendChild(card);
+      });
+    };
+
+    const scheduleDishReorder = () => {
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(reorderDishCards);
+      } else {
+        setTimeout(reorderDishCards, 0);
+      }
+    };
+
+    const dishTargetNeedsReorder = (target) => {
+      if (!target) {
+        return false;
+      }
+      if (target.id === dishGridId) {
+        return true;
+      }
+      if (typeof target.matches === "function" && target.matches(dishCardSelector)) {
+        return true;
+      }
+      if (typeof target.closest === "function") {
+        const grid = target.closest(dishGridSelector);
+        if (grid) {
+          return true;
+        }
+      }
+      if (typeof target.querySelector === "function" && target.querySelector(dishCardSelector)) {
+        return true;
+      }
+      return false;
+    };
+
+    document.addEventListener("DOMContentLoaded", reorderDishCards);
+
     const shouldShowLoading = (elt) =>
       elt && (elt.classList.contains("dish-variation-btn") || elt.classList.contains("favorite-btn"));
 
@@ -493,17 +553,21 @@
 
     document.body.addEventListener("htmx:afterSwap", function (evt) {
       const trigger = evt.detail.elt;
+      const target = evt.detail.target;
       if (shouldShowLoading(trigger)) {
-        const target = evt.detail.target;
         if (target) {
-          const card = target.classList.contains("flip-card")
+          const card = target.classList && target.classList.contains("flip-card")
             ? target
-            : target.querySelector(".flip-card");
+            : (typeof target.querySelector === "function" ? target.querySelector(".flip-card") : null);
           if (card) {
             card.classList.remove("loading");
             card.classList.remove("show-back");
           }
         }
+      }
+
+      if (dishTargetNeedsReorder(target)) {
+        scheduleDishReorder();
       }
     });
 


### PR DESCRIPTION
## Summary
- expose favorite state on concept and dish card wrappers so the DOM can see which cards are favorites
- add lightweight helpers for concept and dish grids that move favorited cards to the front on load and after htmx swaps

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d2f707d8e48332b369be738ac720d2