### PR TITLE
Add contextual AI prompt component

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -1,0 +1,135 @@
+{% load static %}
+{% with root_id=form_id|default:'ai-input' %}
+  {% with placeholders_id=root_id|add:'-placeholders' suggestions_id=root_id|add:'-suggestions' indicator_id=root_id|add:'-indicator' %}
+    {{ placeholder_samples|json_script:placeholders_id }}
+    {{ suggestions|json_script:suggestions_id }}
+    <div id="{{ root_id }}-wrapper" data-ai-input="{{ root_id }}" class="space-y-3">
+      <form
+        id="{{ root_id }}"
+        hx-post="{{ action_url }}"
+        hx-target="{{ target }}"
+        hx-swap="{{ hx_swap|default:'innerHTML' }}"
+        hx-indicator="#{{ indicator_id }}"
+        class="flex flex-col gap-3 sm:flex-row sm:items-center"
+      >
+        <div class="relative flex-1">
+          <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[#f08000]">
+            <i class="fa-solid fa-wand-magic-sparkles text-base"></i>
+          </span>
+          <input
+            type="text"
+            name="prompt"
+            id="{{ root_id }}-field"
+            value="{{ initial_value|default:'' }}"
+            placeholder="{{ placeholder_samples|first|default:'Try: Fall brunch specials' }}"
+            class="w-full rounded-xl border border-slate-200 bg-white/90 px-11 py-3 text-sm text-[#14080E] shadow-sm transition focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+            autocomplete="off"
+          />
+          <button
+            type="submit"
+            class="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 rounded-full bg-[#58B09C] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#43907d] focus:outline-none focus:ring-2 focus:ring-[#58B09C]/40"
+          >
+            <span>Run</span>
+            <i class="fa-solid fa-paper-plane text-[10px]"></i>
+          </button>
+        </div>
+        <button
+          type="button"
+          data-inspire
+          class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#f08000] via-[#f69b2d] to-[#d96f00] px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#f08000]/60"
+        >
+          <span>Inspire Me</span>
+          <i class="fa-solid fa-sparkles text-xs"></i>
+        </button>
+      </form>
+      <div
+        id="{{ indicator_id }}"
+        class="hidden items-center justify-start gap-2 text-sm text-[#49475B] sm:justify-end"
+      >
+        <span class="inline-flex h-2.5 w-2.5 animate-ping rounded-full bg-[#B993D6]"></span>
+        <span class="font-medium">Gathering ideas…</span>
+      </div>
+      {% if suggestions %}
+        <div class="flex flex-wrap gap-2">
+          {% for suggestion in suggestions %}
+            <button
+              type="button"
+              data-suggestion="{{ suggestion }}"
+              class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#B993D6]/90 via-[#c7a6e6]/80 to-[#B993D6]/90 px-4 py-1.5 text-xs font-medium text-white shadow-sm transition-transform hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#B993D6]/50"
+            >
+              <i class="fa-solid fa-lightbulb text-[10px]"></i>
+              <span>{{ suggestion }}</span>
+            </button>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+    <style>
+      #{{ indicator_id }}.htmx-request {
+        display: flex;
+      }
+    </style>
+    <script>
+      (function () {
+        const root = document.getElementById("{{ root_id }}-wrapper");
+        if (!root || root.dataset.aiInitialized === "true") {
+          return;
+        }
+        root.dataset.aiInitialized = "true";
+
+        const form = root.querySelector("form");
+        const input = root.querySelector('input[name="prompt"]');
+        const placeholderEl = document.getElementById("{{ placeholders_id }}");
+        const suggestionEl = document.getElementById("{{ suggestions_id }}");
+        let placeholders = [];
+        let suggestions = [];
+
+        try {
+          placeholders = JSON.parse(placeholderEl ? placeholderEl.textContent : "[]");
+        } catch (error) {
+          placeholders = [];
+        }
+        try {
+          suggestions = JSON.parse(suggestionEl ? suggestionEl.textContent : "[]");
+        } catch (error) {
+          suggestions = [];
+        }
+
+        if (placeholders.length > 1) {
+          let index = 0;
+          setInterval(function () {
+            index = (index + 1) % placeholders.length;
+            if (!input) {
+              return;
+            }
+            if (document.activeElement !== input || !input.value) {
+              input.placeholder = placeholders[index];
+            }
+          }, 4200);
+        }
+
+        root.querySelectorAll('[data-suggestion]').forEach(function (button) {
+          button.addEventListener('click', function () {
+            if (!input) {
+              return;
+            }
+            input.value = button.getAttribute('data-suggestion') || '';
+            form.requestSubmit();
+          });
+        });
+
+        const inspireButton = root.querySelector('[data-inspire]');
+        if (inspireButton) {
+          inspireButton.addEventListener('click', function () {
+            const pool = suggestions.concat(placeholders);
+            const choice = pool[Math.floor(Math.random() * pool.length)] || 'Seasonal chef specials';
+            if (input) {
+              input.value = choice;
+              form.requestSubmit();
+            }
+          });
+        }
+      })();
+    </script>
+  {% endwith %}
+{% endwith %}

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -1,51 +1,25 @@
 {% extends "layouts/app.html" %}
 
 {% block page_intro %}
