### PR TITLE
Enhance dashboard collaboration experience

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -14,6 +14,16 @@
 {% endblock %}
 
 {% block page_content %}
+  <style>
+    @keyframes dashboard-progress-sweep {
+      0% {
+        transform: translateX(-100%);
+      }
+      100% {
+        transform: translateX(100%);
+      }
+    }
+  </style>
   <div class="px-4 py-6 space-y-6">
     {% include "concepts/_card_assets.html" %}
     <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -40,7 +50,7 @@
       </ul>
     </section>
 
-    <div class="grid gap-4 lg:grid-cols-2">
+    <div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
       <section class="rounded-2xl border border-slate-200 bg-white p-6">
         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="text-lg font-semibold text-[#14080E]">Recent concepts</h2>
@@ -55,18 +65,47 @@
         {% if recent_concepts %}
           <ul class="mt-4 space-y-3">
             {% for concept in recent_concepts %}
-              <li class="rounded-xl border border-slate-200 p-4">
+              <li class="relative overflow-hidden rounded-xl border border-slate-200 bg-white/80 p-4 shadow-sm transition hover:border-[#FF5C00]/40" data-concept-item>
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p class="text-sm font-semibold text-[#14080E]">{{ concept.name }}</p>
-                    <p class="text-xs text-slate-500">
-                      {% if concept.runtime_display %}
-                        Ran in {{ concept.runtime_display }} •
+                  <div class="flex flex-1 items-start gap-3">
+                    {% if concept.is_favorited_for_user %}
+                      <div class="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-lg border border-white/60 bg-slate-100 shadow-sm">
+                        {% if concept.sketch_image_url %}
+                          <img
+                            src="{{ concept.sketch_image_url }}"
+                            alt="{{ concept.name }} concept sketch"
+                            class="h-full w-full object-cover"
+                          />
+                        {% else %}
+                          <div class="flex h-full w-full items-center justify-center text-slate-400">
+                            <i class="fa-solid fa-palette text-base" aria-hidden="true"></i>
+                          </div>
+                        {% endif %}
+                        <span class="absolute right-1 top-1 inline-flex items-center justify-center rounded-full bg-white/90 px-1.5 py-0.5 text-[10px] font-semibold text-[#FF5C00] shadow">
+                          <i class="fa-solid fa-star" aria-hidden="true"></i>
+                        </span>
+                      </div>
+                    {% endif %}
+                    <div class="flex-1 space-y-1">
+                      <p class="text-sm font-semibold text-[#14080E]">{{ concept.name }}</p>
+                      <p class="text-xs text-slate-500">
+                        {% if concept.runtime_display %}
+                          Ran in {{ concept.runtime_display }} •
+                        {% endif %}
+                        {{ concept.generated_at|date:"M j, Y g:i a" }}
+                      </p>
+                      {% if concept.is_favorited_for_user %}
+                        <span class="inline-flex items-center gap-1 rounded-full bg-[#FFE6D8] px-2 py-0.5 text-[11px] font-semibold text-[#FF5C00]">
+                          Favorited
+                        </span>
                       {% endif %}
-                      {{ concept.generated_at|date:"M j, Y g:i a" }}
-                    </p>
+                    </div>
                   </div>
-                  <a href="{% if concept.has_dishes %}{% url 'dish_detail' concept.id %}{% else %}{% url 'dishes-generate' concept.id %}{% endif %}" class="inline-flex items-center gap-2 text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">
+                  <a
+                    href="{% if concept.has_dishes %}{% url 'dish_detail' concept.id %}{% else %}{% url 'dishes-generate' concept.id %}{% endif %}"
+                    class="inline-flex items-center gap-2 text-sm font-semibold {% if concept.has_dishes %}text-[#2E005D] hover:text-[#250047]{% else %}text-[#FF5C00] hover:text-[#e05400]{% endif %}"
+                    {% if not concept.has_dishes %}data-generate-progress{% endif %}
+                  >
                     {% if concept.has_dishes %}
                       See dish ideas
                     {% else %}
@@ -74,6 +113,9 @@
                     {% endif %}
                     <i class="fa-solid fa-arrow-right text-xs" aria-hidden="true"></i>
                   </a>
