### PR TITLE
Add manual onboarding fallback for menu submission

### DIFF
--- a/app/templates/_partials/manual_menu.html
+++ b/app/templates/_partials/manual_menu.html
@@ -1,1 +1,65 @@
-<div>Manual Menu</div>
+<div class="rounded-xl border border-slate-200 bg-white px-4 py-4 shadow-sm" data-manual-menu>
+  <div class="flex items-start justify-between gap-3">
+    <div>
+      <h3 class="text-base font-semibold text-[#14080E]">Manual menu submission</h3>
+      <p class="mt-1 text-sm text-slate-600">Paste your latest offerings or upload a PDF so we can capture them.</p>
+    </div>
+    <button
+      type="button"
+      class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+      onclick="document.getElementById('manual-menu-container').innerHTML=''"
+    >
+      <span class="sr-only">Close manual entry</span>
+      <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+    </button>
+  </div>
+
+  <form
+    hx-post="{% url 'manual-menu' %}"
+    hx-target="#manual-menu-container"
+    hx-swap="innerHTML"
+    hx-encoding="multipart/form-data"
+    class="mt-4 space-y-4"
+  >
+    {% csrf_token %}
+    {% if errors %}
+      <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <ul class="list-disc space-y-1 pl-4">
+          {% for error in errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <div class="space-y-2">
+      <label for="manual-menu-text" class="block text-sm font-medium text-slate-700">Paste menu text</label>
+      <textarea
+        id="manual-menu-text"
+        name="menu_text"
+        rows="6"
+        placeholder="Starters\n- Charcuterie Board"
+        class="w-full rounded-xl border border-slate-300 px-3 py-3 text-sm text-slate-700 focus:border-[#5C008B] focus:outline-none focus:ring-2 focus:ring-[#B993D6]"
+      >{{ menu_text }}</textarea>
+      <p class="text-xs text-slate-500">Plain text works great—list sections, dishes, and prices if you have them.</p>
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-sm font-medium text-slate-700" for="manual-menu-file">Or upload a PDF</label>
+      <input
+        type="file"
+        id="manual-menu-file"
+        name="menu_pdf"
+        accept="application/pdf"
+        class="w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 focus:border-[#5C008B] focus:outline-none focus:ring-2 focus:ring-[#B993D6]"
+      >
+      <p class="text-xs text-slate-500">We'll queue a quick parse if you send a PDF.</p>
+    </div>
+
+    <div class="flex justify-end">
+      <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-[#5C008B] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#4a0178]">
+        Submit manual menu
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/templates/onboarding.html
+++ b/app/templates/onboarding.html
@@ -81,6 +81,22 @@
               {% endif %}
             </div>
           </form>
+          <div class="space-y-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm">
+            <div>
+              <p class="font-semibold text-[#14080E]">Need another option?</p>
+              <p class="mt-1 text-slate-600">Paste your menu or upload a file so we can ingest it manually.</p>
+            </div>
+            <button
+              type="button"
+              hx-get="{% url 'manual-menu' %}"
+              hx-target="#manual-menu-container"
+              hx-swap="innerHTML"
+              class="inline-flex items-center justify-center rounded-xl border border-[#5C008B] px-4 py-2 text-sm font-semibold text-[#5C008B] transition hover:bg-[#f3e8ff]"
+            >
+              Enter menu manually
+            </button>
+            <div id="manual-menu-container" class="pt-1"></div>
+          </div>
           {% if latest_menu_version %}
             <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
               <p class="font-semibold text-[#14080E]">Latest import: {{ latest_menu_version.get_status_display }}</p>

--- a/app/views.py
+++ b/app/views.py
@@ -832,6 +832,8 @@ def onboarding_view(request):
             .order_by("-created_at")
             .first()
         )
+        if latest_menu_version and latest_menu_version.status == models.MenuVersion.Status.SUCCEEDED:
+            menu_success = True
 
     if request.method == "POST":
         menu_url = (request.POST.get("menu_url") or "").strip()
@@ -853,6 +855,10 @@ def onboarding_view(request):
                 lambda mv_id=str(latest_menu_version.id): scrape_menu.delay(mv_id)
             )
             menu_success = True
