### PR TITLE
Revamp AI prompt UI and dashboard redirect

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -9,20 +9,6 @@
       data-ai-input="{{ root_id }}"
       class="relative space-y-4 pt-6 sm:pt-0"
     >
-      <div
-        id="{{ indicator_id }}"
-        class="pointer-events-none hidden w-full justify-center sm:absolute sm:right-0 sm:top-0 sm:w-auto sm:justify-end"
-        aria-live="polite"
-      >
-        <div
-          class="flex items-center gap-2 rounded-full border border-[#B993D6]/50 bg-white/95 px-4 py-1.5 text-xs font-semibold text-[#49475B] shadow-lg"
-        >
-          <span
-            class="h-4 w-4 animate-spin rounded-full border-2 border-[#B993D6] border-t-transparent"
-          ></span>
-          <span>Crafting fresh ideas…</span>
-        </div>
-      </div>
 
       <form
         id="{{ root_id }}"
@@ -33,16 +19,22 @@
         class="flex flex-col gap-3 sm:flex-row sm:items-center"
       >
         <div class="relative flex-1">
-          <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[#f08000]">
-            <i class="fa-solid fa-wand-magic-sparkles text-base"></i>
-          </span>
+          <button
+            type="button"
+            data-inspire
+            aria-label="Inspire me"
+            class="absolute inset-y-1.5 left-2 inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#f08000] via-[#f69b2d] to-[#d96f00] text-white shadow-sm transition hover:from-[#f69b2d] hover:via-[#f08000] hover:to-[#f69b2d] focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#f08000]/60"
+          >
+            <i class="fa-solid fa-sparkles"></i>
+            <span class="sr-only">Inspire Me</span>
+          </button>
           <input
             type="text"
             name="prompt"
             id="{{ root_id }}-field"
             value="{{ initial_value|default:'' }}"
             placeholder="{{ placeholder_samples|first|default:'Try: Fall brunch specials' }}"
-            class="w-full rounded-xl border border-slate-200 bg-white/90 px-11 py-3 text-sm text-[#14080E] shadow-sm transition focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+            class="w-full rounded-xl border border-slate-200 bg-white/90 py-3 pl-14 pr-28 text-sm text-[#14080E] shadow-sm transition focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
             autocomplete="off"
           />
           <button
@@ -53,21 +45,16 @@
             <i class="fa-solid fa-paper-plane text-[10px]"></i>
           </button>
         </div>
-        <button
-          type="button"
-          data-inspire
-          class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#f08000] via-[#f69b2d] to-[#d96f00] px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#f08000]/60"
-        >
-          <span>Inspire Me</span>
-          <i class="fa-solid fa-sparkles text-xs"></i>
-        </button>
       </form>
       <div
         id="{{ indicator_id }}"
-        class="hidden items-center justify-start gap-2 text-sm text-[#49475B] sm:justify-end"
+        class="pointer-events-none absolute inset-x-3 bottom-0 hidden"
+        aria-live="polite"
       >
-        <span class="inline-flex h-2.5 w-2.5 animate-ping rounded-full bg-[#B993D6]"></span>
-        <span class="font-medium">Gathering ideas…</span>
+        <span class="sr-only">Mixing new ideas…</span>
+        <div class="h-1 w-full overflow-hidden rounded-full bg-[#E8DAF7]">
+          <div class="indicator-bar h-full w-full"></div>
+        </div>
       </div>
 
       {% if suggestions %}
@@ -87,7 +74,20 @@
     </div>
     <style>
       #{{ indicator_id }}.htmx-request {
-        display: flex;
+        display: block;
+      }
+      #{{ indicator_id }} .indicator-bar {
+        background: linear-gradient(90deg, #B993D6, #FF5C00, #58B09C, #B993D6);
+        background-size: 200% 100%;
+        animation: indicator-shimmer 1.4s linear infinite;
+      }
+      @keyframes indicator-shimmer {
+        0% {
+          background-position: 0% 50%;
+        }
+        100% {
+          background-position: 200% 50%;
+        }
       }
     </style>
     <script>

--- a/app/views.py
+++ b/app/views.py
@@ -1217,7 +1217,15 @@ def concepts_generate_view(request):
             [concept.name for concept in concepts],
         )
 
-    return render(request, "concepts/_concepts_grid.html", {"concepts": concepts})
+    response = render(request, "concepts/_concepts_grid.html", {"concepts": concepts})
+
+    if request.headers.get("HX-Request") == "true":
+        current_url = request.headers.get("HX-Current-URL", "")
+        if "/dashboard/" in current_url:
+            response["HX-Redirect"] = reverse("concepts")
+        return response
+
+    return redirect("concepts")
 
 @login_required
 def concept_favorite_view(request, concept_id):

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -132,8 +132,54 @@ class ViewSmokeTests(TestCase):
         self._create_concepts()
         resp = self.client.get(reverse("concepts"))
         self.assertContains(resp, "C0")
-        gen_resp = self.client.post(reverse("concepts-generate"))
-        self.assertEqual(gen_resp.status_code, 200)
+        payload = {
+            "concepts": [
+                {
+                    "title": f"New {i}",
+                    "subtitle": "Sub",
+                    "reasoning": "Because",
+                    "tags": ["tag1", "tag2", "tag3"],
+                }
+                for i in range(9)
+            ]
+        }
+        fake_response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+        )
+
+        with patch("app.views.client") as mock_client:
+            mock_client.responses.create.return_value = fake_response
+            gen_resp = self.client.post(reverse("concepts-generate"))
+        self.assertEqual(gen_resp.status_code, 302)
+        self.assertEqual(gen_resp["Location"], reverse("concepts"))
+
+    def test_dashboard_generation_hx_redirects_to_concepts(self):
+        self._create_concepts()
+        current_url = f"/dashboard/{self.restaurant.id}/"
+        payload = {
+            "concepts": [
+                {
+                    "title": f"Run {i}",
+                    "subtitle": "Sub",
+                    "reasoning": "Why",
+                    "tags": ["t1", "t2", "t3"],
+                }
+                for i in range(9)
+            ]
+        }
+        fake_response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+        )
+
+        with patch("app.views.client") as mock_client:
+            mock_client.responses.create.return_value = fake_response
+            response = self.client.post(
+                reverse("concepts-generate"),
+                HTTP_HX_REQUEST="true",
+                HTTP_HX_CURRENT_URL=current_url,
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["HX-Redirect"], reverse("concepts"))
 
     def test_concept_favorite(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- restyle the contextual AI input with an inline inspire button and shimmering indicator
- redirect dashboard concept generations to the concepts page while keeping concept page swaps
- cover the new redirect behaviour with focused regression tests

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_concepts_and_generation tests.test_appertivo_views.ViewSmokeTests.test_dashboard_generation_hx_redirects_to_concepts -v 2

------
https://chatgpt.com/codex/tasks/task_e_68d6f66948048332b6adb5a9b38dad64