### PR TITLE
Add tag search view and make tags navigable

### DIFF
--- a/app/templates/app/dish_grid.html
+++ b/app/templates/app/dish_grid.html
@@ -5,7 +5,9 @@
     <p class="text-sm">{{ dish.description }}</p>
     <div>
       {% for tag in dish.category_tags %}
-      <span class="tag bg-orange-100 text-orange-800 px-1 mr-1">{{ tag }}</span>
+      <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}" class="tag bg-orange-100 text-orange-800 px-1 mr-1 inline-block no-underline">
+        {{ tag }}
+      </a>
       {% endfor %}
     </div>
   </div>

--- a/app/templates/concepts/_card.html
+++ b/app/templates/concepts/_card.html
@@ -50,9 +50,12 @@
             {% if concept.tags %}
               <div class="mt-3 flex flex-wrap justify-center gap-2">
                 {% for tag in concept.tags %}
-                  <span class="inline-flex items-center px-3 py-1 rounded-full text-xs md:text-sm font-medium bg-slate-100 text-[#49475B]">
+                  <a
+                    href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                    class="inline-flex items-center px-3 py-1 rounded-full text-xs md:text-sm font-medium bg-slate-100 text-[#49475B] no-underline"
+                  >
                     {{ tag }}
-                  </span>
+                  </a>
                 {% endfor %}
               </div>
             {% endif %}
@@ -82,9 +85,12 @@
           {% if concept.tags %}
             <div class="flex flex-wrap gap-2">
               {% for tag in concept.tags %}
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/15 text-[#49475B]">
+                <a
+                  href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                  class="inline-flex items-center px-3 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/15 text-[#49475B] no-underline"
+                >
                   {{ tag }}
-                </span>
+                </a>
               {% endfor %}
             </div>
           {% endif %}

--- a/app/templates/concepts/test.html
+++ b/app/templates/concepts/test.html
@@ -42,10 +42,10 @@
         <!-- Tags -->
         <div class="mt-3 flex flex-wrap justify-center gap-2">
           {% for tag in dish.category_tags %}
-            <span class="dish-tag dish-tag--category">{{ tag }}</span>
+            <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}" class="dish-tag dish-tag--category no-underline">{{ tag }}</a>
           {% endfor %}
           {% for tag in dish.ingredient_overlap %}
-            <span class="dish-tag dish-tag--ingredient">{{ tag }}</span>
+            <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}" class="dish-tag dish-tag--ingredient no-underline">{{ tag }}</a>
           {% endfor %}
         </div>
 

--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -26,14 +26,20 @@
 
               <div class="flex flex-wrap gap-2 pb-2">
                 {% for tag in dish.category_tags %}
-                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
+                  <a
+                    href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                    class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B] no-underline"
+                  >
                     {{ tag }}
-                  </span>
+                  </a>
                 {% endfor %}
                 {% for tag in dish.ingredient_overlap %}
-                  <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
+                  <a
+                    href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                    class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B] no-underline"
+                  >
                     {{ tag }}
-                  </span>
+                  </a>
                 {% endfor %}
               </div>
             </div>
@@ -94,10 +100,20 @@
 
                 <div class="flex flex-wrap justify-center gap-2">
                   {% for tag in dish.category_tags %}
-                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">{{ tag }}</span>
+                    <a
+                      href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                      class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B] no-underline"
+                    >
+                      {{ tag }}
+                    </a>
                   {% endfor %}
                   {% for tag in dish.ingredient_overlap %}
-                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">{{ tag }}</span>
+                    <a
+                      href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                      class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B] no-underline"
+                    >
+                      {{ tag }}
+                    </a>
                   {% endfor %}
                 </div>
               </div>
@@ -174,14 +190,20 @@
                 </span>
               {% endif %}
               {% for tag in dish.category_tags %}
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B]">
+                <a
+                  href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                  class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B] no-underline"
+                >
                   {{ tag }}
-                </span>
+                </a>
               {% endfor %}
               {% for tag in dish.ingredient_overlap %}
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B]">
+                <a
+                  href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                  class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B] no-underline"
+                >
                   {{ tag }}
-                </span>
+                </a>
               {% endfor %}
             </div>
           </div>