+                </div>
+                <div class="pointer-events-none absolute inset-x-0 bottom-0 hidden h-1 overflow-hidden bg-[#FF5C00]/20" data-progress-bar>
+                  <div class="h-full w-1/2 bg-[#FF5C00]" style="animation: dashboard-progress-sweep 1.2s ease-in-out infinite;"></div>
                 </div>
               </li>
             {% endfor %}
@@ -97,7 +139,7 @@
         {% if recent_dishes %}
           <ul class="mt-4 space-y-3">
             {% for dish in recent_dishes %}
-              <li class="flex gap-3 rounded-xl border border-slate-200 p-4">
+              <li class="relative flex gap-3 rounded-xl border border-slate-200 bg-white/80 p-4 shadow-sm transition hover:border-[#2E005D]/40 {% if dish.needs_collab_attention %}border-[#2E005D] bg-[#F4ECFF]/80{% endif %}">
                 {% if dish.enhancement_image_url %}
                   <img src="{{ dish.enhancement_image_url }}" alt="{{ dish.title }}" class="h-16 w-16 rounded-lg object-cover" />
                 {% else %}
@@ -109,6 +151,15 @@
                   <p class="text-sm font-semibold text-[#14080E]">{{ dish.title }}</p>
                   <p class="text-xs text-slate-500">Concept: {{ dish.parent_concept.name }}</p>
                   <p class="text-xs text-slate-500">Favorited {{ dish.favorited_at|timesince }} ago</p>
+                  {% if dish.needs_collab_attention %}
+                    <span class="inline-flex items-center gap-1 rounded-full bg-[#2E005D]/10 px-2 py-0.5 text-[11px] font-semibold text-[#2E005D]">
+                      <i class="fa-solid fa-circle-exclamation text-[10px]" aria-hidden="true"></i>
+                      Needs attention
+                      {% if dish.pending_feedback_count > 0 %}
+                        <span aria-hidden="true">({{ dish.pending_feedback_count }})</span>
+                      {% endif %}
+                    </span>
+                  {% endif %}
                 </div>
                 <a href="{% url 'dish_detail' dish.parent_concept.id %}" class="self-center text-sm font-semibold text-[#FF5C00] hover:text-[#e05400]">&rsaquo;&rsaquo;</a>
               </li>
