### PR TITLE
Improve concept generator controls and appending behavior

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -1,8 +1,7 @@
 {% load static %}
 {% with root_id=form_id|default:'ai-input' %}
-  {% with placeholders_id=root_id|add:'-placeholders' suggestions_id=root_id|add:'-suggestions' indicator_id=root_id|add:'-indicator' %}
+  {% with placeholders_id=root_id|add:'-placeholders' indicator_id=root_id|add:'-indicator' %}
     {{ placeholder_samples|json_script:placeholders_id }}
-    {{ suggestions|json_script:suggestions_id }}
 
     <div
       id="{{ root_id }}-wrapper"
@@ -10,13 +9,17 @@
       class="relative space-y-4 pt-1 sm:pt-0"
     >
 
+      {% if instructions_text %}
+        <p class="text-xs text-slate-500">{{ instructions_text }}</p>
+      {% endif %}
+
       <form
         id="{{ root_id }}"
         hx-post="{{ action_url }}"
         hx-target="{{ target }}"
         hx-swap="{{ hx_swap|default:'innerHTML' }}"
         hx-indicator="#{{ indicator_id }}"
-        class="flex flex-col gap-3 sm:flex-row sm:items-center"
+        class="space-y-4"
       >
         <div class="relative flex-1">
           <input
@@ -45,24 +48,27 @@
             </button>
           </div>
         </div>
+        <div class="space-y-2">
+          <div class="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+            <span>Classic</span>
+            <span data-slider-value>{{ slider_value|default:50 }}/100</span>
+            <span>Creative</span>
+          </div>
+          <input
+            type="range"
+            name="classic_creative_slider"
+            id="{{ root_id }}-slider"
+            min="0"
+            max="100"
+            value="{{ slider_value|default:50 }}"
+            class="w-full accent-[#B993D6]"
+          >
+        </div>
       </form>
       {% if creative_bias_label %}
         <p class="text-xs text-slate-500">
           {{ creative_bias_label }}
         </p>
-      {% endif %}
-      {% if suggestions %}
-        <div class="flex flex-wrap gap-2">
-          {% for suggestion in suggestions %}
-            <button
-              type="button"
-              class="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-[#49475B] transition hover:bg-slate-100"
-              data-suggestion="{{ suggestion }}"
-            >
-              {{ suggestion }}
-            </button>
-          {% endfor %}
-        </div>
       {% endif %}
       <div
         id="{{ indicator_id }}"
@@ -104,19 +110,12 @@
         const form = root.querySelector("form");
         const input = root.querySelector('input[name="prompt"]');
         const placeholderEl = document.getElementById("{{ placeholders_id }}");
-        const suggestionEl = document.getElementById("{{ suggestions_id }}");
         let placeholders = [];
-        let suggestions = [];
 
         try {
           placeholders = JSON.parse(placeholderEl ? placeholderEl.textContent : "[]");
         } catch (error) {
           placeholders = [];
-        }
-        try {
-          suggestions = JSON.parse(suggestionEl ? suggestionEl.textContent : "[]");
-        } catch (error) {
-          suggestions = [];
         }
 
         if (placeholders.length > 1) {
@@ -132,26 +131,26 @@
           }, 4200);
         }
 
-        root.querySelectorAll('[data-suggestion]').forEach(function (button) {
-          button.addEventListener('click', function () {
-            if (!input) {
-              return;
-            }
-            input.value = button.getAttribute('data-suggestion') || '';
-            form.requestSubmit();
-          });
-        });
-
         const inspireButton = root.querySelector('[data-inspire]');
         if (inspireButton) {
           inspireButton.addEventListener('click', function () {
-            const pool = suggestions.concat(placeholders);
+            const pool = placeholders.length ? placeholders : ['Seasonal chef specials'];
             const choice = pool[Math.floor(Math.random() * pool.length)] || 'Seasonal chef specials';
             if (input) {
               input.value = choice;
               form.requestSubmit();
             }
           });
+        }
+
+        const slider = root.querySelector('#{{ root_id }}-slider');
+        const sliderValue = root.querySelector('[data-slider-value]');
+        if (slider && sliderValue) {
+          const updateSliderValue = function () {
+            sliderValue.textContent = slider.value + '/100';
+          };
+          slider.addEventListener('input', updateSliderValue);
+          updateSliderValue();
         }
       })();
     </script>