-  <div class="flex space-y-1 justify-between items-center">
+  <div class="space-y-1">
+    <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Concepts</p>
     <h1 class="text-xl font-semibold text-[#14080E]">Concept Discovery</h1>
-    <p>
-<button
-  id="generateBtn"
-  hx-get="{% url 'concepts-generate' %}"
-  hx-target="#concepts-grid"
-  hx-swap="innerHTML"
-  data-overlay="true"
-  data-messages='["Cooking up ideas…", "Almost there…", "Plating concepts!"]'
-  class="inline-flex items-center gap-2 rounded-full bg-[#FF5C00]/10 px-4 py-2 text-sm font-semibold text-[#FF5C00] transition hover:-translate-y-0.5 hover:bg-[#FF5C00]/20"
->
-  <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[#FF5C00] text-white">
-    <svg
-      id="concepts-loading"
-      class="hidden h-3.5 w-3.5 animate-spin"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-    </svg>
-    <i class="text-md fa-solid fa-circle-plus" aria-hidden="true"></i>
-  </span>
-  <span class="button-text">Concepts</span>
-</button>
-
-    </p>
+    <p class="text-sm text-slate-600">Keep momentum going with contextual prompts tailored to your restaurant.</p>
   </div>
 {% endblock %}
 
 {% block page_content %}
-{% include "concepts/_card_assets.html" %}
-<style>
-  #concepts-loading.htmx-request {
-    display: inline-block !important;
-  }
-</style>
-<div class="max-w-7xl mx-auto px-4 py-4 space-y-3">
+  {% include "concepts/_card_assets.html" %}
+  <div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
+    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div class="space-y-4">
+        <p class="text-sm font-medium text-[#49475B]">Try a suggestion below or type your own focus to refresh the grid.</p>
+        {% include "_partials/contextual_ai_input.html" with form_id="concepts-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders suggestions=concept_prompt_suggestions %}
+      </div>
+    </section>
 
-  <div id="concepts-grid" class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4
-            gap-0 sm:gap-0 md:gap-3 lg:gap-4 xl:gap-5">
-    {% include 'concepts/_concepts_grid.html' %}
+    <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+      {% include 'concepts/_concepts_grid.html' %}
+    </div>
   </div>
-
-</div>
 {% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -14,6 +14,25 @@
 
 {% block page_content %}
   <div class="px-4 py-6 space-y-6">
+    {% include "concepts/_card_assets.html" %}
+    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div class="space-y-5">
+        <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-wide text-[#B993D6]">Idea launcher</p>
+            <h2 class="text-lg font-semibold text-[#14080E]">Jumpstart new concepts</h2>
+            <p class="text-sm text-[#49475B]">Type your own spark, tap a chip, or let Appertivo surprise you.</p>
+          </div>
+        </div>
+        {% include "_partials/contextual_ai_input.html" with form_id="dashboard-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders suggestions=concept_prompt_suggestions %}
+        <div class="rounded-xl border border-dashed border-[#B993D6]/30 bg-[#F8F5FF] px-4 py-6">
+          <div id="concepts-grid" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <p class="col-span-full text-sm text-[#49475B]">We&rsquo;ll drop fresh ideas here the moment you launch a run.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <div class="grid gap-4 lg:grid-cols-3">
       <section class="lg:col-span-2 rounded-2xl border border-slate-200 bg-white p-6">
         <div class="flex items-start justify-between gap-4">

--- a/app/views.py
+++ b/app/views.py
@@ -38,6 +38,7 @@ load_dotenv()
 _openai_api_key = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=_openai_api_key) if _openai_api_key else None
 import datetime
+from itertools import islice
 
 from app.tasks import create_ideation_run
 
@@ -46,6 +47,12 @@ logger = logging.getLogger(__name__)
 
 
 DEMO_USER_ID = 17
+
+DEFAULT_PROMPT_PLACEHOLDERS = [
+    "Try: Fall brunch specials",
+    "Try: Quick lunch menu",
+    "Try: New dessert twists",
+]
 
 class ConceptList(BaseModel):
     concepts: List[str]
@@ -73,6 +80,90 @@ def _get_default_plan() -> models.Plan:
         code=getattr(settings, "STRIPE_PLAN_CODE", "pro"), defaults=defaults
     )
     return plan
+
+
+def _current_season(current_date: Optional[datetime.date] = None) -> str:
+    """Return a friendly season label for the given date."""
+
+    if current_date is None:
+        try:
+            current_date = timezone.localdate()
+        except Exception:  # pragma: no cover - fallback for naive environments
+            current_date = datetime.date.today()
+
+    month = current_date.month
+    if month in {12, 1, 2}:
+        return "Winter"
+    if month in {3, 4, 5}:
+        return "Spring"
+    if month in {6, 7, 8}:
+        return "Summer"
+    return "Autumn"
+
+
+def build_prompt_suggestions(
+    restaurant: Optional[models.Restaurant],
+    *,
+    max_items: int = 4,
+) -> List[str]:
+    """Create contextual suggestion chips for the AI input component."""
+
+    seen: set[str] = set()
+    suggestions: List[str] = []
+
+    def _add_suggestion(value: Optional[str]) -> None:
+        if not value:
+            return
+        text = value.strip()
+        if not text or text.lower() in seen:
+            return
+        seen.add(text.lower())
+        suggestions.append(text)
+
+    season = _current_season()
+
+    if restaurant:
+        context_data = restaurant.context_json or {}
+        about_data = restaurant.about_json or {}
+
+        cuisine = context_data.get("category") or context_data.get("cuisine")
+        if isinstance(cuisine, (list, tuple)):
+            cuisine = cuisine[0] if cuisine else None
+        if isinstance(cuisine, str):
+            _add_suggestion(f"{cuisine} chef's table")
+
+        city = context_data.get("city") or getattr(restaurant, "location_text", "")
+        if isinstance(city, str) and city:
+            parts = city.split(",")
+            city_name = parts[0].strip()
+            if city_name:
+                _add_suggestion(f"{city_name} neighborhood favorites")
+
+        review_tags = context_data.get("reviews_tags") or []
+        if isinstance(review_tags, list) and review_tags:
+            first_tag = str(review_tags[0]).strip()
+            if first_tag:
+                _add_suggestion(f"Lean into {first_tag} vibes")
+
+        highlights = about_data.get("Highlights") if isinstance(about_data, dict) else {}
+        if isinstance(highlights, dict) and highlights:
+            first_highlight = next(iter(highlights.keys()), "")
+            if first_highlight:
+                _add_suggestion(f"Showcase {first_highlight.lower()} partners")
+
+        _add_suggestion(f"{season} market specials")
+
+    fallback_options = [
+        "Seasonal chef specials",
+        "Comfort classics night",
+        "Weekend brunch board",
+        "Happy hour upgrades",
+    ]
+
+    for option in fallback_options:
+        _add_suggestion(option)
+
+    return list(islice(suggestions, max_items))
 
 
 def _stripe_timestamp(value: Optional[int]) -> datetime.datetime:
@@ -546,6 +637,9 @@ def dashboard(request, restaurant_id):
         ),
         "tbd_message": "Personalized tips will appear here soon.",
         "prompt_for_menu": not bool(restaurant.primary_menu_url),
+        "concept_generate_url": reverse("concepts-generate"),
+        "concept_prompt_placeholders": DEFAULT_PROMPT_PLACEHOLDERS,
+        "concept_prompt_suggestions": build_prompt_suggestions(restaurant),
     }
     return render(request, "dashboard.html", context)
 
