### PR TITLE
Fix dish card context handling for Django 5.2 compatibility

### DIFF
--- a/app/templates/dishes/_card.html
+++ b/app/templates/dishes/_card.html
@@ -1,20 +1,11 @@
 {# Full dish card (lookbook-first) #}
-{% with
-  context_name=card_context|default:"grid"
-  menu_list=menu_options|default:""
-  current_menu=current_menu_id|default:""
-  move_url=menu_move_url|default:""
-  menus_url=menus_workspace_url|default:""
-%}
-
-
 <div
   class="dish-card-wrapper"
   id="dish-{{ dish.id }}"
   data-dish-card
   data-dish-id="{{ dish.id }}"
-  data-current-menu="{{ current_menu }}"
-  data-move-url="{{ move_url }}"
+  data-current-menu="{{ current_menu_id|default:"" }}"
+  data-move-url="{{ menu_move_url|default:"" }}"
   data-favorited="{% if dish.is_favorited %}true{% else %}false{% endif %}"
 >
   <div class="flip-scene h-full">
@@ -51,7 +42,7 @@
             </div>
 
             <footer class="flex justify-end gap-2 pt-1">
-              {% include "dishes/_favorite_button.html" with dish=dish card_context=context_name btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
+              {% include "dishes/_favorite_button.html" with dish=dish card_context=card_context|default:"grid" btn_class='favorite-btn card-action-button bg-white/90 text-slate-500 hover:text-red-400' %}
               <button
                 type="button"
                 class="dish-variation-btn card-action-button bg-white/90 text-slate-600 hover:text-slate-800"
@@ -141,9 +132,9 @@
                 <i class="fa-solid fa-ellipsis"></i>
               </button>
               <div class="dish-menu-panel" data-menu-panel data-no-flip aria-hidden="true">
-                {% if menu_list %}
+                {% if menu_options %}
                   <div class="dish-menu-options" data-no-flip>
-                    {% for menu in menu_list %}
+                    {% for menu in menu_options %}
                       <button
                         type="button"
                         class="dish-menu-option"
@@ -170,9 +161,9 @@
                 {% else %}
                   <div class="dish-menu-empty" data-no-flip>
                     <p>Create a menu to add this dish.</p>
-                    {% if menus_url %}
+                    {% if menus_workspace_url %}
                       <a
-                        href="{{ menus_url }}"
+                        href="{{ menus_workspace_url }}"
                         class="dish-menu-empty-link"
                         data-menu-empty-cta
                         data-no-flip
@@ -251,6 +242,4 @@
     </div>
   </div>
 </div>
-
-{% endwith %}
 

--- a/app/views.py
+++ b/app/views.py
@@ -1909,6 +1909,20 @@ def dish_favorite_view(request, dish_id):
         models.DishIdea.objects.filter(is_deleted=False), id=dish_id
     )
     card_context = request.POST.get("context") or request.GET.get("context") or "grid"
+    current_menu_id = (
+        request.POST.get("current_menu_id")
+        or request.GET.get("current_menu_id")
+        or ""
+    )
+    menu_options: List[dict[str, str]] = []
+    if request.user.is_authenticated:
+        menu_queryset = models.MenuCollection.objects.filter(
+            restaurant=dish.restaurant,
+            restaurant__account__membership__user=request.user,
+        ).order_by("created_at")
+        menu_options = [
+            {"id": str(menu.id), "name": menu.name} for menu in menu_queryset
+        ]
     fav, created = models.FavoriteDish.objects.get_or_create(
         user=request.user, dish=dish, defaults={"favorited_at": timezone.now()}
     )
@@ -1939,6 +1953,9 @@ def dish_favorite_view(request, dish_id):
         {
             "dish": dish,
             "card_context": card_context,
+            "menu_options": menu_options,
+            "menu_move_url": reverse("menu-item-move"),
+            "current_menu_id": current_menu_id,
             "menus_workspace_url": reverse("menus"),
         },
         request=request,
@@ -2133,11 +2150,29 @@ def dish_variation_view(request, dish_id):
 
     decorate_dishes_with_enhancements([new_dish])
 
+    menu_options: List[dict[str, str]] = []
+    if request.user.is_authenticated:
+        menu_queryset = models.MenuCollection.objects.filter(
+            restaurant=restaurant,
+            restaurant__account__membership__user=request.user,
+        ).order_by("created_at")
+        menu_options = [
+            {"id": str(menu.id), "name": menu.name} for menu in menu_queryset
+        ]
+    current_menu_id = (
+        request.POST.get("current_menu_id")
+        or request.GET.get("current_menu_id")
+        or ""
+    )
+
     html = render_to_string(
         "dishes/_card.html",
         {
             "dish": new_dish,
             "card_context": "grid",
+            "menu_options": menu_options,
+            "menu_move_url": reverse("menu-item-move"),
+            "current_menu_id": current_menu_id,
             "menus_workspace_url": reverse("menus"),
         },
         request=request,


### PR DESCRIPTION
## Summary
- remove the obsolete `{% with %}` wrapper in the dish card partial and reference context values directly
- ensure the dish favorite and variation views provide the menu context data that the shared partial consumes

## Testing
- python manage.py check
- python manage.py shell -c "from django.template.loader import render_to_string; from types import SimpleNamespace; dish = SimpleNamespace(id='123e4567-e89b-12d3-a456-426614174000', is_favorited=False, title='Test Dish', description='Tasty', category_tags=['Brunch'], ingredient_overlap=['Eggs'], enhancement_image_url='', enhancement_price_display=''); render_to_string('dishes/_card.html', {'dish': dish, 'card_context': 'grid', 'menu_options': [], 'menu_move_url': '/menus/move/', 'current_menu_id': '', 'menus_workspace_url': '/menus/'})"
- python manage.py shell -c "from django.template.loader import render_to_string; from types import SimpleNamespace; dish = SimpleNamespace(id='123e4567-e89b-12d3-a456-426614174000', is_favorited=True, title='Fav Dish', description='Favorite dish', category_tags=['Dinner'], ingredient_overlap=['Herbs'], enhancement_image_url='https://example.com/img.jpg', enhancement_price_display='$12'); render_to_string('dishes/_card.html', {'dish': dish, 'card_context': 'favorites', 'menu_options': [{'id': '1', 'name': 'Menu'}], 'menu_move_url': '/menus/move/', 'current_menu_id': '1', 'menus_workspace_url': '/menus/'})"

------
https://chatgpt.com/codex/tasks/task_e_68d7d4be71908332ad2d537b28d321fb