### PR TITLE
Improve dish discovery card UI

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -1,20 +1,11 @@
 {# Full dish card (lookbook-first) #}
-{% with
-  context_name=card_context|default:"grid"
-  menu_list=menu_options|default:""
-  current_menu=current_menu_id|default:""
-  move_url=menu_move_url|default:""
-  menus_url=menus_workspace_url|default:""
-%}
-
-
 <div
   class="dish-card-wrapper"
   id="dish-{{ dish.id }}"
   data-dish-card
   data-dish-id="{{ dish.id }}"
-  data-current-menu="{{ current_menu }}"
-  data-move-url="{{ move_url }}"
+  data-current-menu="{{ current_menu_id|default:'' }}"
+  data-move-url="{{ menu_move_url|default:'' }}"
   data-favorited="{% if dish.is_favorited %}true{% else %}false{% endif %}"
 >
   <div class="flip-scene h-full">
@@ -30,7 +21,7 @@
                 {% endif %}
               </header>
 
-              <div class="flex flex-wrap gap-2 pb-2">
+              <div class="flex flex-wrap items-center gap-2 pb-2">
                 {% for tag in dish.category_tags %}
                   <a
                     href="{% url 'tag-search' %}?tag={{ tag|urlencode }}"
@@ -47,11 +38,23 @@
                     {{ tag }}
                   </a>
                 {% endfor %}
+                <button
+                  type="button"
+                  class="dish-delete-btn tag-delete-btn"
+                  hx-post="{% url 'dish-delete' dish.id %}"
+                  hx-trigger="click"
+                  hx-target="closest .dish-card-wrapper"
+                  hx-swap="outerHTML"
+                  aria-label="Dismiss {{ dish.title }}"
+                >
+                  <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
+                  <span>Dismiss</span>
+                </button>
               </div>
             </div>
 
-            <footer class="flex justify-end gap-2 pt-1">
-              {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
+            <footer class="card-bottom-bar flex justify-end gap-2">
+              {% include "dishes/_favorite_button.html" with dish=dish card_context=card_context|default:"grid" btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
               <button
                 type="button"
                 class="dish-variation-btn card-action-button bg-white/90 text-slate-600 hover:text-slate-800"
@@ -63,17 +66,6 @@
               >
                 <i class="fa-solid fa-arrows-rotate"></i>
               </button>
-              <button
-                type="button"
-                class="dish-delete-btn card-action-button bg-white/90 text-red-500 hover:text-red-600"
-                hx-post="{% url 'dish-delete' dish.id %}"
-                hx-trigger="click"
-                hx-target="closest .dish-card-wrapper"
-                hx-swap="outerHTML"
-                aria-label="Dismiss {{ dish.title }}"
-              >
-                <i class="fa-solid fa-thumbs-down"></i>
-              </button>
             </footer>
           </article>
         </div>
@@ -82,21 +74,21 @@
         <div class="flip-face front relative rounded-2xl overflow-hidden shadow-md border border-slate-200 bg-white">
           {% if dish.enhancement_image_url %}
             <!-- Lookbook image -->
-            <img
-              src="{{ dish.enhancement_image_url }}"
-              alt="{{ dish.title }}"
-              class="absolute inset-0 w-full h-full object-cover"
-            />
-            <!-- Top gradient so price badge stays readable -->
-            <div class="pointer-events-none absolute inset-x-0 top-0 h-20 bg-gradient-to-b from-black/25 to-transparent"></div>
+              <img
+                src="{{ dish.enhancement_image_url }}"
+                alt="{{ dish.title }}"
+                class="absolute inset-0 w-full h-full object-cover"
+              />
+              <!-- Top gradient so price badge stays readable -->
+              <div class="pointer-events-none absolute inset-x-0 top-0 h-20 bg-gradient-to-b from-black/25 to-transparent"></div>
 
-            {% if dish.enhancement_price_display %}
-              <span class="absolute top-2 right-2 bg-white/90 text-[#49475B] text-xs md:text-sm font-semibold px-3 py-1 rounded-full shadow">
+              {% if dish.enhancement_price_display %}
+              <span class="price-tag absolute top-2 right-2 text-xs md:text-sm">
                 {{ dish.enhancement_price_display }}
               </span>
-            {% endif %}
-          {% else %}
-            <!-- No image? Show a clean, centered info front -->
+              {% endif %}
+            {% else %}
+              <!-- No image? Show a clean, centered info front -->
             <div class="relative flex h-full flex-col text-center p-4 {{HSM}} {{HMD}} {{HLG}}">
               <div class="dish-card-scroll flex-1 w-full flex flex-col items-center justify-center gap-3 pb-6">
                 <h3 class="text-lg md:text-xl font-bold text-[#49475B]">{{ dish.title }}</h3>
@@ -141,9 +133,9 @@
                 <i class="fa-solid fa-ellipsis"></i>
               </button>
               <div class="dish-menu-panel" data-menu-panel data-no-flip aria-hidden="true">
-                {% if menu_list %}
+                {% if menu_options %}
                   <div class="dish-menu-options" data-no-flip>
-                    {% for menu in menu_list %}
+                    {% for menu in menu_options %}
                       <button
                         type="button"
                         class="dish-menu-option"
@@ -170,9 +162,9 @@
                 {% else %}
                   <div class="dish-menu-empty" data-no-flip>
                     <p>Create a menu to add this dish.</p>
-                    {% if menus_url %}
+                    {% if menus_workspace_url %}
                       <a
-                        href="{{ menus_url }}"
+                        href="{{ menus_workspace_url }}"
                         class="dish-menu-empty-link"
                         data-menu-empty-cta
                         data-no-flip
@@ -199,9 +191,9 @@
             </div>
 
             <!-- Tags -->
-            <div class="flex flex-wrap justify-center gap-2 pb-1">
+            <div class="flex flex-wrap justify-center items-center gap-2 pb-1">
               {% if dish.enhancement_price_display %}
-                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs md:text-sm font-semibold bg-[#ff4c4c] text-light border border-slate-200 shadow-sm">
+                <span class="price-tag text-xs md:text-sm">
                   {{ dish.enhancement_price_display }}
                 </span>
               {% endif %}
@@ -221,22 +213,20 @@
                   {{ tag }}
                 </a>
               {% endfor %}
+              <button
+                type="button"
+                class="dish-delete-btn tag-delete-btn"
+                hx-post="{% url 'dish-delete' dish.id %}"
+                hx-trigger="click"
+                hx-target="closest .dish-card-wrapper"
+                hx-swap="outerHTML"
+                aria-label="Dismiss {{ dish.title }}"
+                data-no-flip
+              >
+                <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
+                <span>Dismiss</span>
+              </button>
             </div>
-          </div>
-
-          <!-- Actions (again, on BACK) -->
-          <div class="flex justify-end gap-2 border-t border-slate-200 pt-3" data-no-flip>
-            <button
-              type="button"
-              class="dish-delete-btn card-action-button text-red-500 hover:text-red-600"
-              hx-post="{% url 'dish-delete' dish.id %}"
-              hx-trigger="click"
-              hx-target="closest .dish-card-wrapper"
-              hx-swap="outerHTML"
-              aria-label="Delete {{ dish.title }}"
-            >
-              🗑️
-            </button>
           </div>
         </div>
       {% endif %}
@@ -251,6 +241,4 @@
     </div>
   </div>
 </div>
-
-{% endwith %}
 

--- a/app/templates/dishes/_card_assets.html
+++ b/app/templates/dishes/_card_assets.html
@@ -153,6 +153,74 @@
     outline-offset: 2px;
   }
 
+  .card-bottom-bar {
+    background: linear-gradient(to top, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+    backdrop-filter: blur(10px);
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 0.75rem;
+    padding-bottom: 0.25rem;
+  }
+
+  .price-tag {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 1.15rem 0.35rem 1.05rem;
+    background: linear-gradient(135deg, #ff6b6b, #ffaf7b);
+    color: #ffffff;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    border-radius: 999px 0 0 999px;
+    clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 50%, calc(100% - 14px) 100%, 0 100%);
+    box-shadow: 0 12px 24px rgba(255, 107, 107, 0.3);
+    z-index: 2;
+  }
+
+  .price-tag::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0.55rem;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.45);
+    transform: translateY(-50%);
+  }
+
+  .tag-delete-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.85rem;
+    border-radius: 9999px;
+    background: rgba(248, 113, 113, 0.12);
+    color: #dc2626;
+    border: 1px solid rgba(248, 113, 113, 0.35);
+    font-weight: 600;
+    font-size: 0.75rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+
+  .tag-delete-btn:hover {
+    background: rgba(248, 113, 113, 0.2);
+    border-color: rgba(248, 113, 113, 0.55);
+    color: #b91c1c;
+    transform: translateY(-1px);
+  }
+
+  .tag-delete-btn:focus-visible {
+    outline: 2px solid rgba(248, 113, 113, 0.75);
+    outline-offset: 2px;
+  }
+
+  .tag-delete-btn i {
+    font-size: 0.85rem;
+  }
+
   .dish-menu-control {
     position: relative;
   }

--- a/app/templates/dishes/grid.html
+++ b/app/templates/dishes/grid.html
@@ -4,3 +4,17 @@
 {% for dish in dishes %}
   {% include "dishes/_card.html" with dish=dish card_context="grid" menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' menus_workspace_url=menus_workspace_url %}
 {% endfor %}
+{% if dishes and dishes_generate_url %}
+  <div class="col-span-full flex justify-center pt-2">
+    <button
+      type="button"
+      hx-post="{{ dishes_generate_url }}"
+      hx-target="#dishes-grid"
+      hx-swap="innerHTML"
+      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
+    >
+      <span>More dishes like these</span>
+      <i class="fa-solid fa-chevron-down text-[10px]"></i>
+    </button>
+  </div>
+{% endif %}

--- a/app/views.py
+++ b/app/views.py
@@ -1898,6 +1898,7 @@ def dish_detail_view(request, concept_id):
         "menu_options": menu_options,
         "menu_move_url": reverse("menu-item-move"),
         "menus_workspace_url": reverse("menus"),
+        "dishes_generate_url": reverse("dishes-generate", args=[concept.id]),
     }
 
     return render(request, template_name, context)

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -259,6 +259,10 @@ class ViewSmokeTests(TestCase):
         )
         self.assertEqual(resp.context["menu_move_url"], reverse("menu-item-move"))
         self.assertEqual(resp.context["menus_workspace_url"], reverse("menus"))
+        self.assertEqual(
+            resp.context["dishes_generate_url"],
+            reverse("dishes-generate", args=[concept.id]),
+        )
 
     def test_dish_detail_empty_menu_renders_workspace_cta(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- Restyle the dish price badge and action footer for a more dynamic discovery card.
- Move the dismiss control into the tag list across card faces and keep styling consistent.
- Add a subtle “More dishes like these” HTMX button and expose its URL in the view context.

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_dish_detail_includes_menu_context


------
https://chatgpt.com/codex/tasks/task_e_68d7236ec26c8332a8330f61ef83eac5