+
+    if request.session.get("menu_success"):
+        menu_success = True
+        request.session.pop("menu_success")
 
     just_signed_up = request.session.pop("just_signed_up", False)
     if request.method == "POST" and just_signed_up and not menu_success:
@@ -917,11 +923,46 @@ def onboarding_status_view(request):
     )
 
 
+@login_required
 def manual_menu_view(request):
     """Allow manual menu entry."""
-    if request.method == "POST":
-        return JsonResponse({"status": "queued"})
-    return render(request, "_partials/manual_menu.html")
+
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    restaurant = None
+    if membership:
+        restaurant = (
+            models.Restaurant.objects.filter(account=membership.account)
+            .order_by("created_at")
+            .first()
+        )
+
+    errors = []
+    menu_text = (request.POST.get("menu_text") or "").strip() if request.method == "POST" else ""
+
+    if not restaurant:
+        errors.append("We couldn't find a restaurant for your account yet.")
+    elif request.method == "POST":
+        menu_pdf = request.FILES.get("menu_pdf")
+        if not menu_text and not menu_pdf:
+            errors.append("Paste your menu or upload a PDF so we can ingest it.")
+        else:
+            menu_version = _process_menu_submission(restaurant, None, menu_text, menu_pdf)
+            if menu_version:
+                request.session["menu_success"] = True
+                if request.headers.get("HX-Request"):
+                    response = HttpResponse(status=204)
+                    response["HX-Redirect"] = reverse("onboarding")
+                    return response
+                return redirect("onboarding")
+            errors.append("We couldn't process your submission. Please try again.")
+
+    status = 400 if errors else 200
+    context = {"errors": errors, "menu_text": menu_text}
+    return render(request, "_partials/manual_menu.html", context, status=status)
 
 
 @login_required

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -104,8 +104,28 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(status_resp.json()["status"], "pending")
 
     def test_manual_menu(self):
-        resp = self.client.get(reverse("manual-menu"))
+        resp = self.client.get(reverse("manual-menu"), HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Manual menu submission")
+
+    def test_manual_menu_creates_menu_version_from_text(self):
+        payload = {"menu_text": "Lunch\n- Soup of the Day"}
+        resp = self.client.post(
+            reverse("manual-menu"), payload, HTTP_HX_REQUEST="true"
+        )
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp["HX-Redirect"], reverse("onboarding"))
+
+        menu_version = models.MenuVersion.objects.get(restaurant=self.restaurant)
+        self.assertEqual(menu_version.source_kind, models.MenuVersion.SourceKind.PASTED_TEXT)
+        self.assertEqual(menu_version.raw_markdown, "Lunch\n- Soup of the Day")
+        self.assertTrue(self.client.session.get("menu_success"))
+
+    def test_manual_menu_requires_content(self):
+        resp = self.client.post(reverse("manual-menu"), {}, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 400)
+        self.assertContains(resp, "Paste your menu or upload a PDF", status_code=400)
+        self.assertEqual(models.MenuVersion.objects.count(), 0)
 
     def test_dashboard_displays_contextual_ai_component(self):
         self.restaurant.context_json = {


### PR DESCRIPTION
## Summary
- add an HTMX-triggered manual submission panel to onboarding when a menu URL is unavailable
- implement server-side handling that creates MenuVersion records from pasted text or uploads and surfaces success feedback
- expand view tests to cover manual menu submissions and validation messaging

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_manual_menu tests.test_appertivo_views.ViewSmokeTests.test_manual_menu_creates_menu_version_from_text tests.test_appertivo_views.ViewSmokeTests.test_manual_menu_requires_content

------
https://chatgpt.com/codex/tasks/task_e_68d7210046ac8332bd177723d3ac60b4