### PR TITLE
Refine favorites page layouts

### DIFF
--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "layouts/app.html" %}
+{% load collaboration_tags %}
 {% block title %}Favorites — Appertivo{% endblock %}
 
 {% block page_intro %}
@@ -11,22 +12,17 @@
 {% endblock %}
 
 {% block page_content %}
-{% include "concepts/_card_assets.html" %}
-{% include "dishes/_card_assets.html" %}
 <style>
   details.favorites-section > summary::-webkit-details-marker { display: none; }
   details.favorites-section > summary::marker { display: none; }
 </style>
-<div
-  id="favorites-root"
-  class="px-4 py-8 space-y-8"
->
+<div class="px-4 py-8 space-y-8">
 
   <details open class="favorites-section group rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
     <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-5">
       <div>
         <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Favorited concepts</h2>
-        <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Flip cards to view details & inspiration</p>
+        <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Quickly open concepts and see where they land.</p>
       </div>
       <span class="ml-auto inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-[#B993D6] transition-transform duration-200 group-open:rotate-180">
         <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
@@ -45,17 +41,70 @@
       </div>
 
       {% if favorite_concepts %}
-        <div id="favorite-concepts-grid" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <ul class="space-y-3">
           {% for favorite in favorite_concepts %}
-            {% url 'favorite-remove' 'concept' favorite.concept.id as remove_favorite_url %}
-            {% include "concepts/_card.html" with concept=favorite.concept favorited=True favorite_url_override=remove_favorite_url show_delete=False %}
+            {% with concept=favorite.concept concept_menus=concept_menu_map|dict_lookup:favorite.concept.id %}
+              {% if concept %}
+                <li
+                  id="favorite-concept-{{ concept.id }}"
+                  class="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                >
+                  <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                    {% if concept.sketch_image_url %}
+                      <img
+                        src="{{ concept.sketch_image_url }}"
+                        alt="{{ concept.name }} sketch"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                        decoding="async"
+                      />
+                    {% else %}
+                      <div class="flex h-full w-full items-center justify-center text-slate-400">
+                        <i class="fa-regular fa-image text-xl" aria-hidden="true"></i>
+                      </div>
+                    {% endif %}
+                  </div>
+                  <div class="flex-1 space-y-1">
+                    <h3 class="text-base font-semibold text-[#49475B]">{{ concept.name }}</h3>
+                    {% if concept.subtitle %}
+                      <p class="text-sm text-slate-600">{{ concept.subtitle }}</p>
+                    {% endif %}
+                  </div>
+                  <div class="flex flex-col items-end gap-2 text-right">
+                    <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-[#49475B]">
+                      <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                      {% if concept_menus %}
+                        {{ concept_menus|join:", " }}
+                      {% else %}
+                        Not in a menu
+                      {% endif %}
+                    </span>
+                    <div class="flex items-center gap-2">
+                      <a
+                        href="{% url 'dish_detail' concept.id %}"
+                        class="inline-flex items-center gap-2 rounded-full bg-[#FF5C00] px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-[#e05400]"
+                      >
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                        <span>Open concept</span>
+                      </a>
+                      <button
+                        type="button"
+                        class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                        hx-post="{% url 'favorite-remove' 'concept' concept.id %}"
+                        hx-target="#favorite-concept-{{ concept.id }}"
+                        hx-swap="outerHTML"
+                        title="Remove from favorites"
+                      >
+                        <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                        <span class="sr-only">Remove {{ concept.name }} from favorites</span>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              {% endif %}
+            {% endwith %}
           {% endfor %}
-        </div>
-        <div id="favorites-dishes-loading" class="mt-4 hidden items-center gap-2 text-sm font-medium text-slate-500">
-          <i class="fa-solid fa-spinner fa-spin"></i>
-          <span>Generating dishes…</span>
-        </div>
-        <div id="favorites-generated-dishes" class="grid grid-cols-1 gap-4 md:grid-cols-2"></div>
+        </ul>
       {% else %}
         <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-6 text-sm text-slate-500">
           Save a concept to see it here. Favoriting unlocks quick access to sketches and fresh dish ideas.
@@ -67,68 +116,92 @@
   <details open class="favorites-section group rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
     <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-5">
       <div>
-        <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Unassigned favorites</h2>
-        <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Keep dishes here until they belong somewhere</p>
+        <h2 class="text-lg font-semibold text-[#49475B] md:text-xl">Favorited dishes</h2>
+        <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Jump into the latest dish run and check menu placement.</p>
       </div>
       <span class="ml-auto inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-[#B993D6] transition-transform duration-200 group-open:rotate-180">
         <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
       </span>
     </summary>
     <div class="space-y-4 px-6 pb-6">
-      <p class="text-sm text-slate-500">Use the … menu on any dish to assign it to a menu. Once assigned, it disappears from this list.</p>
-
-      <div
-        class="rounded-3xl border border-dashed border-slate-200 bg-white p-4"
-        id="favorites-uncategorized"
-      >
-        <div data-uncategorized-list class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {% for favorite in uncategorized_favorites %}
-            <div id="favorite-dish-{{ favorite.dish.id }}" class="favorite-dish-card">
-              {% include "dishes/_card.html" with dish=favorite.dish card_context='favorites' menu_options=menu_options menu_move_url=menu_move_url current_menu_id='' menus_workspace_url=menus_workspace_url %}
-            </div>
+      {% if favorite_dishes %}
+        <ul class="space-y-3">
+          {% for favorite in favorite_dishes %}
+            {% with dish=favorite.dish %}
+              {% if dish %}
+                {% with dish_menus=dish_menu_map|dict_lookup:dish.id %}
+                  <li
+                    id="favorite-dish-{{ dish.id }}"
+                    class="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                  >
+                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                      {% if dish.enhancement_image_url %}
+                        <img
+                          src="{{ dish.enhancement_image_url }}"
+                          alt="{{ dish.title }} image"
+                          class="h-full w-full object-cover"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      {% else %}
+                        <div class="flex h-full w-full items-center justify-center text-slate-400">
+                          <i class="fa-solid fa-utensils text-base" aria-hidden="true"></i>
+                        </div>
+                      {% endif %}
+                    </div>
+                    <div class="flex-1 space-y-1">
+                      <h3 class="text-base font-semibold text-[#49475B]">{{ dish.title }}</h3>
+                      {% if dish.description %}
+                        <p class="text-sm text-slate-600">{{ dish.description }}</p>
+                      {% endif %}
+                      {% if dish.parent_concept %}
+                        <p class="text-xs text-slate-400">Concept: {{ dish.parent_concept.name }}</p>
+                      {% endif %}
+                    </div>
+                    <div class="flex flex-col items-end gap-2 text-right">
+                      <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-[#49475B]">
+                        <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                        {% if dish_menus %}
+                          {{ dish_menus|join:", " }}
+                        {% else %}
+                          Unassigned
+                        {% endif %}
+                      </span>
+                      <div class="flex items-center gap-2">
+                        {% if dish.parent_concept_id %}
+                          <a
+                            href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                            class="inline-flex items-center gap-2 rounded-full bg-[#58B09C] px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-[#4b9c8a]"
+                          >
+                            <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                            <span>Open run</span>
+                          </a>
+                        {% endif %}
+                        <button
+                          type="button"
+                          class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                          hx-post="{% url 'favorite-remove' 'dish' dish.id %}"
+                          hx-target="#favorite-dish-{{ dish.id }}"
+                          hx-swap="outerHTML"
+                          title="Remove from favorites"
+                        >
+                          <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                          <span class="sr-only">Remove {{ dish.title }} from favorites</span>
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                {% endwith %}
+              {% endif %}
+            {% endwith %}
           {% endfor %}
+        </ul>
+      {% else %}
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-6 text-sm text-slate-500">
+          Favorite dishes appear here, whether they live on a menu or not.
         </div>
-        <div
-          id="uncategorized-empty"
-          class="flex h-32 items-center justify-center rounded-xl bg-slate-50 text-sm text-slate-400 {% if uncategorized_favorites %}hidden{% endif %}"
-        >
-          Assigning dishes to menus removes them from this list. Remove a dish from a menu to bring it back here.
-        </div>
-      </div>
+      {% endif %}
     </div>
   </details>
 </div>
-
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const root = document.getElementById('favorites-root');
-    if (!root) return;
-
-    const list = root.querySelector('[data-uncategorized-list]');
-    const emptyState = document.getElementById('uncategorized-empty');
-
-    const updateEmptyState = () => {
-      if (!list || !emptyState) return;
-      const hasItems = list.querySelector('[data-dish-card], .favorite-dish-card');
-      emptyState.classList.toggle('hidden', Boolean(hasItems));
-    };
-
-    updateEmptyState();
-
-    root.addEventListener('dish-menu-moved', (event) => {
-      const detail = event.detail || {};
-      const dishId = detail.dishId;
-      if (!dishId) return;
-      const targetMenuId = detail.targetMenuId || '';
-      if (!targetMenuId) {
-        updateEmptyState();
-        return;
-      }
-      const wrapper = document.getElementById(`favorite-dish-${dishId}`);
-      if (!wrapper) return;
-      wrapper.remove();
-      updateEmptyState();
-    });
-  });
-</script>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -2411,14 +2411,17 @@ def favorites_view(request):
         .select_related("account")
         .first()
     )
