### PR TITLE
Add subtle load more button for concepts grid

### DIFF
--- a/app/templates/concepts/_concepts_grid.html
+++ b/app/templates/concepts/_concepts_grid.html
@@ -1,3 +1,17 @@
 {% for concept in concepts %}
   {% include "concepts/_card.html" with concept=concept %}
 {% endfor %}
+{% if concepts and concept_generate_url %}
+  <div class="col-span-full flex justify-center pt-2">
+    <button
+      type="button"
+      hx-post="{{ concept_generate_url }}"
+      hx-target="#concepts-grid"
+      hx-swap="innerHTML"
+      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
+    >
+      <span>More ideas like these</span>
+      <i class="fa-solid fa-chevron-down text-[10px]"></i>
+    </button>
+  </div>
+{% endif %}

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -19,7 +19,7 @@
     </section>
 
     <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-      {% include 'concepts/_concepts_grid.html' %}
+      {% include 'concepts/_concepts_grid.html' with concept_generate_url=concept_generate_url %}
     </div>
   </div>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -1217,7 +1217,14 @@ def concepts_generate_view(request):
             [concept.name for concept in concepts],
         )
 
-    response = render(request, "concepts/_concepts_grid.html", {"concepts": concepts})
+    response = render(
+        request,
+        "concepts/_concepts_grid.html",
+        {
+            "concepts": concepts,
+            "concept_generate_url": reverse("concepts-generate"),
+        },
+    )
 
     if request.headers.get("HX-Request") == "true":
         current_url = request.headers.get("HX-Current-URL", "")


### PR DESCRIPTION
## Summary
- add a subtle "More ideas" button at the bottom of the concepts grid that triggers another generation request
- pass the concept generation endpoint through the grid partial so the button works for HTMX refreshes

## Testing
- pytest *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d720915af483329a0c2f54571aaf2c