### PR TITLE
Redirect dish generation to detail page

### DIFF
--- a/app/templates/concepts/_card.html
+++ b/app/templates/concepts/_card.html
@@ -113,6 +113,7 @@
               hx-trigger="click"
               data-overlay="true"
               data-messages='["Cooking up ideas…", "Almost there…", "Plating concepts!"]'
+              data-generate-button
             >
               <i class="fa-solid fa-utensils text-[0.8rem]"></i>
               <span>Generate</span>
@@ -138,6 +139,10 @@
       <div class="concept-loading-face">
         <div class="concept-loading-spinner" aria-hidden="true"></div>
         <p class="text-sm font-semibold tracking-wide uppercase">Preparing your concept sketch…</p>
+      </div>
+
+      <div class="concept-progress" aria-hidden="true">
+        <div class="concept-progress__bar"></div>
       </div>
 
       {% if loading %}

--- a/app/templates/concepts/_card_assets.html
+++ b/app/templates/concepts/_card_assets.html
@@ -84,6 +84,10 @@
     opacity: 0;
   }
 
+  .concept-card-wrapper .flip-card.concept-generating .flip-face {
+    opacity: 1;
+  }
+
   .concept-favorite-btn--favorited {
     background: rgba(254, 226, 226, 0.95) !important;
     border-color: rgba(254, 202, 202, 0.9) !important;
@@ -99,9 +103,104 @@
     animation: concept-card-spin 1s linear infinite;
   }
 
+  .concept-card-wrapper .concept-progress {
+    position: absolute;
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    height: 4px;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.55);
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(4px);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .concept-card-wrapper .concept-progress__bar {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, #f08000, #b993d6);
+    transform-origin: left center;
+    animation: concept-progress-bar 1.6s ease-in-out infinite;
+    animation-play-state: paused;
+  }
+
+  .concept-card-wrapper .flip-card.concept-generating .concept-progress {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .concept-card-wrapper .flip-card.concept-generating .concept-progress__bar {
+    animation-play-state: running;
+  }
+
+  .concept-favorite-btn--busy {
+    position: relative;
+    pointer-events: none;
+    color: #f43f5e !important;
+  }
+
+  .concept-favorite-btn--busy span {
+    opacity: 0;
+  }
+
+  .concept-favorite-btn--busy::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 9999px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: concept-card-spin 0.8s linear infinite;
+  }
+
+  [data-generate-button].concept-generate-btn--busy {
+    pointer-events: none;
+    opacity: 0.75;
+  }
+
+  [data-more-ideas] .more-ideas-spinner {
+    display: none;
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 9999px;
+    border: 2px solid rgba(148, 163, 184, 0.55);
+    border-top-color: rgba(79, 70, 229, 0.8);
+  }
+
+  [data-more-ideas].is-loading .more-ideas-spinner {
+    display: inline-block;
+    animation: concept-card-spin 0.9s linear infinite;
+  }
+
+  [data-more-ideas].is-loading .more-ideas-text {
+    opacity: 0.6;
+  }
+
+  [data-more-ideas].is-loading i {
+    opacity: 0;
+  }
+
   @keyframes concept-card-spin {
     to {
       transform: rotate(360deg);
+    }
+  }
+
+  @keyframes concept-progress-bar {
+    0% {
+      transform: scaleX(0.1);
+    }
+    50% {
+      transform: scaleX(0.6);
+    }
+    100% {
+      transform: scaleX(1);
     }
   }
 </style>
@@ -178,36 +277,76 @@
       return wrapper ? wrapper.querySelector('.flip-card') : null;
     };
 
