### PR TITLE
Add subtle scrollable content areas to dish cards

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -16,27 +16,29 @@
       {% if not dish.is_favorited %}
         <div class="flip-face front">
           <article class="h-full border border-slate-200 bg-white p-4 shadow-md flex flex-col gap-4">
-            <header class="space-y-3">
-              <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
-              {% if dish.description %}
-                <p class="text-slate-600 text-sm md:text-base line-clamp-4">{{ dish.description }}</p>
-              {% endif %}
-            </header>
+            <div class="dish-card-scroll flex-1 flex flex-col gap-4">
+              <header class="space-y-3">
+                <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
+                {% if dish.description %}
+                  <p class="text-slate-600 text-sm md:text-base">{{ dish.description }}</p>
+                {% endif %}
+              </header>
 
-            <div class="flex flex-wrap gap-2">
-              {% for tag in dish.category_tags %}
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
-                  {{ tag }}
-                </span>
-              {% endfor %}
-              {% for tag in dish.ingredient_overlap %}
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
-                  {{ tag }}
-                </span>
-              {% endfor %}
+              <div class="flex flex-wrap gap-2 pb-2">
+                {% for tag in dish.category_tags %}
+                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
+                    {{ tag }}
+                  </span>
+                {% endfor %}
+                {% for tag in dish.ingredient_overlap %}
+                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
+                    {{ tag }}
+                  </span>
+                {% endfor %}
+              </div>
             </div>
 
