### PR TITLE
Revamp onboarding and signup flow

### DIFF
--- a/app/templates/_partials/onboarding_welcome.html
+++ b/app/templates/_partials/onboarding_welcome.html
@@ -1,0 +1,40 @@
+<div class="rounded-2xl border border-slate-200 bg-gradient-to-br from-white via-white to-[#F9F7F2] p-5 shadow-sm">
+  <div class="space-y-3">
+    {% if just_signed_up %}
+      <p class="inline-flex items-center gap-2 rounded-full bg-[#5C008B]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[#5C008B]">
+        Welcome aboard!
+      </p>
+    {% endif %}
+    <h3 class="text-lg font-semibold text-[#14080E]">Make the most of your first session</h3>
+    <p class="text-sm text-slate-600">
+      Start by generating a concept board, then explore dishes inspired by your menu. Favoriting ideas keeps the suggestions sharp.
+    </p>
+    <ul class="space-y-2 text-sm text-slate-600">
+      <li class="flex items-start gap-2">
+        <span class="mt-1 h-2 w-2 rounded-full bg-[#FF8300]"></span>
+        <span>Create a 9-card concept board tailored to {{ restaurant.name|default:"your restaurant" }}.</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="mt-1 h-2 w-2 rounded-full bg-[#5C008B]"></span>
+        <span>Open any concept to see dish ideas, plating notes, and pricing cues.</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="mt-1 h-2 w-2 rounded-full bg-emerald-500"></span>
+        <span>Use favorites to signal what you love—we'll recommend more like it.</span>
+      </li>
+    </ul>
+    <div class="flex flex-wrap gap-3 pt-2">
+      <a href="{% url 'concepts-generate' %}" class="inline-flex items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+        Generate concepts
+      </a>
+      <a href="{% url 'concepts' %}" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-[#14080E] transition hover:bg-slate-100">
+        Browse concept gallery
+      </a>
+      {% if dashboard_url %}
+        <a href="{{ dashboard_url }}" class="inline-flex items-center justify-center gap-2 rounded-xl border border-emerald-300 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-100">
+          View dashboard setup
+        </a>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -2,7 +2,7 @@
 
 {% block title %}Sign Up — Appertivo{% endblock %}
 
-{% block auth_title %}Create an Account{% endblock %}
+{% block auth_title %}Create Your Restaurant Workspace{% endblock %}
 
 {% block form_fields %}
   <div>
@@ -30,11 +30,7 @@
     <input type="text" name="location" value="{{ form_data.location }}" required
            class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
   </div>
-  <div>
-    <label class="block text-sm font-medium text-slate-700">Menu URL (optional)</label>
-    <input type="url" name="menu_url" value="{{ form_data.menu_url }}"
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
-  </div>
+  <p class="text-xs text-slate-500">We'll grab the public details for your restaurant automatically after signup.</p>
 {% endblock %}
 
 {% block submit_label %}Sign Up{% endblock %}

--- a/app/templates/onboarding.html
+++ b/app/templates/onboarding.html
@@ -1,79 +1,152 @@
 {% extends "layouts/app.html" %}
 
-{% block title %}Onboarding — Appertivo{% endblock %}
+{% block title %}Welcome — Appertivo{% endblock %}
 
 {% block page_intro %}
   <div class="space-y-1">
-    <h1 class="text-xl font-semibold text-[#14080E]">Welcome to Appertivo</h1>
-    <p class="text-sm text-slate-600">Complete these quick steps to tailor recommendations.</p>
+    <p class="text-xs font-semibold uppercase tracking-wide text-[#5C008B]/70">Onboarding</p>
+    <h1 class="text-2xl font-semibold text-[#14080E]">Let's get your restaurant set up</h1>
+    <p class="text-sm text-slate-600">Follow these steps to personalize Appertivo before you dive into concepts and dishes.</p>
   </div>
 {% endblock %}
 
 {% block page_content %}
-  <div class="px-4 py-8">
-    <div class="mx-auto flex max-w-3xl flex-col gap-6">
-      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 text-slate-600">
-        <div class="flex flex-col gap-4">
+  <div class="px-4 py-10">
+    <div class="mx-auto flex max-w-4xl flex-col gap-6">
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Step 1</p>
+        <div class="mt-3 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div>
-            <p class="text-xs font-semibold uppercase text-slate-400">Step 1</p>
-            <h2 class="mt-2 text-lg font-semibold text-[#14080E]">Start your {{ trial_days }}-day free trial</h2>
-            <p class="text-sm">Unlock unlimited ideation, menu polishing tools, and collaboration features.</p>
-          </div>
-
-          <div class="rounded-xl border border-slate-200 bg-white p-4">
-            {% if subscription %}
-              <p class="text-sm font-semibold text-[#14080E]">You're {{ subscription.get_status_display|lower }}.</p>
-              {% if trial_days_remaining is not None %}
-                <p class="mt-1 text-sm">Your trial ends {{ trial_ends|date:"F j, Y" }} ({{ trial_days_remaining }} days remaining).</p>
-              {% elif trial_ends %}
-                <p class="mt-1 text-sm">Renewal date: {{ trial_ends|date:"F j, Y" }}.</p>
-              {% endif %}
-              {% if subscription.cancel_at_period_end %}
-                <p class="mt-2 text-xs font-medium text-amber-600">Cancellation is scheduled at the end of this period.</p>
-              {% endif %}
-            {% else %}
-              <p class="text-sm">Add a payment method now and you won't be charged until your trial ends.</p>
+            <h2 class="text-lg font-semibold text-[#14080E]">Confirm your restaurant details</h2>
+            <p class="mt-1 text-sm text-slate-600">We're pulling public data to preload your dashboard.</p>
+            {% if restaurant %}
+              <dl class="mt-4 grid gap-2 text-sm text-slate-600">
+                <div class="flex flex-wrap items-center gap-2">
+                  <dt class="font-medium text-[#14080E]">Restaurant:</dt>
+                  <dd>{{ restaurant.name }}</dd>
+                </div>
+                <div class="flex flex-wrap items-center gap-2">
+                  <dt class="font-medium text-[#14080E]">Location:</dt>
+                  <dd>{{ restaurant.location_text }}</dd>
+                </div>
+              </dl>
             {% endif %}
           </div>
+          <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm">
+            {% if outscraper_payload %}
+              <p class="font-semibold text-[#14080E]">Status: {{ outscraper_payload.get_status_display }}</p>
+              {% if outscraper_payload.discovered_menu_url %}
+                <p class="mt-1 break-all text-slate-600">We found a menu link: <a class="text-[#5C008B] underline" href="{{ outscraper_payload.discovered_menu_url }}" target="_blank" rel="noopener">{{ outscraper_payload.discovered_menu_url }}</a></p>
+              {% else %}
+                <p class="mt-1 text-slate-600">We'll notify you as soon as the search finishes.</p>
+              {% endif %}
+            {% else %}
+              <p class="font-semibold text-[#14080E]">Queued</p>
+              <p class="mt-1 text-slate-600">Your lookup request is in progress.</p>
+            {% endif %}
+          </div>
+        </div>
+      </section>
 
-          {% if show_start_trial %}
-            <form method="post" action="{% url 'billing-upgrade' %}">
-              {% csrf_token %}
-              <input type="hidden" name="next" value="{% url 'onboarding' %}">
-              <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
-                Start {{ trial_days }}-day trial
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Step 2</p>
+        <div class="mt-3 space-y-4">
+          <div>
+            <h2 class="text-lg font-semibold text-[#14080E]">Add your live menu link</h2>
+            <p class="mt-1 text-sm text-slate-600">We use your menu to tailor concept ideas and dish recommendations.</p>
+          </div>
+          {% if menu_success %}
+            <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+              Menu received! We're processing it now.
+            </div>
+          {% elif menu_error %}
+            <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+              {{ menu_error }}
+            </div>
+          {% endif %}
+          <form method="post" class="space-y-3">
+            {% csrf_token %}
+            <label class="block text-sm font-medium text-slate-700" for="menu_url">Restaurant menu URL</label>
+            <input id="menu_url" name="menu_url" type="url" required placeholder="https://"
+                   value="{{ restaurant.primary_menu_url }}"
+                   class="w-full rounded-xl border border-slate-300 px-4 py-2 text-sm focus:border-[#5C008B] focus:outline-none focus:ring-2 focus:ring-[#B993D6]">
+            <div class="flex flex-wrap items-center gap-3">
+              <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-[#5C008B] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#4a0178]">
+                Save menu link
               </button>
-            </form>
-          {% else %}
-            <div class="flex flex-wrap gap-3">
-              <a href="{% url 'billing' %}" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-[#14080E] transition hover:bg-slate-100">
-                Manage billing
-              </a>
-              {% if restaurant %}
-                <a href="{% url 'dashboard' restaurant.id %}" class="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600">
-                  Continue to dashboard
+              {% if restaurant and restaurant.primary_menu_url %}
+                <a href="{{ restaurant.primary_menu_url }}" target="_blank" rel="noopener" class="text-sm font-medium text-[#5C008B] underline">
+                  Preview current link
                 </a>
+              {% endif %}
+            </div>
+          </form>
+          {% if latest_menu_version %}
+            <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
+              <p class="font-semibold text-[#14080E]">Latest import: {{ latest_menu_version.get_status_display }}</p>
+              {% if latest_menu_version.source_url %}
+                <p class="mt-1 break-all">Source: {{ latest_menu_version.source_url }}</p>
               {% endif %}
             </div>
           {% endif %}
         </div>
       </section>
 
-      <section class="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-6 text-slate-600">
-        <p class="text-xs font-semibold uppercase text-slate-400">Step 2</p>
-        <h2 class="mt-2 text-lg font-semibold text-[#14080E]">Track menu processing</h2>
-        {% if jobs %}
-          <ul class="mt-4 space-y-2 text-sm">
-            {% for job in jobs %}
-              <li class="flex items-center justify-between rounded-xl bg-white p-3">
-                <span>{{ job.get_kind_display|default:job.kind }}</span>
-                <span class="text-xs font-medium uppercase text-slate-400">{{ job.get_status_display|default:job.status }}</span>
-              </li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          <p class="mt-4 text-sm">We'll keep an eye on your menu imports and alert you once everything is ready.</p>
-        {% endif %}
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Step 3</p>
+        <div class="mt-3 space-y-4">
+          <div>
+            <h2 class="text-lg font-semibold text-[#14080E]">Activate billing to continue</h2>
+            <p class="mt-1 text-sm text-slate-600">Secure your {{ trial_days }}-day free trial. You can cancel anytime before it ends.</p>
+          </div>
+          {% if subscription %}
+            <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
+              <p class="font-semibold text-[#14080E]">{{ subscription.get_status_display }}</p>
+              {% if trial_days_remaining is not None %}
+                <p class="mt-1">{{ trial_days_remaining }} day{{ trial_days_remaining|pluralize }} left in your trial.</p>
+              {% elif trial_ends %}
+                <p class="mt-1">Renews on {{ trial_ends|date:"F j, Y" }}.</p>
+              {% endif %}
+            </div>
+            {% if subscription_allows_dashboard %}
+              <a href="{{ dashboard_url }}" class="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600">
+                Continue to dashboard
+              </a>
+            {% elif subscription_requires_update %}
+              <form method="post" action="{% url 'billing-upgrade' %}" class="inline">
+                {% csrf_token %}
+                {% if dashboard_url %}
+                  <input type="hidden" name="next" value="{{ dashboard_url }}">
+                {% endif %}
+                <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+                  Update billing
+                </button>
+              </form>
+            {% endif %}
+          {% else %}
+            <form method="post" action="{% url 'billing-upgrade' %}" class="inline-flex flex-col gap-3 sm:flex-row sm:items-center">
+              {% csrf_token %}
+              {% if dashboard_url %}
+                <input type="hidden" name="next" value="{{ dashboard_url }}">
+              {% endif %}
+              <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-[#FF5C00] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]">
+                Start {{ trial_days }}-day trial
+              </button>
+              <span class="text-xs text-slate-500">No charges until your trial ends.</span>
+            </form>
+          {% endif %}
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Step 4</p>
+        <div class="mt-3 space-y-4">
+          <div>
+            <h2 class="text-lg font-semibold text-[#14080E]">Explore your creative workspace</h2>
+            <p class="mt-1 text-sm text-slate-600">We lined up a few tips so you can start generating concepts right away.</p>
+          </div>
+          {% include "_partials/onboarding_welcome.html" with restaurant=restaurant just_signed_up=just_signed_up dashboard_url=dashboard_url %}
+        </div>
       </section>
     </div>
   </div>

--- a/app/views.py
+++ b/app/views.py
@@ -199,13 +199,10 @@ def signup_view(request):
         email = (data.get("email") or "").strip()
         restaurant_name = (data.get("restaurant_name") or "").strip()
         location = (data.get("location") or "").strip()
-        raw_menu_url = (data.get("menu_url") or "").strip()
-        menu_url = raw_menu_url or None
         form_data = {
             "email": email,
             "restaurant_name": restaurant_name,
             "location": location,
-            "menu_url": raw_menu_url,
         }
 
         if is_json:
@@ -246,36 +243,21 @@ def signup_view(request):
                     account=account,
                     name=restaurant_name,
                     location_text=location,
-                    primary_menu_url=menu_url,
-                    menu_urls=[menu_url] if menu_url else [],
                 )
-
-                if menu_url:
-                    mv = models.MenuVersion.objects.create(
-                        restaurant=restaurant,
-                        source_url=menu_url,
-                        source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
-                        raw_markdown="",
-                        status=models.MenuVersion.Status.QUEUED,
+                payload = models.OutscraperPayload.objects.create(
+                    restaurant=restaurant,
+                    status=models.OutscraperPayload.Status.QUEUED,
+                    request_params={
+                        "query": f"{restaurant_name} {location}",
+                        "async": "false",
+                        "limit": 1,
+                    },
+                )
+                transaction.on_commit(
+                    lambda payload_id=str(payload.id): run_outscraper_search.delay(
+                        payload_id
                     )
-                    transaction.on_commit(
-                        lambda mv_id=str(mv.id): scrape_menu.delay(mv_id)
-                    )
-                else:
-                    payload = models.OutscraperPayload.objects.create(
-                        restaurant=restaurant,
-                        status=models.OutscraperPayload.Status.QUEUED,
-                        request_params={
-                            "query": f"{restaurant_name} {location}",
-                            "async": "false",
-                            "limit": 1,
-                        },
-                    )
-                    transaction.on_commit(
-                        lambda payload_id=str(payload.id): run_outscraper_search.delay(
-                            payload_id
-                        )
-                    )
+                )
         except IntegrityError:
             error_message = "An account with that email already exists."
             if is_json:
@@ -289,6 +271,7 @@ def signup_view(request):
         login(request, user)
         request.session["onboarding_account_id"] = str(account.id)
         request.session["onboarding_restaurant_id"] = str(restaurant.id)
+        request.session["just_signed_up"] = True
         redirect_url = reverse("onboarding")
         if is_json:
             return JsonResponse(
@@ -608,6 +591,11 @@ def onboarding_view(request):
     account = membership.account if membership else None
     restaurant = None
     subscription = None
+    latest_payload = None
+    latest_menu_version = None
+    menu_success = False
+    menu_error = ""
+
     if account:
         restaurant = (
             models.Restaurant.objects.filter(account=account)
@@ -620,7 +608,52 @@ def onboarding_view(request):
             .first()
         )
 
-    jobs = models.Job.objects.filter(user=request.user)
+    if restaurant:
+        latest_payload = (
+            models.OutscraperPayload.objects.filter(restaurant=restaurant)
+            .order_by("-created_at")
+            .first()
+        )
+        latest_menu_version = (
+            models.MenuVersion.objects.filter(restaurant=restaurant)
+            .order_by("-created_at")
+            .first()
+        )
+
+    if request.method == "POST":
+        menu_url = (request.POST.get("menu_url") or "").strip()
+        if not restaurant:
+            menu_error = "We couldn't find your restaurant record yet."
+        elif not menu_url:
+            menu_error = "Please provide a menu URL."
+        else:
+            restaurant.add_menu_url(menu_url)
+            restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
+            latest_menu_version = models.MenuVersion.objects.create(
+                restaurant=restaurant,
+                source_url=menu_url,
+                source_kind=models.MenuVersion.SourceKind.URL_SCRAPE,
+                raw_markdown="",
+                status=models.MenuVersion.Status.QUEUED,
+            )
+            transaction.on_commit(
+                lambda mv_id=str(latest_menu_version.id): scrape_menu.delay(mv_id)
+            )
+            menu_success = True
+
+    just_signed_up = request.session.pop("just_signed_up", False)
+    if request.method == "POST" and just_signed_up and not menu_success:
+        request.session["just_signed_up"] = True
+
+    subscription_allows_dashboard = False
+    subscription_requires_update = False
+    if subscription:
+        subscription_allows_dashboard = subscription.status in {
+            models.Subscription.Status.ACTIVE,
+            models.Subscription.Status.TRIALING,
+        }
+        subscription_requires_update = not subscription_allows_dashboard
+
     trial_days = getattr(settings, "STRIPE_TRIAL_DAYS", 14)
     trial_ends = subscription.current_period_end if subscription else None
     trial_days_remaining = None
@@ -628,8 +661,9 @@ def onboarding_view(request):
         remaining = subscription.current_period_end - timezone.now()
         trial_days_remaining = max(remaining.days, 0)
 
+    dashboard_url = reverse("dashboard", args=[restaurant.id]) if restaurant else ""
+
     context = {
-        "jobs": jobs,
         "restaurant": restaurant,
         "subscription": subscription,
         "trial_days": trial_days,
@@ -637,6 +671,14 @@ def onboarding_view(request):
         "trial_days_remaining": trial_days_remaining,
         "show_start_trial": not subscription
         or subscription.status == models.Subscription.Status.CANCELED,
+        "outscraper_payload": latest_payload,
+        "latest_menu_version": latest_menu_version,
+        "menu_success": menu_success,
+        "menu_error": menu_error,
+        "just_signed_up": just_signed_up,
+        "dashboard_url": dashboard_url,
+        "subscription_allows_dashboard": subscription_allows_dashboard,
+        "subscription_requires_update": subscription_requires_update,
     }
     return render(request, "onboarding.html", context)
 

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -51,7 +51,7 @@ class SignupViewTests(TestCase):
         self.assertEqual(restaurant.location_text, "City, State")
         self.assertIsNone(restaurant.primary_menu_url)
         self.assertEqual(restaurant.menu_urls, [])
-        self.assertEqual(body["redirect_url"], reverse("dashboard", args=[restaurant.id]))
+        self.assertEqual(body["redirect_url"], reverse("onboarding"))
 
         payload_obj = models.OutscraperPayload.objects.get()
         self.assertEqual(payload_obj.status, models.OutscraperPayload.Status.QUEUED)
@@ -62,7 +62,9 @@ class SignupViewTests(TestCase):
 
     @patch("app.views.run_outscraper_search")
     @patch("app.views.scrape_menu")
-    def test_form_signup_without_menu_triggers_outscraper(self, mock_scrape, mock_outscraper):
+    def test_form_signup_triggers_outscraper_and_redirects_to_onboarding(
+        self, mock_scrape, mock_outscraper
+    ):
         """HTML signup without menu URL should queue Outscraper and redirect."""
         form_data = {
             "email": "owner@example.com",
@@ -76,7 +78,7 @@ class SignupViewTests(TestCase):
             response = self.client.post(reverse("signup"), data=form_data)
 
         restaurant = models.Restaurant.objects.get()
-        self.assertRedirects(response, reverse("dashboard", args=[restaurant.id]))
+        self.assertRedirects(response, reverse("onboarding"))
         self.assertIn("_auth_user_id", self.client.session)
 
         payload_obj = models.OutscraperPayload.objects.get()
@@ -84,35 +86,57 @@ class SignupViewTests(TestCase):
         mock_outscraper.delay.assert_called_once_with(str(payload_obj.id))
         mock_scrape.delay.assert_not_called()
 
-    @patch("app.views.run_outscraper_search")
     @patch("app.views.scrape_menu")
-    def test_form_signup_with_menu_url_scrapes_immediately(self, mock_scrape, mock_outscraper):
-        """Providing a menu URL should create a queued menu version and scrape it."""
+    @patch("app.views.run_outscraper_search")
+    def test_onboarding_menu_submission_creates_menu_version(
+        self, mock_outscraper, mock_scrape
+    ):
+        """Submitting a menu URL on onboarding queues a scrape and saves the URL."""
         form_data = {
             "email": "owner@example.com",
             "password1": "pw",
             "password2": "pw",
             "restaurant_name": "Tasty Place",
             "location": "City, State",
-            "menu_url": "http://example.com/menu",
         }
 
         with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(reverse("signup"), data=form_data)
+            self.client.post(reverse("signup"), data=form_data)
 
         restaurant = models.Restaurant.objects.get()
-        self.assertRedirects(response, reverse("dashboard", args=[restaurant.id]))
-        self.assertEqual(models.OutscraperPayload.objects.count(), 0)
 
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("onboarding"),
+                data={"menu_url": "http://example.com/menu"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        restaurant.refresh_from_db()
+        self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
         menu_version = models.MenuVersion.objects.get()
         self.assertEqual(menu_version.source_url, "http://example.com/menu")
         self.assertEqual(menu_version.status, models.MenuVersion.Status.QUEUED)
-        self.assertEqual(menu_version.source_kind, models.MenuVersion.SourceKind.URL_SCRAPE)
         mock_scrape.delay.assert_called_once_with(str(menu_version.id))
-        mock_outscraper.delay.assert_not_called()
-        restaurant.refresh_from_db()
-        self.assertEqual(restaurant.primary_menu_url, "http://example.com/menu")
-        self.assertEqual(restaurant.menu_urls, ["http://example.com/menu"])
+        mock_outscraper.delay.assert_called()  # from signup
+
+    @patch("app.views.run_outscraper_search")
+    def test_onboarding_requires_menu_url(self, mock_outscraper):
+        """Posting without a URL should show an error message."""
+        form_data = {
+            "email": "owner@example.com",
+            "password1": "pw",
+            "password2": "pw",
+            "restaurant_name": "Tasty Place",
+            "location": "City, State",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(reverse("signup"), data=form_data)
+
+        response = self.client.post(reverse("onboarding"), data={"menu_url": ""})
+        self.assertContains(response, "Please provide a menu URL.")
+        self.assertEqual(models.MenuVersion.objects.count(), 0)
 
     def test_form_signup_with_existing_email_shows_error(self):
         """Duplicate email addresses should not trigger a server error."""


### PR DESCRIPTION
## Summary
- streamline signup to capture restaurant basics and queue Outscraper enrichment automatically
- rebuild the onboarding experience with step-based guidance, menu collection, billing, and welcome messaging
- add onboarding welcome partial and expand signup tests to cover the new flow

## Testing
- python manage.py test tests.test_signup -v 2

------
https://chatgpt.com/codex/tasks/task_e_68d6910ceae4833290ea90855eb77dfe