### PR TITLE
Adjust creativity slider mapping and surface in UI

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -2,6 +2,7 @@
 {% with root_id=form_id|default:'ai-input' %}
   {% with placeholders_id=root_id|add:'-placeholders' suggestions_id=root_id|add:'-suggestions' indicator_id=root_id|add:'-indicator' %}
     {{ placeholder_samples|json_script:placeholders_id }}
+    {{ suggestions|json_script:suggestions_id }}
 
     <div
       id="{{ root_id }}-wrapper"
@@ -40,12 +41,30 @@
               data-inspire
               class="inline-flex items-center gap-1.5 rounded-full bg-[#FF5C00] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#e05400] focus:outline-none focus:ring-2 focus:ring-[#FF5C00]/40"
             >
-              <span>I feel lucky</span>
+              <span>Inspire Me</span>
               <i class="fa-solid fa-sparkles text-[10px]"></i>
             </button>
           </div>
         </div>
       </form>
+      {% if creative_bias_label %}
+        <p class="text-xs text-slate-500">
+          {{ creative_bias_label }}
+        </p>
+      {% endif %}
+      {% if suggestions %}
+        <div class="flex flex-wrap gap-2">
+          {% for suggestion in suggestions %}
+            <button
+              type="button"
+              class="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-[#49475B] transition hover:bg-slate-100"
+              data-suggestion="{{ suggestion }}"
+            >
+              {{ suggestion }}
+            </button>
+          {% endfor %}
+        </div>
+      {% endif %}
       <div
         id="{{ indicator_id }}"
         class="pointer-events-none hidden"

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -24,7 +24,7 @@
     </section>
 
     <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-      {% include "concepts/_concepts_grid.html" with concepts=[] %}
+      {% include "concepts/_concepts_grid.html" with concepts=empty_concepts %}
     </div>
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,7 @@
 """Application views."""
 
 import json, logging, os, uuid
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Iterable, List, Optional
 
 from django.conf import settings
@@ -67,6 +68,24 @@ DEFAULT_PROMPT_PLACEHOLDERS = [
     "Try: Quick lunch menu",
     "Try: New dessert twists",
 ]
+
+
+def _resolve_creativity_settings(
+    restaurant: "models.Restaurant",
+) -> tuple[int, Decimal]:
+    """Return the slider value and mapped temperature for a restaurant."""
+
+    settings = getattr(restaurant, "restaurantsettings", None)
+    if not settings:
+        settings, _ = models.RestaurantSettings.objects.get_or_create(
+            restaurant=restaurant
+        )
+
+    slider = int(getattr(settings, "classic_creative_slider", 50) or 50)
+    slider = max(0, min(100, slider))
+    temperature = Decimal("0.1") + Decimal(slider) * Decimal("0.008")
+    temperature = temperature.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return slider, temperature
 
 class ConceptList(BaseModel):
     concepts: List[str]
@@ -583,6 +602,12 @@ def dashboard(request, restaurant_id):
     settings_obj, _ = models.RestaurantSettings.objects.get_or_create(
         restaurant=restaurant
     )
+    slider_value, slider_temperature = _resolve_creativity_settings(restaurant)
+    slider_temperature_float = float(slider_temperature)
+    creative_bias_label = (
+        "Creative bias: "
+        f"{slider_value}/100 (0 = Classic, 100 = Inventive) · Temp {slider_temperature_float:.2f}"
+    )
 
     subscription = (
         models.Subscription.objects.filter(account=restaurant.account)
@@ -706,6 +731,7 @@ def dashboard(request, restaurant_id):
         "recent_concepts": recent_concepts,
         "recent_dishes": recent_dishes,
         "menus": menus,
+        "empty_concepts": [],
         "settings_url": reverse("settings"),
         "context_toggle_url": reverse(
             "dashboard-context-toggle", args=[restaurant.id]
@@ -715,6 +741,9 @@ def dashboard(request, restaurant_id):
         "concept_generate_url": reverse("concepts-generate"),
         "concept_prompt_placeholders": DEFAULT_PROMPT_PLACEHOLDERS,
         "concept_prompt_suggestions": build_prompt_suggestions(restaurant),
+        "classic_creative_slider": slider_value,
+        "classic_creative_temperature": slider_temperature_float,
+        "creative_bias_label": creative_bias_label,
     }
     return render(request, "dashboard.html", context)
 
@@ -1043,6 +1072,17 @@ def concepts_view(request):
             .first()
         )
 