@@ -796,6 +890,17 @@ def manual_menu_view(request):
 @login_required
 def concepts_view(request):
     """Display latest concepts with favorite state for the user."""
+    membership = models.Membership.objects.filter(user=request.user).select_related(
+        "account"
+    ).first()
+    restaurant = None
+    if membership:
+        restaurant = (
+            models.Restaurant.objects.filter(account=membership.account)
+            .order_by("created_at")
+            .first()
+        )
+
     concepts_qs = models.Concept.objects.order_by("-created_at").annotate(
         has_dishes=Exists(
             models.DishIdea.objects.filter(
@@ -815,7 +920,17 @@ def concepts_view(request):
     for concept in concepts:
         favorites = getattr(concept, "_favorites_for_request_user", [])
         concept.is_favorited_for_user = bool(favorites)
-    return render(request, "concepts/grid.html", {"concepts": concepts})
+    return render(
+        request,
+        "concepts/grid.html",
+        {
+            "concepts": concepts,
+            "restaurant": restaurant,
+            "concept_generate_url": reverse("concepts-generate"),
+            "concept_prompt_placeholders": DEFAULT_PROMPT_PLACEHOLDERS,
+            "concept_prompt_suggestions": build_prompt_suggestions(restaurant),
+        },
+    )
 
 
 @login_required
@@ -873,10 +988,19 @@ def tag_search_view(request):
 def concepts_generate_view(request):
     membership = models.Membership.objects.filter(user=request.user).first()
     restaurant = models.Restaurant.objects.filter(account=membership.account).first()
+    raw_prompt = (request.POST.get("prompt") or "").strip()
+    user_prompt = raw_prompt[:280]
+
+    session_concepts = [
+        name.strip()
+        for name in (request.session.get("generated_concepts") or [])
+        if name and str(name).strip()
+    ]
     previous_concepts = list(
-            Concept.objects.filter(restaurant=restaurant)
-            .order_by("-created_at")
-            .values_list("name", flat=True)[:27])
+        models.Concept.objects.filter(restaurant=restaurant)
+        .order_by("-created_at")
+        .values_list("name", flat=True)[:27]
+    )
 
     logger.info(f"previous concepts: {previous_concepts}")
     if restaurant.active_menu_version:
@@ -889,6 +1013,13 @@ def concepts_generate_view(request):
     Current Restaurant Menu:  {restaurant_menu}
     About Services:  {restaurant.about_json}
     """
+    if session_concepts:
+        context += (
+            "\nPreviously generated concept names to avoid: "
+            + ", ".join(session_concepts[:15])
+        )
+    if user_prompt:
+        context += f"\nUser special instructions: {user_prompt}"
     # Schema definition for structured output
     schema = {
         "name": "concept_list",
@@ -966,6 +1097,12 @@ def concepts_generate_view(request):
             "closely duplicate them: "
             + ", ".join(previous_concepts)
             + "."
+        )
+
+    if user_prompt:
+        system_prompt += (
+            "\n                **Special Focus**: Highlight concepts inspired by: "
+            + user_prompt
         )
 
     response = client.responses.create(

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -107,6 +107,27 @@ class ViewSmokeTests(TestCase):
         resp = self.client.get(reverse("manual-menu"))
         self.assertEqual(resp.status_code, 200)
 
+    def test_dashboard_displays_contextual_ai_component(self):
+        self.restaurant.context_json = {
+            "category": "Italian",
+            "city": "Austin",
+            "reviews_tags": ["cozy ambiance"],
+        }
+        self.restaurant.save(update_fields=["context_json"])
+
+        resp = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
+        self.assertContains(resp, "Inspire Me")
+        self.assertContains(resp, "Italian chef&#x27;s table")
+
+    def test_concepts_page_includes_contextual_ai_input(self):
+        self._create_concepts()
+        self.restaurant.context_json = {"category": "Latin", "city": "Denver"}
+        self.restaurant.save(update_fields=["context_json"])
+
+        resp = self.client.get(reverse("concepts"))
+        self.assertContains(resp, "concepts-ai-input")
+        self.assertContains(resp, "Inspire Me")
+
     def test_concepts_and_generation(self):
         self._create_concepts()
         resp = self.client.get(reverse("concepts"))

--- a/tests/test_llm_views_tasks.py
+++ b/tests/test_llm_views_tasks.py
@@ -285,6 +285,38 @@ class SessionHistoryTests(TestCase):
         self.assertIn("Concept Title 1", stored_concepts)
 
     @patch("app.views.client")
+    def test_concept_generation_accepts_user_prompt(self, mock_client):
+        payload = {
+            "concepts": [
+                {
+                    "title": f"Prompt Concept {i}",
+                    "subtitle": "",
+                    "reasoning": "",
+                    "tags": ["tag"],
+                }
+                for i in range(1, 10)
+            ]
+        }
+        mock_client.responses.create.return_value = self._fake_response(payload)
+
+        self.client.login(username="owner@example.com", password="safe-pass")
+        response = self.client.post(
+            reverse("concepts-generate"), {"prompt": "Vegan brunch spotlight"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        _, kwargs = mock_client.responses.create.call_args
+        messages = kwargs.get("input", [])
+        self.assertGreaterEqual(len(messages), 2)
+        system_content = messages[0]["content"]
+        context_content = messages[1]["content"]
+
+        self.assertIn("Vegan brunch spotlight", system_content)
+        self.assertIn(
+            "User special instructions: Vegan brunch spotlight", context_content
+        )
+
+    @patch("app.views.client")
     def test_dish_generation_records_session_history(self, mock_client):
         dishes_payload = {
             "dishes": [


### PR DESCRIPTION
## Summary
- add a reusable contextual AI input partial with suggestion chips, Inspire Me action, and loading treatment
- surface the component on the dashboard and concepts pages using restaurant-driven placeholder data
- accept user prompts in concept generation and cover the flow with new tests

## Testing
- python manage.py test


------
https://chatgpt.com/codex/tasks/task_e_68d6c4b0a5f08332827fc11e635c84a8