### PR TITLE
Refine dashboard idea launcher layout

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -18,40 +18,41 @@
         class="flex flex-col gap-3 sm:flex-row sm:items-center"
       >
         <div class="relative flex-1">
-          <button
-            type="button"
-            data-inspire
-            aria-label="Inspire me"
-            class="absolute inset-y-1.5 left-2 inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#f08000] via-[#f69b2d] to-[#d96f00] text-white shadow-sm transition hover:from-[#f69b2d] hover:via-[#f08000] hover:to-[#f69b2d] focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-[#f08000]/60"
-          >
-            <i class="fa-solid fa-sparkles"></i>
-            <span class="sr-only">Inspire Me</span>
-          </button>
           <input
             type="text"
             name="prompt"
             id="{{ root_id }}-field"
             value="{{ initial_value|default:'' }}"
             placeholder="{{ placeholder_samples|first|default:'Try: Fall brunch specials' }}"
-            class="w-full rounded-xl border border-slate-200 bg-white/90 py-3 pl-14 pr-28 text-sm text-[#14080E] shadow-sm transition focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
+            class="w-full rounded-xl border border-slate-200 bg-white/90 py-3 pl-4 pr-56 text-sm text-[#14080E] shadow-sm transition focus:border-[#B993D6] focus:outline-none focus:ring-2 focus:ring-[#B993D6]/40"
             autocomplete="off"
           />
-          <button
-            type="submit"
-            class="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 rounded-full bg-[#58B09C] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#43907d] focus:outline-none focus:ring-2 focus:ring-[#58B09C]/40"
-          >
-            <span>Run</span>
-            <i class="fa-solid fa-paper-plane text-[10px]"></i>
-          </button>
+          <div class="absolute inset-y-1.5 right-2 flex items-center gap-2">
+            <button
+              type="submit"
+              class="inline-flex items-center gap-1 rounded-full bg-[#58B09C] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#43907d] focus:outline-none focus:ring-2 focus:ring-[#58B09C]/40"
+            >
+              <span>Run</span>
+              <i class="fa-solid fa-paper-plane text-[10px]"></i>
+            </button>
+            <button
+              type="button"
+              data-inspire
+              class="inline-flex items-center gap-1.5 rounded-full bg-[#FF5C00] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#e05400] focus:outline-none focus:ring-2 focus:ring-[#FF5C00]/40"
+            >
+              <span>I feel lucky</span>
+              <i class="fa-solid fa-sparkles text-[10px]"></i>
+            </button>
+          </div>
         </div>
       </form>
       <div
         id="{{ indicator_id }}"
-        class="pointer-events-none absolute inset-x-3 bottom-0 hidden"
+        class="pointer-events-none hidden"
         aria-live="polite"
       >
         <span class="sr-only">Mixing new ideas…</span>
-        <div class="h-1 w-full overflow-hidden rounded-full bg-[#E8DAF7]">
+        <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-[#E8DAF7]">
           <div class="indicator-bar h-full w-full"></div>
         </div>
       </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -17,22 +17,15 @@
   <div class="px-4 py-6 space-y-6">
     {% include "concepts/_card_assets.html" %}
     <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div class="space-y-5">
-        <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-wide text-[#B993D6]">Idea launcher</p>
-            <h2 class="text-lg font-semibold text-[#14080E]">Jumpstart new concepts</h2>
-            <p class="text-sm text-[#49475B]">Type your own spark, tap a chip, or let Appertivo surprise you.</p>
-          </div>
-        </div>
+      <div class="space-y-4">
+        <p class="text-sm font-medium text-[#49475B]">Try a suggestion below or type your own focus to refresh the grid.</p>
         {% include "_partials/contextual_ai_input.html" with form_id="dashboard-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders suggestions=concept_prompt_suggestions %}
-        <div class="rounded-xl border border-dashed border-[#B993D6]/30 bg-[#F8F5FF] px-4 py-6">
-          <div id="concepts-grid" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            <p class="col-span-full text-sm text-[#49475B]">We&rsquo;ll drop fresh ideas here the moment you launch a run.</p>
-          </div>
-        </div>
       </div>
     </section>
+
+    <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+      {% include "concepts/_concepts_grid.html" with concepts=[] %}
+    </div>
 
 
     <section class="rounded-2xl border border-slate-200 bg-white p-6">


### PR DESCRIPTION
## Summary
- align the dashboard idea launcher section with the concepts page template and drop the unused placeholder message
- reposition the contextual AI controls so the Run and I feel lucky buttons share the input and enlarge the loading indicator bar

## Testing
- python manage.py test


------
https://chatgpt.com/codex/tasks/task_e_68d71a4c960c8332a01f8c851901ebb6