### PR TITLE
Revamp dashboard context checklist and favorites

### DIFF
--- a/app/templates/_partials/restaurant_status.html
+++ b/app/templates/_partials/restaurant_status.html
@@ -1,8 +1,13 @@
 {% if menu_version %}
   {% if menu_version.status == 'succeeded' %}
-    <div class="rounded-xl bg-green-50 border border-green-200 p-4 flex items-center space-x-3">
-      <span class="inline-block h-3 w-3 rounded-full bg-green-400"></span>
-      <p class="text-green-700 font-medium">✅ Your menu is ready!</p>
+    <div class="flex items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+      <div class="flex items-center gap-3">
+        <span class="inline-block h-3 w-3 rounded-full bg-emerald-500"></span>
+        <p class="text-sm font-semibold text-emerald-700">Menu synced to assistant context</p>
+      </div>
+      {% if menu_version.finished_at %}
+        <span class="text-xs font-medium text-emerald-600">Updated {{ menu_version.finished_at|timesince }} ago</span>
+      {% endif %}
     </div>
   {% elif menu_version.status == 'failed' %}
     <div class="rounded-xl bg-red-50 border border-red-200 p-4 flex items-center space-x-3">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -3,24 +3,13 @@
 {% block title %}Dashboard — Appertivo{% endblock %}
 
 {% block page_intro %}
-  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-    <div class="space-y-1">
-      <p class="text-xs font-semibold uppercase text-slate-400">Dashboard</p>
-      <h1 class="text-xl font-semibold text-[#14080E]">Welcome back, {{ request.user.first_name|default:"Chef" }}</h1>
-      <p class="text-sm text-slate-600">Here’s a quick look at how Appertivo is supporting {{ restaurant.name }}.</p>
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="space-y-1">
+        <p class="text-xs font-semibold uppercase text-slate-400">Dashboard</p>
+        <h1 class="text-xl font-semibold text-[#14080E]">Welcome back, {{ request.user.first_name|default:"Chef" }}</h1>
+        <p class="text-sm text-slate-600">Here’s a quick look at how Appertivo is supporting {{ restaurant.name }}.</p>
+      </div>
     </div>