+    slider_value = 50
+    slider_temperature = 0.5
+    creative_bias_label = ""
+    if restaurant:
+        slider_value, temperature_decimal = _resolve_creativity_settings(restaurant)
+        slider_temperature = float(temperature_decimal)
+        creative_bias_label = (
+            "Creative bias: "
+            f"{slider_value}/100 (0 = Classic, 100 = Inventive) · Temp {slider_temperature:.2f}"
+        )
+
     concepts_qs = models.Concept.objects.order_by("-created_at").annotate(
         has_dishes=Exists(
             models.DishIdea.objects.filter(
@@ -1071,6 +1111,9 @@ def concepts_view(request):
             "concept_generate_url": reverse("concepts-generate"),
             "concept_prompt_placeholders": DEFAULT_PROMPT_PLACEHOLDERS,
             "concept_prompt_suggestions": build_prompt_suggestions(restaurant),
+            "classic_creative_slider": slider_value,
+            "classic_creative_temperature": slider_temperature,
+            "creative_bias_label": creative_bias_label,
         },
     )
 
@@ -1133,6 +1176,9 @@ def concepts_generate_view(request):
     raw_prompt = (request.POST.get("prompt") or "").strip()
     user_prompt = raw_prompt[:280]
 
+    slider_value, slider_temperature = _resolve_creativity_settings(restaurant)
+    temperature_float = float(slider_temperature)
+
     session_concepts = [
         name.strip()
         for name in (request.session.get("generated_concepts") or [])
@@ -1155,6 +1201,10 @@ def concepts_generate_view(request):
     Current Restaurant Menu:  {restaurant_menu}
     About Services:  {restaurant.about_json}
     """
+    context += (
+        "\nCreative direction slider: "
+        f"{slider_value}/100 (0 = classic, 100 = highly inventive)."
+    )
     if session_concepts:
         context += (
             "\nPreviously generated concept names to avoid: "
@@ -1221,6 +1271,9 @@ def concepts_generate_view(request):
                 - Cultural heritage nights (Italian Nonna Night, Korean Comfort, etc.)
                 - Weather-responsive themes (Cozy Soup Sundays, Summer Grill Nights)
 
+                **Creative Direction Slider**: {slider_value}/100 where 0 = classic and 100 = highly inventive.
+                Match the ambition of the slider when balancing comforting favorites with bold experimentation.
+
                 **Example Structure**:
                 ```
                 1. **Name**: "Harvest Moon Monday"
@@ -1251,6 +1304,8 @@ def concepts_generate_view(request):
         "prompt": user_prompt,
         "session_concepts": session_concepts[:15],
         "context": context,
+        "classic_creative_slider": slider_value,
+        "temperature": temperature_float,
     }
 
     ideation_run = models.IdeationRun.objects.create(
@@ -1258,8 +1313,8 @@ def concepts_generate_view(request):
         initiated_by_user=request.user,
         type=models.IdeationRun.RunType.CONCEPTS,
         model_name="gpt-4.1-mini",
-        temperature=0.5,
-        classic_creative=50,
+        temperature=slider_temperature,
+        classic_creative=slider_value,
         context_snapshot=context_snapshot,
         status=models.IdeationRun.Status.RUNNING,
         started_at=timezone.now(),)
@@ -1277,6 +1332,7 @@ def concepts_generate_view(request):
                 {"role": "user", "content": context},
             ],
             text={"format": schema},
+            temperature=temperature_float,
         )
         logger.info(context)
         raw_text = response.output[0].content[0].text
@@ -1764,6 +1820,8 @@ def dishes_generate_view(request, concept_id):
     concept = models.Concept.objects.select_related("restaurant").get(id=concept_id)
     restaurant = concept.restaurant
     membership = models.Membership.objects.filter(user=request.user).first()
+    slider_value, slider_temperature = _resolve_creativity_settings(restaurant)
+    temperature_float = float(slider_temperature)
     if restaurant.active_menu_version:
         restaurant_menu = restaurant.active_menu_version.raw_markdown
     else:
@@ -1775,6 +1833,10 @@ def dishes_generate_view(request, concept_id):
         Current Restaurant Menu:  {restaurant_menu}
         About Services:  {restaurant.about_json}
     """
+    context_text += (
+        "\n        Creative direction slider: "
+        f"{slider_value}/100 (0 = classic, 100 = highly inventive)."
+    )
 
     deleted_dishes = list(
         models.DishIdea.objects.filter(restaurant=restaurant, is_deleted=True)
@@ -1785,6 +1847,8 @@ def dishes_generate_view(request, concept_id):
     context_payload = {
         "context": context_text,
         "deleted_dishes": deleted_dishes,
+        "classic_creative_slider": slider_value,
+        "temperature": temperature_float,
     }
 
     logger.info("Starting dish generation: concept=%s, restaurant=%s", concept.name, restaurant.name)
@@ -1837,8 +1901,8 @@ def dishes_generate_view(request, concept_id):
         initiated_by_user=request.user,
         type=models.IdeationRun.RunType.DISHES,
         model_name="gpt-4o-mini",
-        temperature=0.7,
-        classic_creative=50,
+        temperature=slider_temperature,
+        classic_creative=slider_value,
         context_snapshot=context_payload,
         parent_concept=concept,
         status=models.IdeationRun.Status.RUNNING,
@@ -1852,6 +1916,12 @@ def dishes_generate_view(request, concept_id):
         Each dish must include: title, description, ingredient_overlap, category_tags.
         """
 
+        instruction += (
+            "\nCreative direction slider: "
+            f"{slider_value}/100 (0 = classic, 100 = highly inventive)."
+            " Follow this bias when proposing dish riffs."
+        )
+
         if previous_titles:
             instruction += "\nAvoid repeating these dish names: " + ", ".join(previous_titles)
 
@@ -1863,6 +1933,7 @@ def dishes_generate_view(request, concept_id):
                 {"role": "user", "content": json.dumps(context_payload, indent=2)},
             ],
             text={"format": schema},
+            temperature=temperature_float,
         )
 
         raw_text = response.output[0].content[0].text

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -138,6 +139,7 @@ class ViewSmokeTests(TestCase):
         resp = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
         self.assertContains(resp, "Inspire Me")
         self.assertContains(resp, "Italian chef&#x27;s table")
+        self.assertContains(resp, "Creative bias: 50/100")
 
     def test_concepts_page_includes_contextual_ai_input(self):
         self._create_concepts()
@@ -147,6 +149,7 @@ class ViewSmokeTests(TestCase):
         resp = self.client.get(reverse("concepts"))
         self.assertContains(resp, "concepts-ai-input")
         self.assertContains(resp, "Inspire Me")
+        self.assertContains(resp, "Creative bias: 50/100")
 
     def test_concepts_and_generation(self):
         self._create_concepts()
@@ -172,6 +175,43 @@ class ViewSmokeTests(TestCase):
             gen_resp = self.client.post(reverse("concepts-generate"))
         self.assertEqual(gen_resp.status_code, 302)
         self.assertEqual(gen_resp["Location"], reverse("concepts"))
+
+    def test_concept_generation_respects_creativity_slider(self):
+        settings = self.restaurant.restaurantsettings
+        settings.classic_creative_slider = 80
+        settings.save(update_fields=["classic_creative_slider"])
+
+        payload = {
+            "concepts": [
+                {
+                    "title": f"Spice {i}",
+                    "subtitle": "Sub",
+                    "reasoning": "Because",
+                    "tags": ["tag1", "tag2", "tag3"],
+                }
+                for i in range(9)
+            ]
+        }
+        fake_response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+        )
+
+        with patch("app.views.client") as mock_client:
+            mock_client.responses.create.return_value = fake_response
+            self.client.post(reverse("concepts-generate"))
+            _, call_kwargs = mock_client.responses.create.call_args
+
+        run = (
+            models.IdeationRun.objects.filter(type=models.IdeationRun.RunType.CONCEPTS)
+            .order_by("-created_at")
+            .first()
+        )
+        self.assertIsNotNone(run)
+        self.assertEqual(run.classic_creative, 80)
+        self.assertEqual(run.temperature, Decimal("0.74"))
+        self.assertEqual(run.context_snapshot["classic_creative_slider"], 80)
+        self.assertAlmostEqual(run.context_snapshot["temperature"], 0.74, places=2)
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.74, places=2)
 
     def test_dashboard_generation_hx_redirects_to_concepts(self):
         self._create_concepts()
@@ -200,6 +240,48 @@ class ViewSmokeTests(TestCase):
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["HX-Redirect"], reverse("concepts"))
+
+    def test_dish_generation_respects_creativity_slider(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+
+        settings = self.restaurant.restaurantsettings
+        settings.classic_creative_slider = 20
+        settings.save(update_fields=["classic_creative_slider"])
+
+        payload = {
+            "dishes": [
+                {
+                    "title": f"Dish {i}",
+                    "description": "Desc",
+                    "ingredient_overlap": ["Item"],
+                    "category_tags": ["Tag"],
+                }
+                for i in range(9)
+            ]
+        }
+        fake_response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+        )
+
+        with patch("app.views.client") as mock_client:
+            mock_client.responses.create.return_value = fake_response
+            self.client.post(reverse("dishes-generate", args=[concept.id]))
+            _, call_kwargs = mock_client.responses.create.call_args
+
+        run = (
+            models.IdeationRun.objects.filter(
+                type=models.IdeationRun.RunType.DISHES, parent_concept=concept
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        self.assertIsNotNone(run)
+        self.assertEqual(run.classic_creative, 20)
+        self.assertEqual(run.temperature, Decimal("0.26"))
+        self.assertEqual(run.context_snapshot["classic_creative_slider"], 20)
+        self.assertAlmostEqual(run.context_snapshot["temperature"], 0.26, places=2)
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.26, places=2)
 
     def test_concept_favorite(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- map each restaurant's creativity slider to LLM temperature via a shared helper and apply it across concept and dish generation flows
- surface the slider direction in the dashboard/concepts prompt component with a creative bias reminder and quick suggestion chips
- add regression tests that confirm the mapped temperatures and UI hints are rendered

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_dashboard_displays_contextual_ai_component
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_concepts_page_includes_contextual_ai_input
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_concept_generation_respects_creativity_slider
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_dish_generation_respects_creativity_slider

------
https://chatgpt.com/codex/tasks/task_e_68d83456d03c8332bc512b5df279621c