--- a/app/templates/concepts/_card.html
+++ b/app/templates/concepts/_card.html
@@ -40,7 +40,7 @@
             </div>
           </div>
         {% else %}
-          <div class="relative z-10 flex h-full flex-col items-center justify-center p-6 text-center">
+          <div class="relative z-10 flex h-full flex-col items-center justify-center text-center {% if concept.is_favorited_for_user %}p-6{% else %}px-4 py-5 sm:px-5 sm:py-6{% endif %}">
             <h2 class="text-lg md:text-xl lg:text-2xl font-bold text-[#49475B]">
               {{ concept.name }}
             </h2>

--- a/app/templates/concepts/_concepts_grid.html
+++ b/app/templates/concepts/_concepts_grid.html
@@ -1,17 +1,3 @@
 {% for concept in concepts %}
   {% include "concepts/_card.html" with concept=concept %}
 {% endfor %}
-{% if concepts and concept_generate_url %}
-  <div class="col-span-full flex justify-center pt-2">
-    <button
-      type="button"
-      hx-post="{{ concept_generate_url }}"
-      hx-target="#concepts-grid"
-      hx-swap="innerHTML"
-      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
-    >
-      <span>More ideas like these</span>
-      <i class="fa-solid fa-chevron-down text-[10px]"></i>
-    </button>
-  </div>
-{% endif %}

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -13,13 +13,28 @@
   <div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
     <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <div class="space-y-4">
-        <p class="text-sm font-medium text-[#49475B]">Try a suggestion below or type your own focus to refresh the grid.</p>
-        {% include "_partials/contextual_ai_input.html" with form_id="concepts-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders suggestions=concept_prompt_suggestions %}
+        <p class="text-sm font-medium text-[#49475B]">Set the vibe you want to explore and let Appertivo riff on it.</p>
+        {% include "_partials/contextual_ai_input.html" with form_id="concepts-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders instructions_text="Describe a theme and adjust the slider to balance classic and creative energy." slider_value=classic_creative_slider %}
       </div>
     </section>
 
-    <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-      {% include 'concepts/_concepts_grid.html' with concept_generate_url=concept_generate_url %}
+    <div class="space-y-4">
+      <div id="concepts-grid" class="grid grid-cols-2 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+        {% include 'concepts/_concepts_grid.html' %}
+      </div>
+      <div class="flex justify-center">
+        <button
+          type="button"
+          hx-post="{{ concept_generate_url }}"
+          hx-target="#concepts-grid"
+          hx-swap="beforeend"
+          hx-include="#concepts-ai-input-slider"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
+        >
+          <span>More ideas like these</span>
+          <i class="fa-solid fa-chevron-down text-[10px]"></i>
+        </button>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -19,7 +19,7 @@
     <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <div class="space-y-4">
         <p class="text-sm font-medium text-[#49475B]">Try a suggestion below or type your own focus to refresh the grid.</p>
-        {% include "_partials/contextual_ai_input.html" with form_id="dashboard-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders suggestions=concept_prompt_suggestions %}
+        {% include "_partials/contextual_ai_input.html" with form_id="dashboard-ai-input" action_url=concept_generate_url target="#concepts-grid" placeholder_samples=concept_prompt_placeholders slider_value=classic_creative_slider %}
       </div>
     </section>
 

--- a/app/views.py
+++ b/app/views.py
@@ -1177,6 +1177,19 @@ def concepts_generate_view(request):
     user_prompt = raw_prompt[:280]
 
     slider_value, slider_temperature = _resolve_creativity_settings(restaurant)
+    slider_override_raw = request.POST.get("classic_creative_slider")
+    if slider_override_raw is not None:
+        try:
+            slider_override = int(slider_override_raw)
+        except (TypeError, ValueError):
+            slider_override = None
+        if slider_override is not None:
+            slider_override = max(0, min(100, slider_override))
+            slider_value = slider_override
+            slider_temperature = (
+                Decimal("0.1") + Decimal(slider_value) * Decimal("0.008")
+            ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
     temperature_float = float(slider_temperature)
 
     session_concepts = [


### PR DESCRIPTION
## Summary
- add inline creativity slider and concise guidance to the concept generator while removing cramped suggestion chips
- let "More ideas like these" append new concept cards below the current grid and reuse the tuned slider value
- tighten spacing on non-favorited concept cards for fuller text presentation and accept slider overrides during concept generation

## Testing
- pytest *(fails: django settings not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8455967308332bfd9774df716fa59