### PR TITLE
Improve dashboard context checklist accuracy

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -93,7 +93,7 @@
                       {% if concept.runtime_display %}
                         Ran in {{ concept.runtime_display }} •
                       {% endif %}
-                      {{ concept.generated_at|timesince }} ago
+                      {{ concept.generated_at|date:"M j, Y g:i a" }}
                     </p>
                   </div>
                   <a href="{% if concept.has_dishes %}{% url 'dish_detail' concept.id %}{% else %}{% url 'dishes-generate' concept.id %}{% endif %}" class="inline-flex items-center gap-2 text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">

--- a/app/templates/dashboard/_context_item.html
+++ b/app/templates/dashboard/_context_item.html
@@ -15,24 +15,14 @@
         type="checkbox"
         name="include"
         value="true"
-        class="h-4 w-4 rounded border border-slate-300 text-[#FF5C00] focus:ring-[#FF5C00]"
+        class="h-4 w-4 rounded border focus:ring-emerald-500 focus:ring-offset-0 {% if item.included %}border-emerald-500 text-emerald-600{% else %}border-slate-300 text-slate-300{% endif %}"
         {% if item.included %}checked{% endif %}
         {% if not item.present %}disabled{% endif %}
       />
       <span>{{ item.label }}</span>
     </label>
     <div class="flex items-center gap-2">
-      {% if item.present %}
-        <span
-          class="rounded-full px-2 py-1 text-xs font-medium {% if item.included %}bg-emerald-100 text-emerald-700{% else %}bg-amber-100 text-amber-700{% endif %}"
-        >
-          {% if item.included %}
-            In context
-          {% else %}
-            Skipped
-          {% endif %}
-        </span>
-      {% else %}
+      {% if not item.present %}
         <a
           href="{{ settings_url }}"
           class="text-xs font-semibold text-[#FF5C00] hover:text-[#e05400]"

--- a/app/views.py
+++ b/app/views.py
@@ -871,9 +871,12 @@ def decorate_dishes_with_enhancements(dishes: Iterable[models.DishIdea],) -> Lis
 
 
 CONTEXT_ITEM_DEFINITIONS = (
-    ("menu", "Menu synced"),
-    ("context", "Neighborhood & vibe"),
+    ("menu", "Menu link"),
+    ("menu_content", "Menu content"),
+    ("services", "Services info"),
     ("story", "Story & description"),
+    ("reviews", "Guest reviews"),
+    ("ingredients", "Ingredient list"),
 )
 
 
@@ -885,10 +888,61 @@ def build_context_items(
     context_flags = dict(settings_obj.llm_defaults.get("context_flags", {}))
     items: List[dict] = []
 
+    def _has_content(value) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, dict):
+            return any(_has_content(item) for item in value.values())
+        if isinstance(value, (list, tuple, set)):
+            return any(_has_content(item) for item in value)
+        return bool(value)
+
+    menu_urls = [url for url in (restaurant.menu_urls or []) if (url or "").strip()]
+    has_menu_link = bool(restaurant.primary_menu_url or menu_urls)
+
+    if (
+        restaurant.active_menu_version
+        and _has_content(restaurant.active_menu_version.raw_markdown)
+    ):
+        has_menu_content = True
+    else:
+        has_menu_content = models.MenuVersion.objects.filter(
+            restaurant=restaurant,
+            raw_markdown__isnull=False,
+        ).exclude(raw_markdown="").exists()
+
+    about_data = restaurant.about_json or {}
+    services_sections = []
+    if isinstance(about_data, dict):
+        for key, value in about_data.items():
+            if isinstance(key, str) and "service" in key.lower():
+                services_sections.append(value)
+    has_services_info = any(_has_content(section) for section in services_sections)
+
+    context_data = restaurant.context_json or {}
+    review_sources = [
+        restaurant.review_count,
+        restaurant.rating,
+    ]
+    if isinstance(context_data, dict):
+        review_sources.extend(
+            context_data.get(key)
+            for key in ["reviews", "reviews_tags", "review_snippets"]
+            if key in context_data
+        )
+    has_reviews = any(_has_content(value) for value in review_sources)
+
+    has_ingredients = models.Ingredient.objects.filter(restaurant=restaurant).exists()
+
     presence_map = {
-        "menu": bool(restaurant.primary_menu_url or restaurant.active_menu_version),
-        "context": bool(restaurant.context_json),
-        "story": bool(restaurant.description),
+        "menu": has_menu_link,
+        "menu_content": has_menu_content,
+        "services": has_services_info,
+        "story": _has_content(restaurant.description),
+        "reviews": has_reviews,
+        "ingredients": has_ingredients,
     }
 
     updated = False

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -7,7 +7,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from app import models
+from app import models, views
 
 
 @override_settings(SECURE_SSL_REDIRECT=False)
