### PR TITLE
Refine dashboard restaurant management layout

### DIFF
--- a/app/templates/_partials/menu_modal.html
+++ b/app/templates/_partials/menu_modal.html
@@ -1,26 +1,146 @@
-<div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-  <div class="bg-white rounded-xl shadow-lg w-full max-w-lg p-6 space-y-4">
-    <h2 class="text-xl font-bold text-gray-800">Provide Your Menu</h2>
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+  <div class="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-2xl">
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h2 class="text-xl font-semibold text-[#14080E]">Provide Your Menu</h2>
+        <p class="mt-1 text-sm text-slate-600">Add links, paste your menu, or upload a PDF so Appertivo has the latest details.</p>
+      </div>
+      <button
+        type="button"
+        class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+        onclick="document.getElementById('menu-modal').innerHTML=''"
+      >
+        <span class="sr-only">Close</span>
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+    </div>
+
     <form
       hx-post="{% url 'upload_menu' restaurant.id %}"
       hx-target="#restaurant-status"
       hx-swap="outerHTML"
       hx-encoding="multipart/form-data"
       hx-on::after-request="document.getElementById('menu-modal').innerHTML=''"
+      class="mt-6 space-y-5"
+      data-menu-manager
     >
-      <label class="block text-sm font-medium">Menu URL</label>
-      <input type="url" name="menu_url" class="w-full border rounded p-2 mb-3">
-      
-      <label class="block text-sm font-medium">Paste Menu Text</label>
-      <textarea name="menu_text" rows="4" class="w-full border rounded p-2 mb-3"></textarea>
-      
-      <label class="block text-sm font-medium">Upload PDF</label>
-      <input type="file" name="menu_pdf" accept="application/pdf" class="w-full border rounded p-2 mb-3">
+      {% csrf_token %}
+      <div>
+        <div class="flex items-center justify-between gap-2">
+          <h3 class="text-sm font-semibold text-[#14080E]">Menu URLs</h3>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-[#14080E] transition hover:bg-slate-100"
+            data-menu-url-add
+          >
+            <span class="text-base leading-none">＋</span>
+            Add URL
+          </button>
+        </div>
+        <div class="mt-3 space-y-3" data-menu-url-list>
+          {% if restaurant.menu_urls %}
+            {% for url in restaurant.menu_urls %}
+              <div class="flex items-center gap-2" data-menu-url-row>
+                <input
+                  type="url"
+                  name="menu_url"
+                  value="{{ url }}"
+                  placeholder="https://example.com/menu"
+                  class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+                >
+                <button
+                  type="button"
+                  class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                  data-menu-url-remove
+                >
+                  <span class="sr-only">Remove URL</span>
+                  <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+              </div>
+            {% endfor %}
+          {% else %}
+            <div class="flex items-center gap-2" data-menu-url-row>
+              <input
+                type="url"
+                name="menu_url"
+                placeholder="https://example.com/menu"
+                class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+              >
+              <button
+                type="button"
+                class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                data-menu-url-remove
+              >
+                <span class="sr-only">Remove URL</span>
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+              </button>
+            </div>
+          {% endif %}
+        </div>
+        <template data-menu-url-template>
+          <div class="flex items-center gap-2" data-menu-url-row>
+            <input
+              type="url"
+              name="menu_url"
+              placeholder="https://example.com/menu"
+              class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+            >
+            <button
+              type="button"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+              data-menu-url-remove
+            >
+              <span class="sr-only">Remove URL</span>
+              <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+          </div>
+        </template>
+      </div>
 
-      <div class="flex justify-end space-x-2">
-        <button type="button" onclick="document.getElementById('menu-modal').innerHTML=''"
-                class="px-4 py-2 bg-gray-300 rounded">Cancel</button>
-        <button type="submit" class="px-4 py-2 bg-[#f08000] text-white rounded">Submit</button>
+      <div class="space-y-2">
+        <h3 class="text-sm font-semibold text-[#14080E]">Menu content</h3>
+        <textarea
+          name="menu_text"
+          rows="8"
+          placeholder="Appetizers\n- Charcuterie Board"
+          class="w-full rounded-xl border border-slate-200 px-3 py-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+        ></textarea>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <input
+          type="file"
+          id="menu-pdf-input-modal-{{ restaurant.id }}"
+          name="menu_pdf"
+          accept="application/pdf"
+          class="sr-only"
+          data-menu-file
+        >
+        <label
+          for="menu-pdf-input-modal-{{ restaurant.id }}"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-[#14080E] shadow-sm transition hover:bg-slate-100"
+        >
+          <i class="fa-solid fa-file-arrow-up" aria-hidden="true"></i>
+          Choose file
+        </label>
+        <span class="text-xs text-slate-500" data-menu-file-name>No file chosen</span>
+      </div>
+
+      <div class="flex justify-end gap-3">
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
+          onclick="document.getElementById('menu-modal').innerHTML=''"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="inline-flex items-center gap-2 rounded-full bg-[#f08000] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#d96f00]"
+        >
+          <i class="fa-solid fa-paper-plane" aria-hidden="true"></i>
+          Submit
+        </button>
       </div>
     </form>
   </div>

--- a/app/templates/_partials/restaurant_status.html
+++ b/app/templates/_partials/restaurant_status.html
@@ -1,42 +1,296 @@
-{% if menu_version %}
-  {% if menu_version.status == 'succeeded' %}
-    <div class="flex items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
-      <div class="flex items-center gap-3">
-        <span class="inline-block h-3 w-3 rounded-full bg-emerald-500"></span>
-        <p class="text-sm font-semibold text-emerald-700">Menu synced to assistant context</p>
+<div class="space-y-6">
+  {% if restaurant_settings %}
+    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide text-[#B993D6]">Creativity balance</p>
+          <h2 class="text-lg font-semibold text-[#14080E]">Dial in classic versus adventurous ideas</h2>
+          <p class="text-sm text-slate-600">Adjust the slider to guide how Appertivo pitches new dishes.</p>
+        </div>
+        <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-500">
+          <i class="fa-solid fa-sliders" aria-hidden="true"></i>
+          {{ restaurant_settings.classic_creative_slider|default:50 }}/100
+        </span>
       </div>
-      {% if menu_version.finished_at %}
-        <span class="text-xs font-medium text-emerald-600">Updated {{ menu_version.finished_at|timesince }} ago</span>
+      <form
+        hx-post="{% url 'update_creativity' restaurant.id %}"
+        hx-trigger="change delay:150ms"
+        hx-target="none"
+        class="mt-6 flex flex-col gap-3"
+      >
+        <div class="flex items-center gap-4 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span>Classic</span>
+          <div class="h-px flex-1 bg-slate-200"></div>
+          <span>Creative</span>
+        </div>
+        <input
+          type="range"
+          name="classic_creative_slider"
+          min="0"
+          max="100"
+          value="{{ restaurant_settings.classic_creative_slider|default:50 }}"
+          class="w-full accent-[#B993D6]"
+        >
+      </form>
+    </section>
+  {% endif %}
+
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <div class="space-y-4">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-[#14080E]">Restaurant menu</h2>
+          <p class="text-sm text-slate-600">Keep your menu links current and edit the markdown we use for ideation.</p>
+        </div>
+      </div>
+
+      {% if menu_version %}
+        {% if menu_version.status == 'succeeded' %}
+          <div class="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+            <span class="text-lg" aria-hidden="true">✅</span>
+            <div>
+              <p class="text-sm font-semibold text-emerald-700">✅ Your restaurant is ready!</p>
+              {% if menu_version.finished_at %}
+                <p class="text-xs text-emerald-600">Updated {{ menu_version.finished_at|timesince }} ago.</p>
+              {% endif %}
+            </div>
+          </div>
+        {% elif menu_version.status == 'failed' %}
+          <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            We couldn’t find your menu automatically. Please provide it manually.
+            <button
+              type="button"
+              hx-get="{% url 'show_menu_modal' restaurant.id %}"
+              hx-target="#menu-modal"
+              hx-swap="innerHTML"
+              class="ml-3 inline-flex items-center gap-2 rounded-full border border-red-200 bg-white px-3 py-1 text-xs font-semibold text-red-600 hover:bg-red-100"
+            >
+              <i class="fa-solid fa-upload" aria-hidden="true"></i>
+              Provide menu
+            </button>
+          </div>
+        {% else %}
+          <div class="flex items-center gap-3 rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-700">
+            <span class="inline-flex h-3 w-3 animate-bounce rounded-full bg-indigo-400"></span>
+            We’re building your AI menu assistant…
+          </div>
+        {% endif %}
+      {% else %}
+        <div class="flex items-center gap-3 rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-700">
+          <span class="inline-flex h-3 w-3 animate-bounce rounded-full bg-indigo-400"></span>
+          We’re building your AI menu assistant…
+        </div>
+        <div class="rounded-xl border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">
+          We couldn’t detect a menu yet. Please upload or paste one below.
+          <button
+            type="button"
+            hx-get="{% url 'show_menu_modal' restaurant.id %}"
+            hx-target="#menu-modal"
+            hx-swap="innerHTML"
+            class="ml-3 inline-flex items-center gap-2 rounded-full border border-yellow-200 bg-white px-3 py-1 text-xs font-semibold text-yellow-700 hover:bg-yellow-100"
+          >
+            <i class="fa-solid fa-upload" aria-hidden="true"></i>
+            Provide menu
+          </button>
+        </div>
+      {% endif %}
+
+      <form
+        hx-post="{% url 'upload_menu' restaurant.id %}"
+        hx-target="#restaurant-status"
+        hx-swap="outerHTML"
+        hx-encoding="multipart/form-data"
+        class="space-y-6"
+        data-menu-manager
+      >
+        {% csrf_token %}
+        <div>
+          <div class="flex items-center justify-between gap-2">
+            <h3 class="text-sm font-semibold text-[#14080E]">Menu URLs</h3>
+            <button
+              type="button"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-[#14080E] transition hover:bg-slate-100"
+              data-menu-url-add
+            >
+              <span class="text-base leading-none">＋</span>
+              Add URL
+            </button>
+          </div>
+          <div class="mt-3 space-y-3" data-menu-url-list>
+            {% if restaurant.menu_urls %}
+              {% for url in restaurant.menu_urls %}
+                <div class="flex items-center gap-2" data-menu-url-row>
+                  <input
+                    type="url"
+                    name="menu_url"
+                    value="{{ url }}"
+                    placeholder="https://example.com/menu"
+                    class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+                  >
+                  <button
+                    type="button"
+                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                    data-menu-url-remove
+                  >
+                    <span class="sr-only">Remove URL</span>
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                  </button>
+                </div>
+              {% endfor %}
+            {% else %}
+              <div class="flex items-center gap-2" data-menu-url-row>
+                <input
+                  type="url"
+                  name="menu_url"
+                  placeholder="https://example.com/menu"
+                  class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+                >
+                <button
+                  type="button"
+                  class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                  data-menu-url-remove
+                >
+                  <span class="sr-only">Remove URL</span>
+                  <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+              </div>
+            {% endif %}
+          </div>
+          <template data-menu-url-template>
+            <div class="flex items-center gap-2" data-menu-url-row>
+              <input
+                type="url"
+                name="menu_url"
+                placeholder="https://example.com/menu"
+                class="h-11 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+              >
+              <button
+                type="button"
+                class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                data-menu-url-remove
+              >
+                <span class="sr-only">Remove URL</span>
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+              </button>
+            </div>
+          </template>
+        </div>
+
+        <div class="space-y-2">
+          <h3 class="text-sm font-semibold text-[#14080E]">Menu content</h3>
+          <p class="text-xs text-slate-500">Edit or paste the markdown that powers your AI assistant.</p>
+          <textarea
+            name="menu_text"
+            rows="10"
+            placeholder="Appetizers\n- Charcuterie Board"
+            class="w-full rounded-xl border border-slate-200 px-3 py-3 text-sm text-slate-700 shadow-sm focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+          >{{ menu_version.raw_markdown|default_if_none:'' }}</textarea>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-3">
+          <input
+            type="file"
+            id="menu-pdf-input-dashboard-{{ restaurant.id }}"
+            name="menu_pdf"
+            accept="application/pdf"
+            class="sr-only"
+            data-menu-file
+          >
+          <label
+            for="menu-pdf-input-dashboard-{{ restaurant.id }}"
+            class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-[#14080E] shadow-sm transition hover:bg-slate-100"
+          >
+            <i class="fa-solid fa-file-arrow-up" aria-hidden="true"></i>
+            Choose file
+          </label>
+          <span class="text-xs text-slate-500" data-menu-file-name>No file chosen</span>
+        </div>
+
+        <div class="flex justify-end">
+          <button
+            type="submit"
+            class="inline-flex items-center gap-2 rounded-full bg-[#f08000] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#d96f00]"
+          >
+            <i class="fa-solid fa-floppy-disk" aria-hidden="true"></i>
+            Save changes
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm space-y-5">
+    <div>
+      <h2 class="text-lg font-semibold text-[#14080E]">Restaurant snapshot</h2>
+      <p class="text-sm text-slate-600">Quick reference details for your front-of-house team.</p>
+    </div>
+    <div class="grid gap-3 sm:grid-cols-2">
+      {% if restaurant.phone %}
+        <div class="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+          <i class="fa-solid fa-phone-volume text-slate-400" aria-hidden="true"></i>
+          <span>{{ restaurant.phone }}</span>
+        </div>
+      {% endif %}
+      {% if restaurant.website %}
+        <a
+          href="{{ restaurant.website }}"
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-semibold text-[#5C008B] transition hover:bg-slate-100"
+        >
+          <i class="fa-solid fa-globe" aria-hidden="true"></i>
+          <span class="truncate">{{ restaurant.website }}</span>
+        </a>
+      {% endif %}
+      {% if restaurant.rating %}
+        <div class="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+          <i class="fa-solid fa-star text-amber-400" aria-hidden="true"></i>
+          <span>{{ restaurant.rating }} / 5{% if restaurant.review_count %} · {{ restaurant.review_count }} reviews{% endif %}</span>
+        </div>
+      {% endif %}
+      {% if restaurant.primary_menu_url %}
+        <a
+          href="{{ restaurant.primary_menu_url }}"
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-semibold text-[#5C008B] transition hover:bg-slate-100"
+        >
+          <i class="fa-solid fa-book-open" aria-hidden="true"></i>
+          <span class="truncate">{{ restaurant.primary_menu_url }}</span>
+        </a>
       {% endif %}
     </div>
-  {% elif menu_version.status == 'failed' %}
-    <div class="rounded-xl bg-red-50 border border-red-200 p-4 flex items-center space-x-3">
-      <span class="inline-block h-3 w-3 rounded-full bg-red-400"></span>
-      <p class="text-red-700 font-medium">We couldn’t find your menu. Please provide it manually.</p>
-    </div>
-    <div 
-      hx-get="{% url 'show_menu_modal' restaurant.id %}" 
-      hx-trigger="load"
-      hx-target="#menu-modal"
-      hx-swap="innerHTML"
-    ></div>
-  {% else %}
-    <!-- queued/running -->
-    <div class="rounded-xl bg-indigo-50 border border-indigo-200 p-4 flex items-center space-x-3 animate-pulse">
-      <span class="inline-block h-3 w-3 rounded-full bg-indigo-400 animate-bounce"></span>
-      <p class="text-indigo-700 font-medium">We’re building your AI menu assistant…</p>
-    </div>
-  {% endif %}
-{% else %}
-  <!-- No menu yet: treat like failure -->
-  <div class="rounded-xl bg-yellow-50 border border-yellow-200 p-4 flex items-center space-x-3">
-    <span class="inline-block h-3 w-3 rounded-full bg-yellow-400"></span>
-    <p class="text-yellow-700 font-medium">We couldn’t detect a menu. Please upload or paste one.</p>
-  </div>
-  <div 
-    hx-get="{% url 'show_menu_modal' restaurant.id %}" 
-    hx-trigger="load"
-    hx-target="#menu-modal"
-    hx-swap="innerHTML"
-  ></div>
-{% endif %}
+    {% if restaurant.menu_urls|length > 1 %}
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Additional menu URLs</p>
+        <div class="flex flex-col gap-2 text-sm font-semibold text-[#5C008B]">
+          {% for url in restaurant.menu_urls|slice:'1:' %}
+            <a
+              href="{{ url }}"
+              target="_blank"
+              rel="noopener"
+              class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 transition hover:bg-slate-100"
+            >
+              <i class="fa-solid fa-link" aria-hidden="true"></i>
+              <span class="truncate">{{ url }}</span>
+            </a>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <details class="group" data-accordion>
+      <summary class="flex cursor-pointer items-center justify-between gap-3 px-6 py-4 text-sm font-semibold text-[#14080E]">
+        <span>Restaurant context</span>
+        <i class="fa-solid fa-chevron-down text-xs text-slate-400 transition group-open:rotate-180" aria-hidden="true"></i>
+      </summary>
+      <div class="border-t border-slate-200">
+        <pre class="max-h-72 overflow-y-auto whitespace-pre-wrap break-words px-6 py-4 text-xs text-slate-600">
+{% if restaurant.context_json %}{{ restaurant.context_json }}{% else %}No context has been collected yet.{% endif %}
+        </pre>
+      </div>
+    </details>
+  </section>
+</div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,10 +4,37 @@
 
 {% block page_intro %}
     <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <div class="space-y-1">
+      <div class="space-y-2">
         <p class="text-xs font-semibold uppercase text-slate-400">Dashboard</p>
-        <h1 class="text-xl font-semibold text-[#14080E]">Welcome back, {{ request.user.first_name|default:"Chef" }}</h1>
-        <p class="text-sm text-slate-600">Here’s a quick look at how Appertivo is supporting {{ restaurant.name }}.</p>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+          <h1 class="text-2xl font-semibold text-[#14080E]">{{ restaurant.name }}</h1>
+          {% if restaurant.location_text %}
+            <div class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm text-slate-500">
+              <i class="fa-solid fa-location-dot text-slate-400" aria-hidden="true"></i>
+              <span>{{ restaurant.location_text }}</span>
+            </div>
+          {% endif %}
+        </div>
+        <p class="text-sm text-slate-600">Everything you need to keep Appertivo aligned with your dining room.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-3 text-sm text-slate-500">
+        {% if restaurant.phone %}
+          <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
+            <i class="fa-solid fa-phone text-slate-400" aria-hidden="true"></i>
+            {{ restaurant.phone }}
+          </span>
+        {% endif %}
+        {% if restaurant.website %}
+          <a
+            href="{{ restaurant.website }}"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 font-semibold text-[#5C008B] transition hover:text-[#3f0060]"
+          >
+            <i class="fa-solid fa-globe" aria-hidden="true"></i>
+            Website
+          </a>
+        {% endif %}
       </div>
     </div>
 {% endblock %}
@@ -220,6 +247,8 @@
     </section>
   </div>
 
+  <div id="menu-modal"></div>
+
   {% if prompt_for_menu %}
     <script>
       document.addEventListener('DOMContentLoaded', function () {
@@ -238,4 +267,112 @@
       });
     </script>
   {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      function setupMenuManager(manager) {
+        if (!manager || manager.dataset.menuManagerReady === 'true') {
+          return;
+        }
+        manager.dataset.menuManagerReady = 'true';
+
+        const list = manager.querySelector('[data-menu-url-list]');
+        const template = manager.querySelector('[data-menu-url-template]');
+        const addButton = manager.querySelector('[data-menu-url-add]');
+        if (!list || !template) {
+          return;
+        }
+
+        function createRow(value) {
+          const fragment = template.content.firstElementChild.cloneNode(true);
+          const input = fragment.querySelector('input[name="menu_url"]');
+          if (input) {
+            input.value = value || '';
+          }
+          return fragment;
+        }
+
+        function refreshRemoveButtons() {
+          const rows = Array.from(list.querySelectorAll('[data-menu-url-row]'));
+          rows.forEach(function (row) {
+            const removeButton = row.querySelector('[data-menu-url-remove]');
+            if (!removeButton) {
+              return;
+            }
+            if (rows.length <= 1) {
+              removeButton.classList.add('invisible');
+              removeButton.setAttribute('tabindex', '-1');
+            } else {
+              removeButton.classList.remove('invisible');
+              removeButton.removeAttribute('tabindex');
+            }
+          });
+        }
+
+        function ensureAtLeastOneRow() {
+          if (!list.querySelector('[data-menu-url-row]')) {
+            list.appendChild(createRow(''));
+          }
+          refreshRemoveButtons();
+        }
+
+        if (!list.querySelector('[data-menu-url-row]')) {
+          list.appendChild(createRow(''));
+        }
+        refreshRemoveButtons();
+
+        list.addEventListener('click', function (event) {
+          const removeButton = event.target.closest('[data-menu-url-remove]');
+          if (!removeButton) {
+            return;
+          }
+          const row = removeButton.closest('[data-menu-url-row]');
+          if (row) {
+            row.remove();
+          }
+          ensureAtLeastOneRow();
+        });
+
+        if (addButton) {
+          addButton.addEventListener('click', function () {
+            list.appendChild(createRow(''));
+            refreshRemoveButtons();
+            const inputs = list.querySelectorAll('input[name="menu_url"]');
+            const lastInput = inputs[inputs.length - 1];
+            if (lastInput) {
+              lastInput.focus();
+            }
+          });
+        }
+
+        const fileInput = manager.querySelector('[data-menu-file]');
+        const fileName = manager.querySelector('[data-menu-file-name]');
+        if (fileInput && fileName) {
+          fileName.dataset.defaultText = fileName.textContent || 'No file chosen';
+          fileInput.addEventListener('change', function () {
+            if (fileInput.files && fileInput.files.length > 0) {
+              fileName.textContent = fileInput.files[0].name;
+            } else {
+              fileName.textContent = fileName.dataset.defaultText;
+            }
+          });
+        }
+      }
+
+      function initMenuManagers(root) {
+        root.querySelectorAll('[data-menu-manager]').forEach(setupMenuManager);
+      }
+
+      initMenuManagers(document);
+
+      document.body.addEventListener('htmx:afterSwap', function (event) {
+        if (event.detail && event.detail.target) {
+          initMenuManagers(event.detail.target);
+        }
+      });
+    });
+  </script>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -2534,7 +2534,10 @@ def notification_list_view(request):
 
 def restaurant_status(request, restaurant_id):
     """HTMX endpoint that returns current status widget."""
-    restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
+    restaurant = get_object_or_404(
+        models.Restaurant.objects.select_related("restaurantsettings"),
+        id=restaurant_id,
+    )
     payload = (
         models.OutscraperPayload.objects.filter(restaurant=restaurant)
         .order_by("-created_at")
@@ -2544,6 +2547,7 @@ def restaurant_status(request, restaurant_id):
         "restaurant": restaurant,
         "menu_version": restaurant.active_menu_version,
         "payload": payload,
+        "restaurant_settings": getattr(restaurant, "restaurantsettings", None),
     }
     return render(request, "_partials/restaurant_status.html", context)
 
@@ -2616,9 +2620,18 @@ def upload_menu(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
 
     if request.method == "POST":
-        menu_url = (request.POST.get("menu_url") or "").strip()
+        submitted_urls = request.POST.getlist("menu_url")
+        menu_urls = [url.strip() for url in submitted_urls if url and url.strip()]
+        if submitted_urls:
+            restaurant.set_menu_urls(menu_urls)
+            restaurant.save(update_fields=["menu_urls", "primary_menu_url"])
+
         menu_text = (request.POST.get("menu_text") or "").strip()
         menu_pdf = request.FILES.get("menu_pdf")
+
+        menu_url = None
+        if not menu_text and not menu_pdf and menu_urls:
+            menu_url = menu_urls[0]
 
         _process_menu_submission(restaurant, menu_url, menu_text, menu_pdf)
 


### PR DESCRIPTION
## Summary
- move the dashboard header to highlight restaurant details and add client-side helpers for dynamic menu URL inputs
- redesign the restaurant status card with a creativity slider, structured menu management form, and an accordion for context
- refresh the menu modal and backend handler to support multiple URLs, custom file uploads, and cleaner status messaging

## Testing
- python manage.py test tests.test_restaurant_status

------
https://chatgpt.com/codex/tasks/task_e_68d6cf1c631883328bd52cb850cc1943