### PR TITLE
Add menus CTA to dish cards when menu options are missing

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -1,5 +1,11 @@
 {# Full dish card (lookbook-first) #}
-{% with context_name=card_context|default:"grid" menu_list=menu_options|default:"" current_menu=current_menu_id|default:"" move_url=menu_move_url|default:"" %}
+{% with
+  context_name=card_context|default:"grid"
+  menu_list=menu_options|default:""
+  current_menu=current_menu_id|default:""
+  move_url=menu_move_url|default:""
+  menus_url=menus_workspace_url|default:""
+%}
 
 
 <div
@@ -162,9 +168,19 @@
                     Remove from menus
                   </button>
                 {% else %}
-                  <p class="dish-menu-empty" data-no-flip>
-                    Create a menu to add this dish.
-                  </p>
+                  <div class="dish-menu-empty" data-no-flip>
+                    <p>Create a menu to add this dish.</p>
+                    {% if menus_url %}
+                      <a
+                        href="{{ menus_url }}"
+                        class="dish-menu-empty-link"
+                        data-menu-empty-cta
+                        data-no-flip
+                      >
+                        Open menus workspace
+                      </a>
+                    {% endif %}
+                  </div>
                 {% endif %}
               </div>
             </div>

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -252,6 +252,10 @@
   }
 
   .dish-menu-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
     margin: 0;
     padding: 0.5rem 0.25rem;
     font-size: 0.8rem;
@@ -259,6 +263,30 @@
     color: #64748b;
     max-width: 12rem;
     text-align: left;
+  }
+
+  .dish-menu-empty p {
+    margin: 0;
+  }
+
+  .dish-menu-empty-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.375rem;
+    background: #f1f5f9;
+    color: #334155;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .dish-menu-empty-link:hover,
+  .dish-menu-empty-link:focus-visible {
+    background: #e2e8f0;
+    color: #1e293b;
   }
 
   .dish-tag {
@@ -608,6 +636,12 @@
       if (option) {
         evt.preventDefault();
         handleMenuSelection(option);
+        return;
+      }
+
+      const emptyCta = evt.target.closest("[data-menu-empty-cta]");
+      if (emptyCta) {
+        closeAllMenus();
         return;
       }
 

--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -2,5 +2,5 @@
 {% include "dishes/_card_assets.html" %}
 
 {% for dish in dishes %}
-  {% include "dishes/_card.html" with dish=dish card_context="grid" menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' %}
+  {% include "dishes/_card.html" with dish=dish card_context="grid" menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' menus_workspace_url=menus_workspace_url %}
 {% endfor %}

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -91,7 +91,7 @@
         <div data-uncategorized-list class="grid grid-cols-1 gap-4 md:grid-cols-2">
           {% for favorite in uncategorized_favorites %}
             <div id="favorite-dish-{{ favorite.dish.id }}" class="favorite-dish-card">
-              {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' %}
+              {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' menus_workspace_url=menus_workspace_url %}
             </div>
           {% endfor %}
         </div>

--- a/app/templates/menus/main.html
+++ b/app/templates/menus/main.html
@@ -97,7 +97,7 @@
                 data-menu-id="{{ menu.id }}"
                 draggable="true"
               >
-                {% include "dishes/_card.html" with dish=item.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id=menu.id %}
+                {% include "dishes/_card.html" with dish=item.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id=menu.id menus_workspace_url=menus_workspace_url %}
               </div>
             {% endfor %}
           </div>

--- a/app/views.py
+++ b/app/views.py
@@ -788,6 +788,7 @@ def menus_view(request):
         "menus": menus,
         "menu_options": menu_options,
         "menu_move_url": reverse("menu-item-move"),
+        "menus_workspace_url": reverse("menus"),
     }
     return render(request, "menus/main.html", ctx)
 
@@ -1838,6 +1839,7 @@ def dish_detail_view(request, concept_id):
         "dishes": dishes,
         "menu_options": menu_options,
         "menu_move_url": reverse("menu-item-move"),
+        "menus_workspace_url": reverse("menus"),
     }
 
     return render(request, template_name, context)
@@ -1876,7 +1878,11 @@ def dish_favorite_view(request, dish_id):
 
     html = render_to_string(
         "dishes/_card.html",
-        {"dish": dish, "card_context": card_context},
+        {
+            "dish": dish,
+            "card_context": card_context,
+            "menus_workspace_url": reverse("menus"),
+        },
         request=request,
     )
     return HttpResponse(html)
@@ -2070,7 +2076,13 @@ def dish_variation_view(request, dish_id):
     decorate_dishes_with_enhancements([new_dish])
 
     html = render_to_string(
-        "dishes/_card.html", {"dish": new_dish, "card_context": "grid"}, request=request
+        "dishes/_card.html",
+        {
+            "dish": new_dish,
+            "card_context": "grid",
+            "menus_workspace_url": reverse("menus"),
+        },
+        request=request,
     )
     return HttpResponse(html)
 
@@ -2146,6 +2158,7 @@ def favorites_view(request):
         "uncategorized_favorites": uncategorized_favorites,
         "menu_options": menus_payload,
         "menu_move_url": reverse("menu-item-move"),
+        "menus_workspace_url": reverse("menus"),
     }
     return render(request, "favorites/dashboard.html", ctx)
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -238,6 +238,17 @@ class ViewSmokeTests(TestCase):
             [{"id": str(menu.id), "name": menu.name}],
         )
         self.assertEqual(resp.context["menu_move_url"], reverse("menu-item-move"))
+        self.assertEqual(resp.context["menus_workspace_url"], reverse("menus"))
+
+    def test_dish_detail_empty_menu_renders_workspace_cta(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+        self._create_dishes(concept)
+
+        resp = self.client.get(reverse("dish_detail", args=[concept.id]))
+        self.assertContains(resp, "Open menus workspace")
+        self.assertContains(resp, f'href="{reverse("menus")}"')
+        self.assertContains(resp, "data-menu-empty-cta")
 
     def test_dish_detail_excludes_deleted_dishes(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- render a call-to-action link in the dish card menu empty state so users can open the menus workspace
- expose the menus workspace URL to the card partial from all render paths and close the dropdown when the CTA is clicked
- expand the dish detail view tests to assert the CTA is present when no menu options are available

## Testing
- pytest tests/test_appertivo_views.py::ViewSmokeTests::test_dish_detail_empty_menu_renders_workspace_cta *(fails: missing Django dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d720e88f2883329718bd35aeed482e