-            <footer class="mt-auto flex justify-end gap-2">
+            <footer class="flex justify-end gap-2 pt-1">
               {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
               <button
                 type="button"
@@ -83,19 +85,21 @@
             {% endif %}
           {% else %}
             <!-- No image? Show a clean, centered info front -->
-            <div class="relative flex flex-col items-center justify-center text-center p-4 {{HSM}} {{HMD}} {{HLG}}">
-              <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
-              {% if dish.description %}
-                <p class="mt-2 text-slate-600 text-sm md:text-base line-clamp-4">{{ dish.description }}</p>
-              {% endif %}
+            <div class="relative flex h-full flex-col text-center p-4 {{HSM}} {{HMD}} {{HLG}}">
+              <div class="dish-card-scroll flex-1 w-full flex flex-col items-center justify-center gap-3 pb-6">
+                <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
+                {% if dish.description %}
+                  <p class="text-slate-600 text-sm md:text-base">{{ dish.description }}</p>
+                {% endif %}
 
-              <div class="mt-3 flex flex-wrap justify-center gap-2">
-                {% for tag in dish.category_tags %}
-                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">{{ tag }}</span>
-                {% endfor %}
-                {% for tag in dish.ingredient_overlap %}
-                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">{{ tag }}</span>
-                {% endfor %}
+                <div class="flex flex-wrap justify-center gap-2">
+                  {% for tag in dish.category_tags %}
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">{{ tag }}</span>
+                  {% endfor %}
+                  {% for tag in dish.ingredient_overlap %}
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">{{ tag }}</span>
+                  {% endfor %}
+                </div>
               </div>
             </div>
           {% endif %}
@@ -153,35 +157,37 @@
 
         {# ---------------- BACK (DETAILS) ---------------- #}
         <div class="flip-face flip-back bg-white text-slate-800 rounded-2xl shadow-md border border-slate-200 p-4 flex flex-col gap-4 {{HSM}} {{HMD}} {{HLG}}">
-          <!-- Title & Description -->
-          <div class="flex-1 text-center space-y-3">
-            <h3 class="text-lg md:text-xl font-bold text-[#49475B] text-center">{{ dish.title }}</h3>
-            {% if dish.description %}
-              <p class="text-slate-600 text-sm md:text-base text-center line-clamp-6">{{ dish.description }}</p>
-            {% endif %}
-          </div>
+          <div class="dish-card-scroll flex-1 space-y-4">
+            <!-- Title & Description -->
+            <div class="text-center space-y-3">
+              <h3 class="text-lg md:text-xl font-bold text-[#49475B] text-center">{{ dish.title }}</h3>
+              {% if dish.description %}
+                <p class="text-slate-600 text-sm md:text-base text-center">{{ dish.description }}</p>
+              {% endif %}
+            </div>
 
-          <!-- Tags -->
-          <div class="flex flex-wrap justify-center gap-2">
-            {% if dish.enhancement_price_display %}
-              <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-semibold bg-[#ff4c4c] text-light border border-slate-200 shadow-sm">
-                {{ dish.enhancement_price_display }}
-              </span>
-            {% endif %}
-            {% for tag in dish.category_tags %}
-              <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
-                {{ tag }}
-              </span>
-            {% endfor %}
-            {% for tag in dish.ingredient_overlap %}
-              <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
-                {{ tag }}
-              </span>
-            {% endfor %}
+            <!-- Tags -->
+            <div class="flex flex-wrap justify-center gap-2 pb-1">
+              {% if dish.enhancement_price_display %}
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-semibold bg-[#ff4c4c] text-light border border-slate-200 shadow-sm">
+                  {{ dish.enhancement_price_display }}
+                </span>
+              {% endif %}
+              {% for tag in dish.category_tags %}
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+              {% for tag in dish.ingredient_overlap %}
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
+                  {{ tag }}
+                </span>
+              {% endfor %}
+            </div>
           </div>
 
           <!-- Actions (again, on BACK) -->
-          <div class="mt-auto flex justify-end gap-2 pt-3 border-t border-slate-200" data-no-flip>
+          <div class="flex justify-end gap-2 border-t border-slate-200 pt-3" data-no-flip>
             <button
               type="button"
               class="dish-delete-btn card-action-button text-red-500 hover:text-red-600"

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -46,6 +46,57 @@
     transform: rotateY(180deg);
   }
 
+  .dish-card-scroll {
+    position: relative;
+    overflow-y: auto;
+    padding-right: 0.35rem;
+    margin-right: -0.35rem;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    overscroll-behavior: contain;
+    --dish-scroll-fade: rgba(255, 255, 255, 0.95);
+  }
+
+  .dish-card-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  .dish-card-scroll::before,
+  .dish-card-scroll::after {
+    content: "";
+    position: sticky;
+    left: 0;
+    right: 0;
+    height: 1.75rem;
+    pointer-events: none;
+    z-index: 5;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .dish-card-scroll::before {
+    top: 0;
+    background: linear-gradient(to bottom, var(--dish-scroll-fade), transparent);
+  }
+
+  .dish-card-scroll::after {
+    bottom: 0;
+    background: linear-gradient(to top, var(--dish-scroll-fade), transparent);
+  }
+
+  .dish-card-scroll[data-scrollable="true"]::before,
+  .dish-card-scroll[data-scrollable="true"]::after {
+    opacity: 1;
+  }
+
+  .dish-card-scroll[data-at-top="true"]::before {
+    opacity: 0;
+  }
+
+  .dish-card-scroll[data-at-bottom="true"]::after {
+    opacity: 0;
+  }
+
   .clamp-3 {
     display: -webkit-box;
     -webkit-line-clamp: 3;
@@ -354,7 +405,49 @@
       return false;
     };
 
-    document.addEventListener("DOMContentLoaded", reorderDishCards);
+    const scrollHintSelector = ".dish-card-scroll";
+
+    const updateScrollHints = (container) => {
+      if (!container) {
+        return;
+      }
+
+      const scrollTop = container.scrollTop || 0;
+      const clientHeight = container.clientHeight || 0;
+      const scrollHeight = container.scrollHeight || 0;
+      const canScroll = scrollHeight > clientHeight + 1;
+
+      container.setAttribute("data-scrollable", canScroll ? "true" : "false");
+      container.setAttribute("data-at-top", scrollTop <= 1 ? "true" : "false");
+      container.setAttribute(
+        "data-at-bottom",
+        scrollTop + clientHeight >= scrollHeight - 1 ? "true" : "false"
+      );
+    };
+
+    const bindScrollHints = (container) => {
+      if (!container) {
+        return;
+      }
+
+      if (container.dataset.scrollHintBound === "true") {
+        updateScrollHints(container);
+        return;
+      }
+
+      container.dataset.scrollHintBound = "true";
+      updateScrollHints(container);
+      container.addEventListener("scroll", () => updateScrollHints(container));
+    };
+
+    const setupScrollHints = () => {
+      document.querySelectorAll(scrollHintSelector).forEach(bindScrollHints);
+    };
+
+    document.addEventListener("DOMContentLoaded", () => {
+      reorderDishCards();
+      setupScrollHints();
+    });
 
     const shouldShowLoading = (elt) =>
       elt && (elt.classList.contains("dish-variation-btn") || elt.classList.contains("favorite-btn"));
@@ -569,6 +662,8 @@
       if (dishTargetNeedsReorder(target)) {
         scheduleDishReorder();
       }
+
+      setupScrollHints();
     });
 
     document.body.addEventListener("click", function (evt) {
@@ -591,6 +686,10 @@
       }
 
       card.classList.toggle("show-back");
+    });
+
+    window.addEventListener("resize", () => {
+      document.querySelectorAll(scrollHintSelector).forEach(updateScrollHints);
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- wrap dish card fronts and backs in scrollable containers so long descriptions and tags no longer get clipped
- add hidden-scroll styling with fade hints to mimic the subtle scroll affordance used on the concept cards
- update the dish card enhancement script to initialise, refresh, and maintain the new scroll hint state after HTMX swaps and window resizes

## Testing
- python manage.py runserver 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68d6a5f9aa94833299726f9e23051c83