@@ -117,6 +168,45 @@
         {% else %}
           <p class="mt-4 text-sm text-slate-600">Generate dishes from a concept to see them here.</p>
         {% endif %}
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-white p-6">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="text-lg font-semibold text-[#14080E]">Collaboration updates</h2>
+          {% if pending_collaboration_total %}
+            <span class="inline-flex items-center gap-1 rounded-full bg-[#2E005D]/10 px-2 py-0.5 text-[11px] font-semibold text-[#2E005D]">
+              <i class="fa-solid fa-users" aria-hidden="true"></i>
+              {{ pending_collaboration_total }}
+            </span>
+          {% endif %}
+        </div>
+        {% if collaboration_updates %}
+          <ul class="mt-4 space-y-3">
+            {% for update in collaboration_updates %}
+              <li class="rounded-xl border border-slate-200 bg-slate-50/70 p-3 shadow-sm">
+                <p class="text-sm font-medium text-[#14080E]">{{ update.message }}</p>
+                <p class="mt-1 text-xs text-slate-500">
+                  {{ update.menu_name }}
+                  {% if update.dish_title %}
+                    • {{ update.dish_title }}
+                  {% endif %}
+                  • {{ update.created_at|timesince }} ago
+                </p>
+              </li>
+            {% endfor %}
+          </ul>
+          {% if collaboration_updates_more %}
+            <p class="mt-3 text-xs font-medium text-[#2E005D]">+{{ collaboration_updates_more }} more pending feedback item{{ collaboration_updates_more|pluralize }} in the collaboration hub.</p>
+          {% endif %}
+        {% else %}
+          <p class="mt-4 text-sm text-slate-600">No collaboration feedback pending. Share a menu to gather quick reactions.</p>
+        {% endif %}
+        <div class="mt-4 flex items-center gap-2 text-xs">
+          <a href="{% url 'menus' %}" class="inline-flex items-center gap-1 text-[#2E005D] font-semibold hover:text-[#250047]">
+            <i class="fa-solid fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+            Open collaboration hub
+          </a>
+        </div>
       </section>
     </div>
 
@@ -131,23 +221,48 @@
       {% if menus %}
         <div class="mt-4 space-y-3">
           {% for menu in menus %}
-            <details class="rounded-xl border border-slate-200 p-4" {% if forloop.first %}open{% endif %}>
-              <summary class="flex cursor-pointer items-center justify-between gap-2 text-sm font-semibold text-[#14080E]">
-                <span>{{ menu.name }}</span>
-                <span class="text-xs font-medium text-slate-500">{{ menu.menu_items|length }} dishes</span>
+            <details class="group relative overflow-hidden rounded-2xl border border-slate-200 p-4 shadow-sm" style="background-color: {% cycle '#F9F7FF' '#F3FAFF' '#FFF6F1' '#F4FFF5' '#FFF5FA' %};" {% if forloop.first %}open{% endif %}>
+              <summary class="flex cursor-pointer items-center justify-between gap-3 text-sm font-semibold text-[#14080E]">
+                <div class="flex items-center gap-2">
+                  <i class="fa-solid fa-book-open text-xs text-[#2E005D]" aria-hidden="true"></i>
+                  <span>{{ menu.name }}</span>
+                </div>
+                <div class="flex items-center gap-2 text-xs text-slate-500">
+                  <span class="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium text-[#49475B] shadow-sm">{{ menu.menu_items|length }} dish{{ menu.menu_items|length|pluralize }}</span>
+                  {% if menu.pending_feedback_count %}
+                    <span class="inline-flex items-center gap-1 rounded-full bg-[#2E005D]/15 px-2 py-0.5 font-semibold text-[#2E005D]">
+                      <i class="fa-solid fa-comment-dots text-[10px]" aria-hidden="true"></i>
+                      {{ menu.pending_feedback_count }}
+                    </span>
+                  {% endif %}
+                </div>
               </summary>
-              <ul class="mt-3 space-y-2 text-sm text-slate-600">
+              <div class="mt-3 rounded-2xl bg-white/70 p-4 shadow-sm">
                 {% if menu.menu_items %}
-                  {% for item in menu.menu_items %}
-                    <li class="flex items-center justify-between gap-3">
-                      <span>{{ item.dish.title }}</span>
-                      <a href="{% url 'dish_detail' item.dish.parent_concept.id %}" class="text-xs font-semibold text-[#FF5C00] hover:text-[#e05400]">Open</a>
-                    </li>
-                  {% endfor %}
+                  <ul class="grid gap-2 text-sm text-[#49475B] sm:grid-cols-2">
+                    {% for item in menu.menu_items %}
+                      <li class="flex items-center justify-between gap-3 rounded-xl border border-white/70 bg-white/80 px-3 py-2 shadow-sm">
+                        <div class="flex flex-col">
+                          <span class="font-medium">{{ item.dish.title }}</span>
+                          <span class="text-[11px] text-slate-500">{{ item.dish.parent_concept.name }}</span>
+                        </div>
+                        <a href="{% url 'dish_detail' item.dish.parent_concept.id %}" class="inline-flex items-center gap-1 text-xs font-semibold text-[#2E005D] hover:text-[#250047]">
+                          Open
+                          <i class="fa-solid fa-arrow-up-right-from-square text-[9px]" aria-hidden="true"></i>
+                        </a>
+                      </li>
+                    {% endfor %}
+                  </ul>
                 {% else %}
-                  <li>No dishes added yet.</li>
+                  <div class="flex items-center justify-between gap-3 rounded-xl border border-dashed border-slate-300 bg-white/60 px-3 py-3 text-sm text-slate-500">
+                    <span>No dishes added yet.</span>
+                    <a href="{% url 'menus' %}" class="inline-flex items-center gap-1 text-xs font-semibold text-[#FF5C00] hover:text-[#e05400]">
+                      Add dishes
+                      <i class="fa-solid fa-plus text-[9px]" aria-hidden="true"></i>
+                    </a>
+                  </div>
                 {% endif %}
-              </ul>
+              </div>
             </details>
           {% endfor %}
         </div>
@@ -193,6 +308,31 @@
   {{ block.super }}
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      function initConceptProgress(root) {
+        if (!root) {
+          return;
+        }
+        root.querySelectorAll('[data-generate-progress]').forEach(function (link) {
+          if (!link || link.dataset.progressReady === 'true') {
+            return;
+          }
+          link.dataset.progressReady = 'true';
+          link.addEventListener('click', function () {
+            const item = link.closest('[data-concept-item]');
+            if (!item || item.dataset.progressActive === 'true') {
+              return;
+            }
+            item.dataset.progressActive = 'true';
+            const progress = item.querySelector('[data-progress-bar]');
+            if (progress) {
+              progress.classList.remove('hidden');
+            }
+          });
+        });
+      }
+
+      initConceptProgress(document);
+
       function setupMenuManager(manager) {
         if (!manager || manager.dataset.menuManagerReady === 'true') {
           return;
@@ -291,6 +431,7 @@
       document.body.addEventListener('htmx:afterSwap', function (event) {
         if (event.detail && event.detail.target) {
           initMenuManagers(event.detail.target);
+          initConceptProgress(event.detail.target);
         }
       });
     });

--- a/app/views.py
+++ b/app/views.py
@@ -681,12 +681,22 @@ def dashboard(request, restaurant_id):
         .order_by("-created_at")
     )
     recent_concepts = list(concepts_qs[:4])
