### PR TITLE
Add Stripe trial onboarding and webhook sync

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -12,7 +12,7 @@ class TimestampedAdmin(admin.ModelAdmin):
 # Register core org/account/user models
 @admin.register(models.Account)
 class AccountAdmin(TimestampedAdmin):
-    list_display = ("id", "name", "created_at")
+    list_display = ("id", "name", "stripe_customer_id", "created_at")
 
 
 @admin.register(models.UserProfile)

--- a/app/migrations/0008_account_stripe_customer_id.py
+++ b/app/migrations/0008_account_stripe_customer_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0007_dishidea_is_deleted"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="account",
+            name="stripe_customer_id",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -22,6 +22,7 @@ class Account(TimestampedModel):
     """Organization account."""
 
     name = models.TextField(null=True, blank=True)
+    stripe_customer_id = models.TextField(null=True, blank=True)
 
 
 class UserProfile(TimestampedModel):

--- a/app/templates/billing/main.html
+++ b/app/templates/billing/main.html
@@ -11,8 +11,68 @@
 
 {% block page_content %}
   <div class="px-4 py-8">
-    <div class="rounded-2xl border border-slate-200 bg-white/90 p-6 text-slate-600">
-      <p>Billing management is coming soon.</p>
+    <div class="mx-auto max-w-3xl space-y-6">
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6">
+        <div class="flex flex-col gap-4 text-slate-600">
+          <div>
+            <p class="text-xs font-semibold uppercase text-slate-400">Current plan</p>
+            <h2 class="mt-2 text-lg font-semibold text-[#14080E]">{{ plan.name|default:"Pro" }}</h2>
+            <p class="text-sm">${{ plan.limits.price|default:"199" }}/month • {{ trial_days }}-day free trial</p>
+          </div>
+
+          {% if plan.features %}
+            <ul class="grid gap-2 rounded-xl bg-slate-50 p-4 text-sm text-slate-600 sm:grid-cols-2">
+              {% for feature in plan.features %}
+                <li class="flex items-start gap-2">
+                  <span class="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                    <i class="fa-solid fa-check text-xs" aria-hidden="true"></i>
+                  </span>
+                  <span>{{ feature }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+
+          <div class="rounded-xl border border-slate-200 bg-white p-4">
+            {% if subscription %}
+              <p class="text-sm font-semibold text-[#14080E]">Status: {{ subscription.get_status_display }}</p>
+              {% if trial_days_remaining is not None %}
+                <p class="mt-1 text-sm text-slate-600">Trial ends {{ trial_end|date:"F j, Y" }} ({{ trial_days_remaining }} days remaining)</p>
+              {% elif trial_end %}
+                <p class="mt-1 text-sm text-slate-600">Renews on {{ trial_end|date:"F j, Y" }}</p>
+              {% endif %}
+              {% if subscription.cancel_at_period_end %}
+                <p class="mt-2 text-xs font-medium text-amber-600">Cancellation scheduled at period end.</p>
+              {% endif %}
+            {% else %}
+              <p class="text-sm text-slate-600">You have not started a subscription yet. Begin your {{ trial_days }}-day free trial to unlock the full experience.</p>
+            {% endif %}
+          </div>
+
+          {% if show_start_trial %}
+            <form method="post" action="{% url 'billing-upgrade' %}">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{% url 'billing' %}">
+              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+                Start {{ trial_days }}-day trial
+              </button>
+            </form>
+          {% elif subscription %}
+            <div class="flex flex-wrap gap-3">
+              <form method="post" action="{% url 'billing-cancel' %}">
+                {% csrf_token %}
+                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-[#14080E] transition hover:bg-slate-100" {% if subscription.cancel_at_period_end %}disabled{% endif %}>
+                  {% if subscription.cancel_at_period_end %}
+                    Cancellation scheduled
+                  {% else %}
+                    Cancel at period end
+                  {% endif %}
+                </button>
+              </form>
+            </div>
+          {% endif %}
+        </div>
+      </section>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -37,9 +37,13 @@
           {% endif %}
         </div>
         {% if trial_info.show_upgrade %}
-          <a href="{% url 'billing-upgrade' %}" class="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
-            {{ trial_info.action_label }}
-          </a>
+          <form method="post" action="{% url 'billing-upgrade' %}" class="mt-4">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{% url 'billing' %}">
+            <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+              {{ trial_info.action_label }}
+            </button>
+          </form>
         {% endif %}
       </section>
     </div>

--- a/app/templates/onboarding.html
+++ b/app/templates/onboarding.html
@@ -11,8 +11,70 @@
 
 {% block page_content %}
   <div class="px-4 py-8">
-    <div class="rounded-2xl border border-slate-200 bg-white/90 p-6 text-slate-600">
-      <p>The onboarding flow will live here.</p>
+    <div class="mx-auto flex max-w-3xl flex-col gap-6">
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 text-slate-600">
+        <div class="flex flex-col gap-4">
+          <div>
+            <p class="text-xs font-semibold uppercase text-slate-400">Step 1</p>
+            <h2 class="mt-2 text-lg font-semibold text-[#14080E]">Start your {{ trial_days }}-day free trial</h2>
+            <p class="text-sm">Unlock unlimited ideation, menu polishing tools, and collaboration features.</p>
+          </div>
+
+          <div class="rounded-xl border border-slate-200 bg-white p-4">
+            {% if subscription %}
+              <p class="text-sm font-semibold text-[#14080E]">You're {{ subscription.get_status_display|lower }}.</p>
+              {% if trial_days_remaining is not None %}
+                <p class="mt-1 text-sm">Your trial ends {{ trial_ends|date:"F j, Y" }} ({{ trial_days_remaining }} days remaining).</p>
+              {% elif trial_ends %}
+                <p class="mt-1 text-sm">Renewal date: {{ trial_ends|date:"F j, Y" }}.</p>
+              {% endif %}
+              {% if subscription.cancel_at_period_end %}
+                <p class="mt-2 text-xs font-medium text-amber-600">Cancellation is scheduled at the end of this period.</p>
+              {% endif %}
+            {% else %}
+              <p class="text-sm">Add a payment method now and you won't be charged until your trial ends.</p>
+            {% endif %}
+          </div>
+
+          {% if show_start_trial %}
+            <form method="post" action="{% url 'billing-upgrade' %}">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{% url 'onboarding' %}">
+              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+                Start {{ trial_days }}-day trial
+              </button>
+            </form>
+          {% else %}
+            <div class="flex flex-wrap gap-3">
+              <a href="{% url 'billing' %}" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-[#14080E] transition hover:bg-slate-100">
+                Manage billing
+              </a>
+              {% if restaurant %}
+                <a href="{% url 'dashboard' restaurant.id %}" class="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600">
+                  Continue to dashboard
+                </a>
+              {% endif %}
+            </div>
+          {% endif %}
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-6 text-slate-600">
+        <p class="text-xs font-semibold uppercase text-slate-400">Step 2</p>
+        <h2 class="mt-2 text-lg font-semibold text-[#14080E]">Track menu processing</h2>
+        {% if jobs %}
+          <ul class="mt-4 space-y-2 text-sm">
+            {% for job in jobs %}
+              <li class="flex items-center justify-between rounded-xl bg-white p-3">
+                <span>{{ job.get_kind_display|default:job.kind }}</span>
+                <span class="text-xs font-medium uppercase text-slate-400">{{ job.get_status_display|default:job.status }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="mt-4 text-sm">We'll keep an eye on your menu imports and alert you once everything is ready.</p>
+        {% endif %}
+      </section>
     </div>
   </div>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -21,7 +21,9 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
+import stripe
 from pydantic import BaseModel
 from django.core.cache import cache
 import hashlib
@@ -38,8 +40,114 @@ import datetime
 
 from app.tasks import create_ideation_run
 
+stripe.api_key = settings.STRIPE_SECRET_KEY or ""
+logger = logging.getLogger(__name__)
+
 class ConceptList(BaseModel):
     concepts: List[str]
+
+
+def _ensure_stripe_api_key() -> None:
+    """Refresh the Stripe API key from settings for the current process."""
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY or ""
+
+
+def _get_default_plan() -> models.Plan:
+    """Fetch or create the default plan used for subscriptions."""
+
+    defaults = {
+        "name": "Pro",
+        "limits": {"concept_runs": 100, "dish_runs": 100, "price": "199"},
+        "features": [
+            "Unlimited menu scrapes",
+            "Concept and dish generation",
+            "Team collaboration",
+        ],
+    }
+    plan, _ = models.Plan.objects.get_or_create(
+        code=getattr(settings, "STRIPE_PLAN_CODE", "pro"), defaults=defaults
+    )
+    return plan
+
+
+def _stripe_timestamp(value: Optional[int]) -> datetime.datetime:
+    """Convert a Stripe timestamp into an aware datetime."""
+
+    if not value:
+        return timezone.now()
+    return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+
+
+def _sync_subscription(subscription_data: dict) -> None:
+    """Create or update a subscription based on Stripe payload."""
+
+    sub_id = subscription_data.get("id")
+    if not sub_id:
+        return
+
+    account: Optional[models.Account] = None
+    local = models.Subscription.objects.filter(provider_sub_id=sub_id).first()
+    if local:
+        account = local.account
+
+    metadata = subscription_data.get("metadata") or {}
+    if not account:
+        account_id = metadata.get("account_id")
+        if account_id:
+            account = models.Account.objects.filter(id=account_id).first()
+
+    if not account:
+        customer_id = subscription_data.get("customer")
+        if customer_id:
+            account = models.Account.objects.filter(
+                stripe_customer_id=customer_id
+            ).first()
+
+    if not account:
+        return
+
+    customer_id = subscription_data.get("customer")
+    if customer_id and account.stripe_customer_id != customer_id:
+        account.stripe_customer_id = customer_id
+        account.save(update_fields=["stripe_customer_id"])
+
+    plan = _get_default_plan()
+    status = subscription_data.get("status", models.Subscription.Status.TRIALING)
+    defaults = {
+        "plan": plan,
+        "provider": models.Subscription.Provider.STRIPE,
+        "provider_customer_id": customer_id or "",
+        "status": status,
+        "current_period_start": _stripe_timestamp(
+            subscription_data.get("current_period_start")
+        ),
+        "current_period_end": _stripe_timestamp(
+            subscription_data.get("current_period_end")
+        ),
+        "cancel_at_period_end": subscription_data.get(
+            "cancel_at_period_end", False
+        ),
+    }
+
+    models.Subscription.objects.update_or_create(
+        account=account,
+        provider=models.Subscription.Provider.STRIPE,
+        provider_sub_id=sub_id,
+        defaults=defaults,
+    )
+
+
+def _latest_subscription_for_account(
+    account: models.Account,
+) -> Optional[models.Subscription]:
+    """Return the most recent subscription for an account."""
+
+    return (
+        models.Subscription.objects.filter(account=account)
+        .order_by("-created_at")
+        .first()
+    )
 
 
 def _get_session_list(session, key: str) -> List[str]:
@@ -179,7 +287,9 @@ def signup_view(request):
             )
 
         login(request, user)
-        redirect_url = reverse("dashboard", args=[restaurant.id])
+        request.session["onboarding_account_id"] = str(account.id)
+        request.session["onboarding_restaurant_id"] = str(restaurant.id)
+        redirect_url = reverse("onboarding")
         if is_json:
             return JsonResponse(
                 {
@@ -486,15 +596,70 @@ def menus_view(request):
     return render(request, "menus/main.html", ctx)
 
 
+@login_required
 def onboarding_view(request):
-    """Show onboarding progress."""
+    """Show onboarding progress and billing step."""
+
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    account = membership.account if membership else None
+    restaurant = None
+    subscription = None
+    if account:
+        restaurant = (
+            models.Restaurant.objects.filter(account=account)
+            .order_by("created_at")
+            .first()
+        )
+        subscription = (
+            models.Subscription.objects.filter(account=account)
+            .order_by("-created_at")
+            .first()
+        )
+
     jobs = models.Job.objects.filter(user=request.user)
-    return render(request, "onboarding.html", {"jobs": jobs})
+    trial_days = getattr(settings, "STRIPE_TRIAL_DAYS", 14)
+    trial_ends = subscription.current_period_end if subscription else None
+    trial_days_remaining = None
+    if subscription and subscription.status == models.Subscription.Status.TRIALING:
+        remaining = subscription.current_period_end - timezone.now()
+        trial_days_remaining = max(remaining.days, 0)
+
+    context = {
+        "jobs": jobs,
+        "restaurant": restaurant,
+        "subscription": subscription,
+        "trial_days": trial_days,
+        "trial_ends": trial_ends,
+        "trial_days_remaining": trial_days_remaining,
+        "show_start_trial": not subscription
+        or subscription.status == models.Subscription.Status.CANCELED,
+    }
+    return render(request, "onboarding.html", context)
 
 
+@login_required
 def onboarding_status_view(request):
     """Return simple onboarding status."""
-    return JsonResponse({"status": "pending"})
+
+    membership = models.Membership.objects.filter(user=request.user).first()
+    subscription = None
+    if membership:
+        subscription = (
+            models.Subscription.objects.filter(account=membership.account)
+            .order_by("-created_at")
+            .first()
+        )
+
+    return JsonResponse(
+        {
+            "status": "pending" if not subscription else subscription.status,
+            "subscription_started": bool(subscription),
+        }
+    )
 
 
 def manual_menu_view(request):
@@ -1836,8 +2001,6 @@ def update_creativity(request, restaurant_id):
     return JsonResponse({"status": "ok"})
 
 
-logger = logging.getLogger(__name__)
-
 @login_required
 @require_POST
 def rescrape_menu(request, restaurant_id):
@@ -1879,19 +2042,171 @@ def update_notifications(request):
 
 
 
+@login_required
 def billing_view(request):
     """Show billing page."""
-    return render(request, "billing/main.html")
+
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    account = membership.account if membership else None
+    subscription = _latest_subscription_for_account(account) if account else None
+    plan = _get_default_plan() if account else None
+    trial_days = getattr(settings, "STRIPE_TRIAL_DAYS", 14)
+    trial_end = subscription.current_period_end if subscription else None
+    trial_days_remaining = None
+    if subscription and subscription.status == models.Subscription.Status.TRIALING:
+        remaining = subscription.current_period_end - timezone.now()
+        trial_days_remaining = max(remaining.days, 0)
+
+    context = {
+        "plan": plan,
+        "subscription": subscription,
+        "trial_days": trial_days,
+        "trial_end": trial_end,
+        "trial_days_remaining": trial_days_remaining,
+        "show_start_trial": bool(account)
+        and (
+            not subscription
+            or subscription.status == models.Subscription.Status.CANCELED
+        ),
+    }
+    return render(request, "billing/main.html", context)
 
 
+@login_required
+@require_POST
 def billing_upgrade_view(request):
-    """Start upgrade flow."""
-    return JsonResponse({"status": "ok"})
+    """Create a Stripe Checkout session to start the trial subscription."""
+
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    price_id = getattr(settings, "STRIPE_PRICE_ID", "")
+    if not membership or not price_id:
+        return redirect("billing")
+
+    account = membership.account
+    _ensure_stripe_api_key()
+    metadata = {"account_id": str(account.id)}
+    next_path = request.POST.get("next") or reverse("billing")
+    if not isinstance(next_path, str) or not next_path.startswith("/"):
+        next_path = reverse("billing")
+    success_url = request.build_absolute_uri(next_path)
+    cancel_url = success_url
+
+    session_kwargs = {
+        "mode": "subscription",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "subscription_data": {
+            "trial_period_days": getattr(settings, "STRIPE_TRIAL_DAYS", 14),
+            "metadata": metadata,
+        },
+        "metadata": metadata,
+    }
+
+    if account.stripe_customer_id:
+        session_kwargs["customer"] = account.stripe_customer_id
+    else:
+        session_kwargs["customer_email"] = request.user.email
+
+    try:
+        checkout_session = stripe.checkout.Session.create(**session_kwargs)
+    except stripe.error.StripeError:
+        logger.exception("Unable to create Stripe Checkout session", exc_info=True)
+        return redirect("billing")
+
+    return redirect(checkout_session.url)
 
 
+@login_required
+@require_POST
 def billing_cancel_view(request):
-    """Cancel subscription."""
-    return JsonResponse({"status": "ok"})
+    """Cancel subscription at period end."""
+
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    if not membership:
+        return redirect("billing")
+
+    account = membership.account
+    subscription = _latest_subscription_for_account(account)
+    if not subscription:
+        return redirect("billing")
+
+    if (
+        subscription.provider == models.Subscription.Provider.STRIPE
+        and getattr(settings, "STRIPE_SECRET_KEY", "")
+    ):
+        _ensure_stripe_api_key()
+        try:
+            stripe.Subscription.modify(
+                subscription.provider_sub_id, cancel_at_period_end=True
+            )
+        except stripe.error.StripeError:
+            logger.exception("Unable to cancel Stripe subscription", exc_info=True)
+
+    if not subscription.cancel_at_period_end:
+        subscription.cancel_at_period_end = True
+        subscription.save(update_fields=["cancel_at_period_end"])
+
+    return redirect("billing")
+
+
+@csrf_exempt
+@require_POST
+def stripe_webhook_view(request):
+    """Handle Stripe webhook callbacks for subscriptions."""
+
+    payload = request.body
+    sig_header = request.META.get("HTTP_STRIPE_SIGNATURE", "")
+    secret = getattr(settings, "STRIPE_WEBHOOK_SECRET", "")
+
+    if secret:
+        try:
+            event = stripe.Webhook.construct_event(payload, sig_header, secret)
+        except ValueError:
+            return HttpResponseBadRequest("invalid_payload")
+        except stripe.error.SignatureVerificationError:
+            return HttpResponseForbidden("invalid_signature")
+    else:
+        try:
+            event = json.loads(payload or "{}")
+        except json.JSONDecodeError:
+            return HttpResponseBadRequest("invalid_json")
+
+    event_type = event.get("type")
+    data_object = event.get("data", {}).get("object", {})
+
+    if event_type == "checkout.session.completed":
+        subscription_id = data_object.get("subscription")
+        if subscription_id:
+            _ensure_stripe_api_key()
+            try:
+                subscription = stripe.Subscription.retrieve(subscription_id)
+            except stripe.error.StripeError:
+                logger.exception(
+                    "Unable to retrieve subscription %s from Stripe", subscription_id
+                )
+            else:
+                _sync_subscription(subscription)
+    elif event_type in {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }:
+        _sync_subscription(data_object)
+
+    return HttpResponse(status=200)
 
 
 def job_status_view(request, job_id):

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -66,7 +66,23 @@ MESSAGE_TAGS = {
     message_constants.ERROR: 'danger',
 }
 
-STRIPE_API_KEY = 'your_stripe_secret_key_here'
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer from environment variables with a fallback."""
+
+    try:
+        return int(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+STRIPE_PUBLISHABLE_KEY = os.getenv("STRIPE_PUBLISHABLE_KEY", "")
+STRIPE_PRICE_ID = os.getenv("STRIPE_PRICE_ID", "")
+STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
+STRIPE_TRIAL_DAYS = _env_int("STRIPE_TRIAL_DAYS", 14)
+STRIPE_PLAN_CODE = os.getenv("STRIPE_PLAN_CODE", "pro")
+STRIPE_API_KEY = STRIPE_SECRET_KEY
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
     path("billing/", app_views.billing_view, name="billing"),
     path("billing/upgrade/", app_views.billing_upgrade_view, name="billing-upgrade"),
     path("billing/cancel/", app_views.billing_cancel_view, name="billing-cancel"),
+    path("stripe/webhook/", app_views.stripe_webhook_view, name="stripe-webhook"),
     path("jobs/<uuid:job_id>/", app_views.job_status_view, name="job-status"),
     path("notifications/", app_views.notification_list_view, name="notification-list"),
     # Existing API and sample views

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -10,7 +11,12 @@ from django.utils import timezone
 from app import models, views
 
 
-@override_settings(SECURE_SSL_REDIRECT=False)
+@override_settings(
+    SECURE_SSL_REDIRECT=False,
+    STRIPE_PRICE_ID="price_test",
+    STRIPE_SECRET_KEY="sk_test",
+    STRIPE_TRIAL_DAYS=14,
+)
 class ViewSmokeTests(TestCase):
     """Ensure newly added views respond correctly."""
 
@@ -81,6 +87,7 @@ class ViewSmokeTests(TestCase):
         }
         resp = self.client.post(reverse("signup"), data)
         self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("onboarding"))
         self.assertTrue(User.objects.filter(username="new@example.com").exists())
 
     def test_login_authenticates(self):
@@ -706,13 +713,23 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(mv.source_kind, models.MenuVersion.SourceKind.IMAGE_OCR)
         mock_parse.assert_called_once()
 
-    def test_billing_views(self):
+    @patch("app.views.stripe.Subscription.modify")
+    @patch("app.views.stripe.checkout.Session.create")
+    def test_billing_views(self, mock_checkout, mock_modify):
+        mock_checkout.return_value = SimpleNamespace(url="https://stripe.test/session")
+
         resp = self.client.get(reverse("billing"))
         self.assertEqual(resp.status_code, 200)
-        up = self.client.post(reverse("billing-upgrade"))
-        self.assertEqual(up.status_code, 200)
+
+        up = self.client.post(
+            reverse("billing-upgrade"), {"next": reverse("billing")}
+        )
+        self.assertEqual(up.status_code, 302)
+        self.assertEqual(up["Location"], "https://stripe.test/session")
+        mock_checkout.assert_called_once()
+
         cancel = self.client.post(reverse("billing-cancel"))
-        self.assertEqual(cancel.status_code, 200)
+        self.assertEqual(cancel.status_code, 302)
 
     def test_job_status_and_notifications(self):
         job = models.Job.objects.create(

--- a/tests/test_stripe_flow.py
+++ b/tests/test_stripe_flow.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from app import models
+
+
+@override_settings(
+    STRIPE_PRICE_ID="price_test",
+    STRIPE_SECRET_KEY="sk_test",
+    STRIPE_TRIAL_DAYS=14,
+    STRIPE_WEBHOOK_SECRET="whsec_test",
+)
+class StripeFlowTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("stripe@example.com", password="pw")
+        self.account = models.Account.objects.create(name="Stripe Co")
+        models.Membership.objects.create(account=self.account, user=self.user)
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account, name="Stripe Resto", location_text="City"
+        )
+        self.client.login(username="stripe@example.com", password="pw")
+
+    @patch("app.views.stripe.checkout.Session.create")
+    def test_start_trial_checkout_metadata(self, mock_checkout):
+        mock_checkout.return_value = SimpleNamespace(url="https://stripe.test/session")
+
+        response = self.client.post(
+            reverse("billing-upgrade"), {"next": reverse("onboarding")}
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "https://stripe.test/session")
+        _, kwargs = mock_checkout.call_args
+        self.assertEqual(kwargs["metadata"]["account_id"], str(self.account.id))
+        self.assertEqual(kwargs["subscription_data"]["trial_period_days"], 14)
+        self.assertEqual(kwargs["customer_email"], self.user.email)
+
+    @patch("app.views.stripe.Subscription.retrieve")
+    @patch("app.views.stripe.Webhook.construct_event")
+    def test_webhook_checkout_creates_subscription(self, mock_construct, mock_retrieve):
+        event = {
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "subscription": "sub_123",
+                    "metadata": {"account_id": str(self.account.id)},
+                    "customer": "cus_123",
+                }
+            },
+        }
+        mock_construct.return_value = event
+        mock_retrieve.return_value = {
+            "id": "sub_123",
+            "customer": "cus_123",
+            "status": "trialing",
+            "current_period_start": 100,
+            "current_period_end": 200,
+            "cancel_at_period_end": False,
+            "metadata": {"account_id": str(self.account.id)},
+        }
+
+        response = self.client.post(
+            reverse("stripe-webhook"),
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        subscription = models.Subscription.objects.get(provider_sub_id="sub_123")
+        self.assertEqual(subscription.status, "trialing")
+        self.assertEqual(subscription.provider_customer_id, "cus_123")
+        self.account.refresh_from_db()
+        self.assertEqual(self.account.stripe_customer_id, "cus_123")
+
+        status_resp = self.client.get(reverse("onboarding-status"))
+        self.assertEqual(status_resp.json()["status"], "trialing")


### PR DESCRIPTION
## Summary
- configure Stripe environment settings and add a default subscription plan record
- add onboarding and billing flows that launch a 14-day Stripe Checkout trial and show plan status
- sync subscription data through a Stripe webhook, persist customer ids, and cover the flow with tests

## Testing
- python manage.py test tests.test_appertivo_views tests.test_stripe_flow *(fails: pre-existing view routing errors around concept and dish URLs)*

------
https://chatgpt.com/codex/tasks/task_e_68d6898dad6483329f209b04f75e5621