### PR TITLE
Display concept metadata on dish detail page

### DIFF
--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -18,6 +18,29 @@
 {% block page_content %}
 <div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
 
+  <div class="space-y-3">
+    <div class="space-y-1">
+      <h2 class="text-2xl font-semibold text-[#14080E]">{{ concept.name }}</h2>
+      {% if concept.subtitle %}
+        <p class="text-sm text-[#4F4A50]">{{ concept.subtitle }}</p>
+      {% endif %}
+    </div>
+
+    {% if concept_tags %}
+      <div class="flex flex-wrap gap-2">
+        {% for tag in concept_tags %}
+          <span class="inline-flex items-center rounded-full bg-[#FFF0E5] px-3 py-1 text-xs font-medium text-[#FF5C00]">
+            {{ tag }}
+          </span>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    {% if concept_reasoning %}
+      <p class="text-sm leading-relaxed text-[#14080E]">{{ concept_reasoning|linebreaksbr }}</p>
+    {% endif %}
+  </div>
+
 <div id="dishes-grid"
      class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4
             gap-1 sm:gap-3 md:gap-4 lg:gap-4 xl:gap-5">

--- a/app/views.py
+++ b/app/views.py
@@ -1833,8 +1833,18 @@ def dish_detail_view(request, concept_id):
         template_name,
     )
 
+    concept_tags = concept.tags or []
+    if isinstance(concept_tags, (tuple, set)):
+        concept_tags = list(concept_tags)
+    elif not isinstance(concept_tags, list):
+        concept_tags = [concept_tags] if concept_tags else []
+
+    concept_tags = [str(tag) for tag in concept_tags if str(tag).strip()]
+
     context = {
         "concept": concept,
+        "concept_tags": concept_tags,
+        "concept_reasoning": concept.reasoning or "",
         "dishes": dishes,
         "menu_options": menu_options,
         "menu_move_url": reverse("menu-item-move"),

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -251,6 +251,36 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertNotContains(resp, dish.title)
 
+    def test_dish_detail_displays_concept_metadata(self):
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="m",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=concept_run,
+            name="Coastal Brunch",
+            subtitle="Bright citrus and seafood pairings",
+            reasoning="Highlight local catch with citrus.\nGreat for summer afternoons.",
+            tags=["Seasonal", "Coastal"],
+            rank_order=0,
+        )
+        self._create_dishes(concept)
+
+        resp = self.client.get(reverse("dish_detail", args=[concept.id]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Coastal Brunch")
+        self.assertContains(resp, "Bright citrus and seafood pairings")
+        self.assertContains(resp, "Seasonal")
+        self.assertContains(resp, "Highlight local catch with citrus.")
+
     def test_dish_delete_removes_dish_and_assets(self):
         self._create_concepts()
         concept = models.Concept.objects.first()


### PR DESCRIPTION
## Summary
- render concept name, subtitle, tags, and reasoning on the dish detail page
- pass normalized concept metadata to the dish detail template for consistent rendering
- add a regression test ensuring concept metadata appears when viewing generated dishes

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_dish_detail_displays_concept_metadata

------
https://chatgpt.com/codex/tasks/task_e_68d720d6c5d88332bcbf998fadf1b33d