### PR TITLE
Ensure dashboard navigation links include restaurant id

### DIFF
--- a/app/templates/layouts/app.html
+++ b/app/templates/layouts/app.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load navigation_tags %}
 
 {% block head_scripts %}
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
@@ -31,13 +32,7 @@
 {% endblock %}
 
 {% block header %}
-  {% if restaurant %}
-    {% url 'dashboard' restaurant.id as dashboard_url %}
-  {% elif request.resolver_match.kwargs.restaurant_id %}
-    {% url 'dashboard' request.resolver_match.kwargs.restaurant_id as dashboard_url %}
-  {% else %}
-    {% url 'home' as dashboard_url %}
-  {% endif %}
+  {% resolve_dashboard_url as dashboard_url %}
   <header class="relative border-b border-slate-200 bg-white/80 backdrop-blur z-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
       <div class="flex items-start gap-4">

--- a/app/templates/layouts/marketing.html
+++ b/app/templates/layouts/marketing.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load navigation_tags %}
 
 {% block html_attrs %} x-data="{ mobileMenuOpen: false }" class="h-full"{% endblock %}
 
@@ -19,13 +20,7 @@
 {% endblock %}
 
 {% block header %}
-  {% if restaurant %}
-    {% url 'dashboard' restaurant.id as dashboard_url %}
-  {% elif request.resolver_match.kwargs.restaurant_id %}
-    {% url 'dashboard' request.resolver_match.kwargs.restaurant_id as dashboard_url %}
-  {% else %}
-    {% url 'home' as dashboard_url %}
-  {% endif %}
+  {% resolve_dashboard_url as dashboard_url %}
   <header class="bg-gradient-to-r from-[#2E005D] via-[#5C008B] to-[#8E008B] text-white shadow">
     <div class="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
       <a href="{{ dashboard_url }}" class="text-2xl font-bold tracking-tight">Appertivo</a>

--- a/app/templatetags/__init__.py
+++ b/app/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Template tag packages for the app."""

--- a/app/templatetags/navigation_tags.py
+++ b/app/templatetags/navigation_tags.py
@@ -1,0 +1,52 @@
+"""Custom template tags for navigation helpers."""
+
+from django import template
+from django.urls import reverse
+
+from app import models
+
+register = template.Library()
+
+
+def _membership_restaurant_id(user):
+    """Return the first restaurant id for the user's account."""
+    membership = (
+        models.Membership.objects.filter(user=user)
+        .select_related("account")
+        .first()
+    )
+    if not membership:
+        return None
+    return (
+        models.Restaurant.objects.filter(account=membership.account)
+        .order_by("created_at")
+        .values_list("id", flat=True)
+        .first()
+    )
+
+
+@register.simple_tag(takes_context=True)
+def resolve_dashboard_url(context):
+    """Resolve the dashboard URL including the restaurant identifier when possible."""
+    # Prefer an explicit restaurant provided in the template context.
+    restaurant = context.get("restaurant")
+    if getattr(restaurant, "id", None):
+        return reverse("dashboard", args=[restaurant.id])
+
+    request = context.get("request")
+    if not request:
+        return reverse("home")
+
+    resolver_match = getattr(request, "resolver_match", None)
+    if resolver_match:
+        restaurant_id = resolver_match.kwargs.get("restaurant_id")
+        if restaurant_id:
+            return reverse("dashboard", args=[restaurant_id])
+
+    user = getattr(request, "user", None)
+    if user and user.is_authenticated:
+        restaurant_id = _membership_restaurant_id(user)
+        if restaurant_id:
+            return reverse("dashboard", args=[restaurant_id])
+
+    return reverse("home")

--- a/tests/test_navigation_dashboard_url.py
+++ b/tests/test_navigation_dashboard_url.py
@@ -1,0 +1,40 @@
+"""Tests for dashboard URL resolution in navigation templates."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app import models
+
+
+class DashboardNavigationURLTests(TestCase):
+    """Ensure the dashboard link points to the user-specific restaurant."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="owner", email="owner@example.com", password="testpass123"
+        )
+        self.account = models.Account.objects.create(name="Test Account")
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="Test Restaurant",
+            location_text="Test City",
+        )
+        models.Membership.objects.create(
+            account=self.account,
+            user=self.user,
+            role=models.Membership.Role.OWNER,
+        )
+
+    def test_marketing_layout_uses_dashboard_url_with_restaurant(self):
+        self.client.login(username="owner", password="testpass123")
+        response = self.client.get(reverse("home"))
+        expected_url = reverse("dashboard", args=[self.restaurant.id])
+        self.assertContains(response, f'href="{expected_url}"')
+
+    def test_app_layout_uses_dashboard_url_with_restaurant(self):
+        self.client.login(username="owner", password="testpass123")
+        response = self.client.get(reverse("concepts"))
+        expected_url = reverse("dashboard", args=[self.restaurant.id])
+        self.assertContains(response, f'href="{expected_url}"')


### PR DESCRIPTION
## Summary
- add a navigation template tag that resolves the dashboard URL for the active restaurant
- update app and marketing layouts to use the new tag so links include the restaurant id
- cover the navigation behaviour with tests for both layouts

## Testing
- python manage.py test tests.test_navigation_dashboard_url -v 2

------
https://chatgpt.com/codex/tasks/task_e_68d3315213e08332a17291c456a38ab3