+    const isConceptFavoriteButton = (elt) => elt && elt.classList.contains('concept-favorite-btn');
+    const isConceptDeleteButton = (elt) => elt && elt.classList.contains('concept-delete-btn');
+    const isConceptSketchLoader = (elt) => elt && elt.classList.contains('concept-sketch-loader');
+    const isConceptGenerateButton = (elt) => elt && elt.hasAttribute('data-generate-button');
+    const isMoreIdeasButton = (elt) => elt && elt.hasAttribute('data-more-ideas');
+
     const shouldShowConceptLoading = (elt) => {
       if (!elt) {
         return false;
       }
-      return (
-        elt.classList.contains('concept-favorite-btn') ||
-        elt.classList.contains('concept-delete-btn') ||
-        elt.classList.contains('concept-sketch-loader')
-      );
+      return isConceptDeleteButton(elt) || isConceptSketchLoader(elt);
+    };
+
+    const clearConceptTriggerState = (trigger) => {
+      if (!trigger) {
+        return;
+      }
+      const card = findConceptCard(trigger);
+      if (card) {
+        if (shouldShowConceptLoading(trigger)) {
+          card.classList.remove('loading');
+        }
+        if (isConceptGenerateButton(trigger)) {
+          card.classList.remove('concept-generating');
+        }
+      }
+      if (isConceptFavoriteButton(trigger)) {
+        trigger.classList.remove('concept-favorite-btn--busy');
+      }
+      if (isConceptGenerateButton(trigger)) {
+        trigger.classList.remove('concept-generate-btn--busy');
+        trigger.removeAttribute('disabled');
+      }
+      if (isMoreIdeasButton(trigger)) {
+        trigger.classList.remove('is-loading');
+        trigger.removeAttribute('disabled');
+      }
     };
 
     document.body.addEventListener('htmx:beforeRequest', function (evt) {
       const trigger = evt.detail && evt.detail.elt;
-      if (!shouldShowConceptLoading(trigger)) {
-        return;
-      }
       const card = findConceptCard(trigger);
-      if (!card) {
-        return;
+
+      if (isConceptFavoriteButton(trigger)) {
+        trigger.classList.add('concept-favorite-btn--busy');
       }
-      card.classList.remove('show-back');
-      card.classList.add('loading');
+
+      if (isConceptGenerateButton(trigger)) {
+        if (card) {
+          card.classList.remove('show-back');
+          card.classList.add('concept-generating');
+        }
+        trigger.classList.add('concept-generate-btn--busy');
+        trigger.setAttribute('disabled', 'disabled');
+      } else if (shouldShowConceptLoading(trigger)) {
+        if (card) {
+          card.classList.remove('show-back');
+          card.classList.add('loading');
+        }
+      }
+
+      if (isMoreIdeasButton(trigger)) {
+        trigger.classList.add('is-loading');
+        trigger.setAttribute('disabled', 'disabled');
+      }
     });
 
     document.body.addEventListener('htmx:responseError', function (evt) {
       const trigger = evt.detail && evt.detail.elt;
-      const card = findConceptCard(trigger);
-      if (card) {
-        card.classList.remove('loading');
-      }
+      clearConceptTriggerState(trigger);
     });
 
     document.body.addEventListener('htmx:afterSwap', function (evt) {
@@ -216,21 +355,17 @@
 
       if (shouldShowConceptLoading(trigger)) {
         if (!target) {
-          const card = findConceptCard(trigger);
-          if (card) {
-            card.classList.remove('loading');
-          }
+          clearConceptTriggerState(trigger);
         } else if (
           (typeof target.matches === 'function' && target.matches(conceptCardSelector)) ||
           (typeof target.querySelector === 'function' && target.querySelector(conceptCardSelector))
         ) {
-          // Replaced with a fresh card, no need to toggle loading.
+          // replaced card
         } else {
-          const card = findConceptCard(trigger);
-          if (card) {
-            card.classList.remove('loading');
-          }
+          clearConceptTriggerState(trigger);
         }
+      } else {
+        clearConceptTriggerState(trigger);
       }
 
       if (conceptTargetNeedsReorder(target)) {
@@ -243,7 +378,7 @@
       if (!card) {
         return;
       }
-      if (card.classList.contains('loading')) {
+      if (card.classList.contains('loading') || card.classList.contains('concept-generating')) {
         return;
       }
       const wrapper = card.closest('[data-concept-card]');

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -30,8 +30,10 @@
           hx-swap="beforeend"
           hx-include="#concepts-ai-input-slider"
           class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
+          data-more-ideas
         >
-          <span>More ideas like these</span>
+          <span class="more-ideas-spinner" aria-hidden="true"></span>
+          <span class="more-ideas-text">More ideas like these</span>
           <i class="fa-solid fa-chevron-down text-[10px]"></i>
         </button>
       </div>

--- a/app/views.py
+++ b/app/views.py
@@ -1414,11 +1414,17 @@ def concept_favorite_view(request, concept_id):
     fav, created = models.FavoriteConcept.objects.get_or_create(
         user=request.user, concept=concept, defaults={"favorited_at": timezone.now()}
     )
-    favorited = created
 
+    if created:
+        if request.headers.get("HX-Request") == "true":
+            response = HttpResponse(status=204)
+            response["HX-Redirect"] = reverse("dish_detail", args=[concept.id])
+            return response
+        return redirect("dish_detail", concept_id=concept.id)
+
+    favorited = False
     if not created:
         fav.delete()
-        favorited = False
         if concept.sketch_image_url:
             concept.sketch_image_url = None
             concept.save(update_fields=["sketch_image_url"])
@@ -1988,26 +1994,9 @@ def dishes_generate_view(request, concept_id):
         ideation_run.save(update_fields=["status", "error_message"])
 
     if htmx_request:
-        decorate_dishes_with_enhancements(dish_objects)
-        for dish in dish_objects:
-            dish.is_favorited = False
-        menu_options: List[dict[str, str]] = []
-        if request.user.is_authenticated:
-            menu_queryset = models.MenuCollection.objects.filter(
-                restaurant=restaurant,
-                restaurant__account__membership__user=request.user,
-            ).order_by("created_at")
-            menu_options = [
-                {"id": str(menu.id), "name": menu.name} for menu in menu_queryset
-            ]
-
-        context = {
-            "dishes": dish_objects,
-            "menu_options": menu_options,
-            "menu_move_url": reverse("menu-item-move"),
-            "menus_workspace_url": reverse("menus"),
-        }
-        return render(request, "dishes/grid.html", context)
+        response = HttpResponse(status=204)
+        response["HX-Redirect"] = reverse("dish_detail", args=[concept.id])
+        return response
 
     return dish_detail_view(request, concept_id)
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -283,6 +283,34 @@ class ViewSmokeTests(TestCase):
         self.assertAlmostEqual(run.context_snapshot["temperature"], 0.26, places=2)
         self.assertAlmostEqual(call_kwargs["temperature"], 0.26, places=2)
 
+    def test_dishes_generate_htmx_redirects(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+        payload = {
+            "dishes": [
+                {
+                    "title": "Dish",
+                    "description": "Desc",
+                    "ingredient_overlap": ["Item"],
+                    "category_tags": ["Tag"],
+                }
+                for _ in range(9)
+            ]
+        }
+        fake_response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+        )
+
+        with patch("app.views.client") as mock_client:
+            mock_client.responses.create.return_value = fake_response
+            resp = self.client.post(
+                reverse("dishes-generate", args=[concept.id]),
+                HTTP_HX_REQUEST="true",
+            )
+
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp["HX-Redirect"], reverse("dish_detail", args=[concept.id]))
+
     def test_concept_favorite(self):
         self._create_concepts()
         concept = models.Concept.objects.first()
@@ -291,6 +319,18 @@ class ViewSmokeTests(TestCase):
         self.assertTrue(
             models.FavoriteConcept.objects.filter(user=self.user, concept=concept).exists()
         )
+
+    def test_concept_favorite_htmx_redirects_to_dishes(self):
+        self._create_concepts()
+        concept = models.Concept.objects.first()
+
+        resp = self.client.post(
+            reverse("concept-favorite", args=[concept.id]),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp["HX-Redirect"], reverse("dish_detail", args=[concept.id]))
 
     def test_concepts_page_marks_existing_favorites(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- redirect HTMX concept favorite requests to the dish detail page
- send dish generation HTMX responses to the dish detail page and show progress feedback on concept cards
- add button and spinner affordances plus tests to cover the new redirects

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_concept_favorite_htmx_redirects_to_dishes tests.test_appertivo_views.ViewSmokeTests.test_dishes_generate_htmx_redirects


------
https://chatgpt.com/codex/tasks/task_e_68d850f836d483329decd82f0da206b9