-    favorite_concepts = list(
+    favorite_concepts: list[models.FavoriteConcept] = []
+    for favorite in (
         models.FavoriteConcept.objects.filter(user=request.user)
         .select_related("concept", "concept__restaurant")
         .order_by("-favorited_at")
-    )
-    for favorite in favorite_concepts:
-        if favorite.concept:
-            favorite.concept.is_favorited_for_user = True
+    ):
+        concept = favorite.concept
+        if not concept:
+            continue
+        concept.is_favorited_for_user = True
+        favorite_concepts.append(favorite)
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(user=request.user)
         .select_related("dish__parent_concept", "dish__restaurant")
@@ -2448,6 +2451,24 @@ def favorites_view(request):
             for item in items:
                 menu_dishes.append(item.dish)
 
+    concept_menu_map: dict[uuid.UUID, list[str]] = {}
+    dish_menu_map: dict[uuid.UUID, list[str]] = {}
+    for menu in menus:
+        menu_name = menu.name
+        for item in getattr(menu, "menu_items", []) or []:
+            dish = getattr(item, "dish", None)
+            if not dish:
+                continue
+            dish_entry = dish_menu_map.setdefault(dish.id, [])
+            if menu_name not in dish_entry:
+                dish_entry.append(menu_name)
+            concept = getattr(dish, "parent_concept", None)
+            if not concept:
+                continue
+            concept_entry = concept_menu_map.setdefault(concept.id, [])
+            if menu_name not in concept_entry:
+                concept_entry.append(menu_name)
+
     all_dishes = [fav.dish for fav in favorite_dishes] + menu_dishes
     decorate_dishes_with_enhancements(all_dishes)
     for dish in all_dishes:
@@ -2475,6 +2496,8 @@ def favorites_view(request):
         "menu_options": menus_payload,
         "menu_move_url": reverse("menu-item-move"),
         "menus_workspace_url": reverse("menus"),
+        "concept_menu_map": concept_menu_map,
+        "dish_menu_map": dish_menu_map,
     }
     return render(request, "favorites/dashboard.html", ctx)
 


### PR DESCRIPTION
## Summary
- present favorited concepts and dishes in streamlined list layouts with thumbnails, menu badges, and quick actions
- expose menu assignments for favorites in the view context to support the new presentation

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_favorites_views --verbosity 2


------
https://chatgpt.com/codex/tasks/task_e_68d850ffa8b88332b46de876b64bea40