--- a/app/templates/search/results.html
+++ b/app/templates/search/results.html
@@ -1,0 +1,114 @@
+{% extends "layouts/app.html" %}
+
+{% block page_intro %}
+  <div class="space-y-1">
+    <h1 class="text-xl font-semibold text-[#14080E]">Tag results</h1>
+    {% if search_tag %}
+      <p class="text-sm text-slate-500">Showing concepts and dishes tagged with “{{ search_tag }}”.</p>
+    {% else %}
+      <p class="text-sm text-slate-500">Select a tag to explore matching concepts and dishes.</p>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block page_content %}
+  <div class="px-4 py-6 space-y-8">
+    <section class="space-y-3">
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-[#14080E]">Concepts</h2>
+        <span class="text-sm text-slate-500">{{ concept_results|length }} found</span>
+      </header>
+      {% if concept_results %}
+        <ul class="space-y-4">
+          {% for concept in concept_results %}
+            <li class="rounded-xl border border-slate-200 bg-white/90 shadow-sm p-4">
+              <div class="space-y-2">
+                <div class="flex items-start justify-between gap-3">
+                  <div class="space-y-1">
+                    <h3 class="text-base font-semibold text-[#14080E]">{{ concept.name }}</h3>
+                    {% if concept.subtitle %}
+                      <p class="text-sm text-slate-600">{{ concept.subtitle }}</p>
+                    {% endif %}
+                  </div>
+                  <a href="{% url 'dish_detail' concept.id %}"
+                     class="text-sm font-semibold text-[#f08000] transition hover:text-[#d96f00] no-underline">
+                    View dishes
+                  </a>
+                </div>
+                {% if concept.tags %}
+                  <div class="flex flex-wrap gap-2">
+                    {% for tag in concept.tags %}
+                      <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                         class="inline-flex items-center px-3 py-1 rounded-full text-xs md:text-sm font-medium bg-slate-100 text-[#49475B] no-underline">
+                        {{ tag }}
+                      </a>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-sm text-slate-500">
+          {% if search_tag %}
+            No concepts found for this tag.
+          {% else %}
+            Pick a tag to see matching concepts.
+          {% endif %}
+        </p>
+      {% endif %}
+    </section>
+
+    <section class="space-y-3">
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-[#14080E]">Dishes</h2>
+        <span class="text-sm text-slate-500">{{ dish_results|length }} found</span>
+      </header>
+      {% if dish_results %}
+        <ul class="space-y-4">
+          {% for dish in dish_results %}
+            <li class="rounded-xl border border-slate-200 bg-white/90 shadow-sm p-4">
+              <div class="space-y-2">
+                <div class="space-y-1">
+                  <a href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                     class="text-base font-semibold text-[#14080E] transition hover:text-[#f08000] no-underline">
+                    {{ dish.title }}
+                  </a>
+                  {% if dish.description %}
+                    <p class="text-sm text-slate-600">{{ dish.description }}</p>
+                  {% endif %}
+                  <p class="text-xs uppercase tracking-wide text-slate-400">
+                    Concept: {{ dish.parent_concept.name }}
+                  </p>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  {% for tag in dish.category_tags %}
+                    <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                       class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#B993D6]/20 text-[#49475B] no-underline">
+                      {{ tag }}
+                    </a>
+                  {% endfor %}
+                  {% for tag in dish.ingredient_names %}
+                    <a href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
+                       class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-medium bg-[#58B09C]/20 text-[#49475B] no-underline">
+                      {{ tag }}
+                    </a>
+                  {% endfor %}
+                </div>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-sm text-slate-500">
+          {% if search_tag %}
+            No dishes found for this tag.
+          {% else %}
+            Pick a tag to see matching dishes.
+          {% endif %}
+        </p>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -10,7 +10,8 @@ from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
-from django.db.models import Exists, Max, OuterRef, Prefetch
+from django.db.models import Exists, Max, OuterRef, Prefetch, Q, TextField
+from django.db.models.functions import Cast
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -734,6 +735,57 @@ def concepts_view(request):
         favorites = getattr(concept, "_favorites_for_request_user", [])
         concept.is_favorited_for_user = bool(favorites)
     return render(request, "concepts/grid.html", {"concepts": concepts})
+
+
+@login_required
+def tag_search_view(request):
+    """Search concepts and dishes by tag for the current user's restaurants."""
+
+    search_tag = (request.GET.get("tag") or request.GET.get("q") or "").strip()
+    membership = models.Membership.objects.filter(user=request.user).select_related(
+        "account"
+    ).first()
+
+    restaurant_ids: List[str] = []
+    if membership:
+        restaurant_ids = list(
+            models.Restaurant.objects.filter(account=membership.account)
+            .values_list("id", flat=True)
+        )
+
+    concept_results: List[models.Concept] = []
+    dish_results: List[models.DishIdea] = []
+
+    if search_tag and restaurant_ids:
+        concept_results = list(
+            models.Concept.objects.filter(restaurant_id__in=restaurant_ids)
+            .annotate(tags_text=Cast("tags", TextField()))
+            .filter(tags_text__icontains=search_tag)
+            .order_by("-created_at")[:25]
+        )
+
+        dish_results = list(
+            models.DishIdea.objects.filter(
+                restaurant_id__in=restaurant_ids, is_deleted=False
+            )
+            .annotate(
+                category_text=Cast("category_tags", TextField()),
+                ingredient_text=Cast("ingredient_names", TextField()),
+            )
+            .filter(
+                Q(category_text__icontains=search_tag)
+                | Q(ingredient_text__icontains=search_tag)
+            )
+            .select_related("parent_concept")
+            .order_by("-created_at")[:25]
+        )
+
+    context = {
+        "search_tag": search_tag,
+        "concept_results": concept_results,
+        "dish_results": dish_results,
+    }
+    return render(request, "search/results.html", context)
 
 
 @login_required

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path("concepts/favorites/", app_views.concepts_favorites_view, name="concepts-favorites"),
     path("concepts/<uuid:concept_id>/favorite/", app_views.concept_favorite_view, name="concept-favorite"),
     path("concepts/<uuid:concept_id>/background/",app_views.concept_background_view, name="concept-background",),
+    path("search/", app_views.tag_search_view, name="tag-search"),
     path("dishes/<uuid:concept_id>/generate/", app_views.dishes_generate_view, name="dishes-generate"),
     path("dishes/<uuid:concept_id>/", app_views.dish_detail_view, name="dish_detail"),
 

--- a/tests/test_tag_search.py
+++ b/tests/test_tag_search.py
@@ -1,0 +1,106 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from app import models
+
+
+class TagSearchViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("searcher@example.com", password="pw12345")
+        self.account = models.Account.objects.create(name="Primary")
+        models.Membership.objects.create(account=self.account, user=self.user)
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="Testaurant",
+            location_text="City",
+        )
+
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="model",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=concept_run,
+            name="Harvest Nights",
+            subtitle="Cozy autumn specials",
+            reasoning="Celebrates seasonal produce",
+            tags=["Seasonal", "Local"],
+            rank_order=1,
+        )
+
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="model",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=self.concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        self.dish = models.DishIdea.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=dish_run,
+            parent_concept=self.concept,
+            title="Sweet Corn Bisque",
+            description="Silky corn soup",
+            ingredient_names=["Sweet corn", "Cream"],
+            category_tags=["Seasonal", "Comfort"],
+        )
+
+        self.client.login(username="searcher@example.com", password="pw12345")
+
+    def test_tag_search_returns_concepts_and_dishes(self):
+        response = self.client.get(reverse("tag-search"), {"tag": "seasonal"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.concept.name)
+        self.assertContains(response, self.dish.title)
+        self.assertContains(response, self.dish.parent_concept.name)
+
+    def test_tag_search_excludes_other_accounts(self):
+        other_account = models.Account.objects.create(name="Other")
+        other_restaurant = models.Restaurant.objects.create(
+            account=other_account,
+            name="Elsewhere",
+            location_text="Town",
+        )
+        other_user = User.objects.create_user("other@example.com", password="pw")
+        other_run = models.IdeationRun.objects.create(
+            restaurant=other_restaurant,
+            initiated_by_user=other_user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="model",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        models.Concept.objects.create(
+            restaurant=other_restaurant,
+            ideation_run=other_run,
+            name="Spicy Night",
+            subtitle="Bold flavors",
+            reasoning="Focus on heat",
+            tags=["Seasonal"],
+            rank_order=1,
+        )
+
+        response = self.client.get(reverse("tag-search"), {"tag": "seasonal"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.concept.name)
+        self.assertNotContains(response, "Spicy Night")
+
+    def test_tag_search_requires_login(self):
+        self.client.logout()
+        response = self.client.get(reverse("tag-search"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response["Location"])


### PR DESCRIPTION
## Summary
- make concept and dish tags link to a new tag search route without changing their visual styling
- add a tag search view and template to list matching concepts and dishes for the signed-in user
- cover the new behaviour with focused view tests

## Testing
- python manage.py test tests.test_tag_search

------
https://chatgpt.com/codex/tasks/task_e_68d6b841f208833285a827610c76caac