@@ -585,6 +585,91 @@ class ViewSmokeTests(TestCase):
         settings.refresh_from_db()
         self.assertIn("context_flags", settings.llm_defaults)
         self.assertFalse(settings.llm_defaults["context_flags"]["story"])
+
+    def test_context_checklist_reflects_data_sources(self):
+        settings = self.restaurant.restaurantsettings
+        settings.llm_defaults = {}
+        settings.save(update_fields=["llm_defaults"])
+
+        self.restaurant.active_menu_version = None
+        self.restaurant.about_json = None
+        self.restaurant.description = ""
+        self.restaurant.review_count = None
+        self.restaurant.rating = None
+        self.restaurant.context_json = {}
+        self.restaurant.set_menu_urls([])
+        self.restaurant.save(
+            update_fields=[
+                "active_menu_version",
+                "about_json",
+                "description",
+                "review_count",
+                "rating",
+                "context_json",
+                "menu_urls",
+                "primary_menu_url",
+            ]
+        )
+
+        models.MenuVersion.objects.filter(restaurant=self.restaurant).delete()
+        models.Ingredient.objects.filter(restaurant=self.restaurant).delete()
+
+        items = views.build_context_items(self.restaurant, settings)
+        presence = {item["key"]: item["present"] for item in items}
+        self.assertEqual(
+            presence,
+            {
+                "menu": False,
+                "menu_content": False,
+                "services": False,
+                "story": False,
+                "reviews": False,
+                "ingredients": False,
+            },
+        )
+
+        menu_version = models.MenuVersion.objects.create(
+            restaurant=self.restaurant,
+            source_url="https://example.com/menu",
+            source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
+            raw_markdown="Menu text",
+            status=models.MenuVersion.Status.SUCCEEDED,
+        )
+        self.restaurant.active_menu_version = menu_version
+        self.restaurant.set_menu_urls(["https://example.com/menu"])
+        self.restaurant.about_json = {"Service options": {"Dine-in": True}}
+        self.restaurant.description = "House story"
+        self.restaurant.review_count = 5
+        self.restaurant.context_json = {"reviews_tags": ["friendly staff"]}
+        self.restaurant.save(
+            update_fields=[
+                "active_menu_version",
+                "menu_urls",
+                "primary_menu_url",
+                "about_json",
+                "description",
+                "review_count",
+                "context_json",
+            ]
+        )
+        models.Ingredient.objects.create(restaurant=self.restaurant, name="Salt")
+
+        settings.llm_defaults = {}
+        settings.save(update_fields=["llm_defaults"])
+
+        refreshed_items = views.build_context_items(self.restaurant, settings)
+        refreshed_presence = {item["key"]: item["present"] for item in refreshed_items}
+        self.assertEqual(
+            refreshed_presence,
+            {
+                "menu": True,
+                "menu_content": True,
+                "services": True,
+                "story": True,
+                "reviews": True,
+                "ingredients": True,
+            },
+        )
 
     def test_logout_via_get_redirects(self):
         response = self.client.get(reverse("logout"))


### PR DESCRIPTION
## Summary
- expand the dashboard context checklist to verify menu links, content, services, reviews, and ingredients from real data
- simplify the checklist UI by relying on green checkboxes and update the recent concepts timestamp to show the exact run time
- add coverage ensuring the checklist reports presence for each data source

## Testing
- `python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_context_checklist_reflects_data_sources`


------
https://chatgpt.com/codex/tasks/task_e_68d31f690f1483329925930d3ebfcbbd