+    concept_ids = [concept.id for concept in recent_concepts]
+    favorite_concept_ids: set[str] = set()
+    if concept_ids:
+        favorite_concept_ids = set(
+            models.FavoriteConcept.objects.filter(
+                user=request.user, concept_id__in=concept_ids
+            ).values_list("concept_id", flat=True)
+        )
+
     for concept in recent_concepts:
         concept.runtime_display = format_run_duration(concept.ideation_run)
         run_finished = (
             concept.ideation_run.finished_at if concept.ideation_run else None
         )
         concept.generated_at = run_finished or concept.created_at
+        concept.is_favorited_for_user = concept.id in favorite_concept_ids
 
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(
@@ -700,6 +710,23 @@ def dashboard(request, restaurant_id):
     for fav, dish in zip(favorite_dishes, recent_dishes):
         dish.is_favorited = True
         dish.favorited_at = fav.favorited_at
+
+    dish_ids = [dish.id for dish in recent_dishes]
+    pending_feedback_by_dish: dict[str, int] = {}
+    if dish_ids:
+        pending_feedback_by_dish = {
+            row["feedback__dish_id"]: row["count"]
+            for row in models.FeedbackAction.objects.filter(
+                feedback__dish_id__in=dish_ids,
+                status=models.FeedbackAction.Status.PENDING,
+            )
+            .values("feedback__dish_id")
+            .annotate(count=Count("id"))
+        }
+
+    for dish in recent_dishes:
+        dish.pending_feedback_count = pending_feedback_by_dish.get(dish.id, 0)
+        dish.needs_collab_attention = dish.pending_feedback_count > 0
 
     menus = list(
         models.MenuCollection.objects.filter(restaurant=restaurant)
@@ -722,6 +749,42 @@ def dashboard(request, restaurant_id):
         ]
         menu.menu_items = items
 
+    menu_ids = [menu.id for menu in menus]
+    pending_feedback_by_menu: dict[str, int] = {}
+    if menu_ids:
+        pending_feedback_by_menu = {
+            row["feedback__menu_id"]: row["count"]
+            for row in models.FeedbackAction.objects.filter(
+                feedback__menu_id__in=menu_ids,
+                status=models.FeedbackAction.Status.PENDING,
+            )
+            .values("feedback__menu_id")
+            .annotate(count=Count("id"))
+        }
+
+    for menu in menus:
+        menu.pending_feedback_count = pending_feedback_by_menu.get(menu.id, 0)
+
+    collaboration_actions_qs = models.FeedbackAction.objects.filter(
+        feedback__menu__restaurant=restaurant,
+        status=models.FeedbackAction.Status.PENDING,
+    ).select_related("feedback__menu", "feedback__dish")
+
+    collaboration_updates = [
+        {
+            "id": action.id,
+            "message": _format_feedback_activity(action.feedback),
+            "menu_name": getattr(action.feedback.menu, "name", ""),
+            "dish_title": getattr(getattr(action.feedback, "dish", None), "title", ""),
+            "created_at": action.feedback.created_at,
+        }
+        for action in collaboration_actions_qs.order_by("-created_at")[:5]
+    ]
+    pending_collaboration_total = collaboration_actions_qs.count()
+    collaboration_updates_more = max(
+        pending_collaboration_total - len(collaboration_updates), 0
+    )
+
     context_items = build_context_items(restaurant, settings_obj)
 
     context = {
@@ -731,6 +794,9 @@ def dashboard(request, restaurant_id):
         "recent_concepts": recent_concepts,
         "recent_dishes": recent_dishes,
         "menus": menus,
+        "collaboration_updates": collaboration_updates,
+        "pending_collaboration_total": pending_collaboration_total,
+        "collaboration_updates_more": collaboration_updates_more,
         "empty_concepts": [],
         "settings_url": reverse("settings"),
         "context_toggle_url": reverse(

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from types import SimpleNamespace
 from decimal import Decimal
 from unittest.mock import patch
@@ -140,6 +141,96 @@ class ViewSmokeTests(TestCase):
         self.assertContains(resp, "Inspire Me")
         self.assertContains(resp, "Italian chef&#x27;s table")
         self.assertContains(resp, "Creative bias: 50/100")
+
+    def test_dashboard_shows_collaboration_feedback_summary(self):
+        concept_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="concept",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        concept = models.Concept.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=concept_run,
+            name="Signature",
+            rank_order=1,
+        )
+        concept.sketch_image_url = "https://example.com/sketch.jpg"
+        concept.save(update_fields=["sketch_image_url"])
+        models.FavoriteConcept.objects.create(
+            user=self.user,
+            concept=concept,
+            favorited_at=timezone.now(),
+        )
+
+        dish_run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.DISHES,
+            model_name="dish",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            parent_concept=concept,
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        dish = models.DishIdea.objects.create(
+            restaurant=self.restaurant,
+            ideation_run=dish_run,
+            parent_concept=concept,
+            title="Seared Scallops",
+            description="Rich",
+            ingredient_names=[],
+            category_tags=[],
+        )
+        models.FavoriteDish.objects.create(
+            user=self.user,
+            dish=dish,
+            favorited_at=timezone.now(),
+        )
+
+        menu = models.MenuCollection.objects.create(
+            restaurant=self.restaurant,
+            created_by_user=self.user,
+            name="Chef's Table",
+        )
+        models.MenuItem.objects.create(menu=menu, dish=dish, position=1)
+        link = models.CollaborationLink.objects.create(
+            menu=menu,
+            expires_at=timezone.now() + timedelta(days=7),
+            is_active=True,
+        )
+        feedback = models.Feedback.objects.create(
+            menu=menu,
+            dish=dish,
+            link=link,
+            type=models.Feedback.Type.COMMENT,
+            payload={"comment": "Consider extra citrus"},
+            anon_id="abc123",
+        )
+        models.FeedbackAction.objects.create(feedback=feedback)
+
+        resp = self.client.get(reverse("dashboard", args=[self.restaurant.id]))
+
+        recent_concepts = resp.context["recent_concepts"]
+        self.assertTrue(recent_concepts)
+        self.assertTrue(recent_concepts[0].is_favorited_for_user)
+        self.assertEqual(recent_concepts[0].sketch_image_url, "https://example.com/sketch.jpg")
+
+        recent_dishes = resp.context["recent_dishes"]
+        self.assertTrue(recent_dishes)
+        self.assertTrue(recent_dishes[0].needs_collab_attention)
+        self.assertEqual(recent_dishes[0].pending_feedback_count, 1)
+
+        self.assertEqual(resp.context["pending_collaboration_total"], 1)
+        self.assertEqual(resp.context["collaboration_updates_more"], 0)
+        updates = resp.context["collaboration_updates"]
+        self.assertTrue(updates)
+        self.assertEqual(updates[0]["menu_name"], menu.name)
 
     def test_concepts_page_includes_contextual_ai_input(self):
         self._create_concepts()


### PR DESCRIPTION
## Summary
- surface favorited concept sketches in the recent list, differentiate action links, and add a subtle loading bar when generating dishes
- flag favorite dishes that have pending collaboration feedback and introduce a collaboration updates panel with refreshed menu styling
- update the dashboard view logic to collect collaboration state and add a regression test for the new context

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_dashboard_shows_collaboration_feedback_summary


------
https://chatgpt.com/codex/tasks/task_e_68d858e182d0833296a9a8b7652b8d97