-    <div class="flex flex-wrap items-center gap-2">
-      <a href="{% url 'concepts-generate' %}" class="inline-flex items-center gap-2 rounded-full bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#e05400]">
-        <span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-white/20 text-white">
-          <i class="fa-solid fa-sparkles text-xs" aria-hidden="true"></i>
-        </span>
-        New Concepts
-      </a>
-      <a href="{% url 'concepts' %}" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-[#14080E] transition hover:bg-slate-100">
-        Browse concepts
-      </a>
-    </div>
-  </div>
 {% endblock %}
 
 {% block page_content %}
@@ -71,41 +60,27 @@
 
     <section class="rounded-2xl border border-slate-200 bg-white p-6">
       <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 class="text-lg font-semibold text-[#14080E]">Restaurant context checklist</h2>
-          <p class="text-sm text-slate-600">Complete the basics so the assistant understands your restaurant.</p>
-        </div>
+        <h2 class="text-lg font-semibold text-[#14080E]">Restaurant context checklist</h2>
         <a href="{{ settings_url }}" class="inline-flex items-center gap-2 text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">Update settings</a>
       </div>
       <ul class="mt-4 grid gap-3 sm:grid-cols-3">
         {% for item in context_items %}
-          <li class="rounded-xl border border-slate-200 p-4">
-            <div class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full {% if item.present %}bg-emerald-100 text-emerald-600{% else %}bg-slate-100 text-slate-500{% endif %}">
-                {% if item.present %}
-                  <i class="fa-solid fa-check text-xs" aria-hidden="true"></i>
-                {% else %}
-                  <i class="fa-solid fa-plus text-xs" aria-hidden="true"></i>
-                {% endif %}
-              </span>
-              <div class="space-y-1">
-                <p class="text-sm font-semibold text-[#14080E]">{{ item.label }}</p>
-                <p class="text-sm text-slate-600">{{ item.description }}</p>
-                {% if not item.present %}
-                  <a href="{{ settings_url }}" class="text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">Add now</a>
-                {% endif %}
-              </div>
-            </div>
-          </li>
+          {% include "dashboard/_context_item.html" with item=item toggle_url=context_toggle_url settings_url=settings_url %}
         {% endfor %}
       </ul>
     </section>
 
     <div class="grid gap-4 lg:grid-cols-2">
       <section class="rounded-2xl border border-slate-200 bg-white p-6">
-        <div class="flex items-center justify-between gap-2">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="text-lg font-semibold text-[#14080E]">Recent concepts</h2>
-          <a href="{% url 'concepts' %}" class="text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">View all</a>
+          <div class="flex items-center gap-2">
+            <a href="{% url 'concepts-generate' %}" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-[#14080E] transition hover:bg-slate-100">
+              <i class="fa-solid fa-sparkles text-[10px]" aria-hidden="true"></i>
+              New run
+            </a>
+            <a href="{% url 'concepts' %}" class="text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">View all</a>
+          </div>
         </div>
         {% if recent_concepts %}
           <ul class="mt-4 space-y-3">
@@ -114,7 +89,12 @@
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p class="text-sm font-semibold text-[#14080E]">{{ concept.name }}</p>
-                    <p class="text-xs text-slate-500">Generated {{ concept.created_at|timesince }} ago</p>
+                    <p class="text-xs text-slate-500">
+                      {% if concept.runtime_display %}
+                        Ran in {{ concept.runtime_display }} •
+                      {% endif %}
+                      {{ concept.generated_at|timesince }} ago
+                    </p>
                   </div>
                   <a href="{% if concept.has_dishes %}{% url 'dish_detail' concept.id %}{% else %}{% url 'dishes-generate' concept.id %}{% endif %}" class="inline-flex items-center gap-2 text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">
                     {% if concept.has_dishes %}
@@ -135,7 +115,13 @@
 
       <section class="rounded-2xl border border-slate-200 bg-white p-6">
         <div class="flex items-center justify-between gap-2">
-          <h2 class="text-lg font-semibold text-[#14080E]">Recent dishes</h2>
+          <div class="flex items-center gap-2">
+            <h2 class="text-lg font-semibold text-[#14080E]">Favorite dishes</h2>
+            <span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+              <i class="fa-solid fa-star text-[9px]" aria-hidden="true"></i>
+              Saved
+            </span>
+          </div>
           <a href="{% url 'favorites' %}" class="text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">See favorites</a>
         </div>
         {% if recent_dishes %}
@@ -152,9 +138,9 @@
                 <div class="flex-1 space-y-1">
                   <p class="text-sm font-semibold text-[#14080E]">{{ dish.title }}</p>
                   <p class="text-xs text-slate-500">Concept: {{ dish.parent_concept.name }}</p>
-                  <p class="text-xs text-slate-500">{{ dish.created_at|timesince }} ago</p>
+                  <p class="text-xs text-slate-500">Favorited {{ dish.favorited_at|timesince }} ago</p>
                 </div>
-                <a href="{% url 'dish_detail' dish.parent_concept.id %}" class="self-center text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">Open run</a>
+                <a href="{% url 'dish_detail' dish.parent_concept.id %}" class="self-center text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">&rsaquo;&rsaquo;</a>
               </li>
             {% endfor %}
           </ul>

--- a/app/templates/dashboard/_context_item.html
+++ b/app/templates/dashboard/_context_item.html
@@ -1,0 +1,45 @@
+<li class="rounded-xl border border-slate-200 p-4 {% if not item.present %}opacity-70{% endif %}">
+  <form
+    method="post"
+    hx-post="{{ toggle_url }}"
+    hx-target="closest li"
+    hx-swap="outerHTML"
+    hx-trigger="change from:input[type='checkbox']"
+    class="flex items-center justify-between gap-3"
+  >
+    {% csrf_token %}
+    <input type="hidden" name="key" value="{{ item.key }}" />
+    <input type="hidden" name="include" value="false" />
+    <label class="flex items-center gap-3 text-sm font-semibold text-[#14080E]">
+      <input
+        type="checkbox"
+        name="include"
+        value="true"
+        class="h-4 w-4 rounded border border-slate-300 text-[#FF5C00] focus:ring-[#FF5C00]"
+        {% if item.included %}checked{% endif %}
+        {% if not item.present %}disabled{% endif %}
+      />
+      <span>{{ item.label }}</span>
+    </label>
+    <div class="flex items-center gap-2">
+      {% if item.present %}
+        <span
+          class="rounded-full px-2 py-1 text-xs font-medium {% if item.included %}bg-emerald-100 text-emerald-700{% else %}bg-amber-100 text-amber-700{% endif %}"
+        >
+          {% if item.included %}
+            In context
+          {% else %}
+            Skipped
+          {% endif %}
+        </span>
+      {% else %}
+        <a
+          href="{{ settings_url }}"
+          class="text-xs font-semibold text-[#FF5C00] hover:text-[#e05400]"
+        >
+          Add now
+        </a>
+      {% endif %}
+    </div>
+  </form>
+</li>

--- a/app/views.py
+++ b/app/views.py
@@ -11,7 +11,12 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
 from django.db.models import Exists, Max, OuterRef, Prefetch
-from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    JsonResponse,
+)
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -230,8 +235,12 @@ def logout_view(request):
 @login_required
 def dashboard(request, restaurant_id):
     restaurant = get_object_or_404(
-        models.Restaurant.objects.select_related("account"),
+        models.Restaurant.objects.select_related("account", "restaurantsettings"),
         id=restaurant_id,
+    )
+
+    settings_obj, _ = models.RestaurantSettings.objects.get_or_create(
+        restaurant=restaurant
     )
 
     subscription = (
@@ -295,6 +304,7 @@ def dashboard(request, restaurant_id):
 
     concepts_qs = (
         models.Concept.objects.filter(restaurant=restaurant)
+        .select_related("ideation_run")
         .annotate(
             has_dishes=Exists(
                 models.DishIdea.objects.filter(
@@ -305,13 +315,25 @@ def dashboard(request, restaurant_id):
         .order_by("-created_at")
     )
     recent_concepts = list(concepts_qs[:4])
+    for concept in recent_concepts:
+        concept.runtime_display = format_run_duration(concept.ideation_run)
+        run_finished = (
+            concept.ideation_run.finished_at if concept.ideation_run else None
+        )
+        concept.generated_at = run_finished or concept.created_at
 
-    dishes_qs = (
-        models.DishIdea.objects.filter(restaurant=restaurant, is_deleted=False)
-        .select_related("parent_concept")
-        .order_by("-created_at")
+    favorite_dishes = list(
+        models.FavoriteDish.objects.filter(
+            user=request.user, dish__restaurant=restaurant
+        )
+        .select_related("dish__parent_concept")
+        .order_by("-favorited_at")[:4]
     )
-    recent_dishes = decorate_dishes_with_enhancements(dishes_qs[:4])
+    dishes_only = [fav.dish for fav in favorite_dishes]
+    recent_dishes = decorate_dishes_with_enhancements(dishes_only)
+    for fav, dish in zip(favorite_dishes, recent_dishes):
+        dish.is_favorited = True
+        dish.favorited_at = fav.favorited_at
 
     menus = list(
         models.MenuCollection.objects.filter(restaurant=restaurant)
@@ -334,25 +356,7 @@ def dashboard(request, restaurant_id):
         ]
         menu.menu_items = items
 
-    context_items = [
-        {
-            "label": "Menu on file",
-            "present": bool(
-                restaurant.primary_menu_url or restaurant.active_menu_version
-            ),
-            "description": "Menus keep concepts grounded in what you actually serve.",
-        },
-        {
-            "label": "Restaurant context",
-            "present": bool(restaurant.context_json),
-            "description": "Neighborhood, cuisine and vibe sharpen the AI suggestions.",
-        },
-        {
-            "label": "Story & description",
-            "present": bool(restaurant.description),
-            "description": "Share your story so dishes reflect your brand voice.",
-        },
-    ]
+    context_items = build_context_items(restaurant, settings_obj)
 
     context = {
         "restaurant": restaurant,
@@ -362,10 +366,58 @@ def dashboard(request, restaurant_id):
         "recent_dishes": recent_dishes,
         "menus": menus,
         "settings_url": reverse("settings"),
+        "context_toggle_url": reverse(
+            "dashboard-context-toggle", args=[restaurant.id]
+        ),
         "tbd_message": "Personalized tips will appear here soon.",
         "prompt_for_menu": not bool(restaurant.primary_menu_url),
     }
     return render(request, "dashboard.html", context)
+
+
+@login_required
+@require_POST
+def dashboard_context_toggle(request, restaurant_id):
+    restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
+    membership_exists = models.Membership.objects.filter(
+        account=restaurant.account, user=request.user
+    ).exists()
+    if not membership_exists:
+        return HttpResponseForbidden("not_allowed")
+
+    settings_obj, _ = models.RestaurantSettings.objects.get_or_create(
+        restaurant=restaurant
+    )
+
+    key = request.POST.get("key")
+    valid_keys = {item[0] for item in CONTEXT_ITEM_DEFINITIONS}
+    if key not in valid_keys:
+        return HttpResponseBadRequest("invalid_key")
+
+    include_values = request.POST.getlist("include")
+    include_raw = include_values[-1] if include_values else "false"
+    include = str(include_raw).lower() in {"1", "true", "yes", "on"}
+
+    context_flags = dict(settings_obj.llm_defaults.get("context_flags", {}))
+    context_flags[key] = include
+    settings_obj.llm_defaults["context_flags"] = context_flags
+    settings_obj.save(update_fields=["llm_defaults"])
+
+    context_items = build_context_items(restaurant, settings_obj)
+    item = next((item for item in context_items if item["key"] == key), None)
+    if not item:
+        return HttpResponseBadRequest("unknown_item")
+
+    html = render_to_string(
+        "dashboard/_context_item.html",
+        {
+            "item": item,
+            "settings_url": reverse("settings"),
+            "toggle_url": reverse("dashboard-context-toggle", args=[restaurant.id]),
+        },
+        request=request,
+    )
+    return HttpResponse(html)
 
 
 @login_required
@@ -816,6 +868,93 @@ def decorate_dishes_with_enhancements(dishes: Iterable[models.DishIdea],) -> Lis
             dish.enhancement_price_display = ""
 
     return dish_list
+
+
+CONTEXT_ITEM_DEFINITIONS = (
+    ("menu", "Menu synced"),
+    ("context", "Neighborhood & vibe"),
+    ("story", "Story & description"),
+)
+
+
+def build_context_items(
+    restaurant: models.Restaurant, settings_obj: models.RestaurantSettings
+) -> List[dict]:
+    """Return context checklist items with presence + preference state."""
+
+    context_flags = dict(settings_obj.llm_defaults.get("context_flags", {}))
+    items: List[dict] = []
+
+    presence_map = {
+        "menu": bool(restaurant.primary_menu_url or restaurant.active_menu_version),
+        "context": bool(restaurant.context_json),
+        "story": bool(restaurant.description),
+    }
+
+    updated = False
+    for key, _ in CONTEXT_ITEM_DEFINITIONS:
+        if key not in context_flags:
+            context_flags[key] = presence_map.get(key, False)
+            updated = True
+
+    if updated:
+        settings_obj.llm_defaults["context_flags"] = context_flags
+        settings_obj.save(update_fields=["llm_defaults"])
+
+    for key, label in CONTEXT_ITEM_DEFINITIONS:
+        present = presence_map.get(key, False)
+        include_preference = bool(context_flags.get(key))
+        included = include_preference and present
+        status = "missing"
+        if present and included:
+            status = "included"
+        elif present:
+            status = "excluded"
+        items.append(
+            {
+                "key": key,
+                "label": label,
+                "present": present,
+                "included": included,
+                "status": status,
+            }
+        )
+
+    return items
+
+
+def format_run_duration(run: Optional[models.IdeationRun]) -> Optional[str]:
+    """Return a short string describing the runtime for a concept run."""
+
+    if not run:
+        return None
+
+    started = run.started_at or run.created_at
+    finished = run.finished_at or timezone.now()
+    if not started or not finished:
+        return None
+
+    delta = finished - started
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 1:
+        return "<1s"
+
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+
+    parts: List[str] = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if seconds and not hours:
+        parts.append(f"{seconds}s")
+
+    if not parts:
+        parts.append("<1s")
+
+    return " ".join(parts)
 
 
 def ensure_dish_enhancement(dish: models.DishIdea, user: Optional[User]) -> Optional[models.Enhancement]:

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
     path("login/", app_views.login_view, name="login"),
     path("logout/", app_views.logout_view, name="logout"),
     path("dashboard/<uuid:restaurant_id>/", app_views.dashboard, name="dashboard"),
+    path(
+        "dashboard/<uuid:restaurant_id>/context-toggle/",
+        app_views.dashboard_context_toggle,
+        name="dashboard-context-toggle",
+    ),
 
 
     ## onboarding

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -573,6 +573,19 @@ class ViewSmokeTests(TestCase):
         response = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
         self.assertNotIn("show_menu_modal", response.content.decode())
 
+    def test_dashboard_context_toggle_updates_preference(self):
+        self.restaurant.description = "Tasty story"
+        self.restaurant.save(update_fields=["description"])
+
+        toggle_url = reverse("dashboard-context-toggle", args=[self.restaurant.id])
+        resp = self.client.post(toggle_url, {"key": "story", "include": "false"})
+        self.assertEqual(resp.status_code, 200)
+
+        settings = self.restaurant.restaurantsettings
+        settings.refresh_from_db()
+        self.assertIn("context_flags", settings.llm_defaults)
+        self.assertFalse(settings.llm_defaults["context_flags"]["story"])
+
     def test_logout_via_get_redirects(self):
         response = self.client.get(reverse("logout"))
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Summary
- tighten the restaurant context checklist into interactive toggleable items that control inclusion in LLM context and reflect menu sync status
- surface concept generation runtimes, add a quick "New run" shortcut, and show recent favorite dishes with imagery and streamlined actions
- expose an HTMX endpoint for updating context preferences and cover it with a regression test

## Testing
- pytest *(fails: missing Django settings configuration for test discovery)*
- python manage.py test


------
https://chatgpt.com/codex/tasks/task_e_68d31a9539888332a88c68785e595285