### PR TITLE
Unify creative balance slider across pages

### DIFF
--- a/app/templates/_partials/creative_balance_control.html
+++ b/app/templates/_partials/creative_balance_control.html
@@ -1,0 +1,71 @@
+{% with slider_value=slider_value|default:restaurant_settings.classic_creative_slider|default:50 %}
+  <section
+    class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm {{ section_classes|default:'' }}"
+    data-creative-balance
+  >
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        {% if eyebrow %}
+          <p class="text-xs font-semibold uppercase tracking-wide text-[#B993D6]">{{ eyebrow }}</p>
+        {% endif %}
+        <h2 class="text-lg font-semibold text-[#14080E]">{{ title|default:"Dial in classic versus adventurous ideas" }}</h2>
+        {% if description %}
+          <p class="text-sm text-slate-600">{{ description }}</p>
+        {% endif %}
+      </div>
+      <span
+        class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-500"
+      >
+        <i class="fa-solid fa-sliders" aria-hidden="true"></i>
+        <span data-creative-balance-value>{{ slider_value }}/100</span>
+      </span>
+    </div>
+    <form
+      hx-post="{{ action_url }}"
+      hx-trigger="{{ hx_trigger|default:'change delay:150ms' }}"
+      hx-target="{{ hx_target|default:'none' }}"
+      class="mt-6 flex flex-col gap-3"
+    >
+      <div class="flex items-center gap-4 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <span>Classic</span>
+        <div class="h-px flex-1 bg-slate-200"></div>
+        <span>Creative</span>
+      </div>
+      <input
+        type="range"
+        name="classic_creative_slider"
+        min="0"
+        max="100"
+        value="{{ slider_value }}"
+        class="w-full accent-[#B993D6]"
+        data-creative-balance-input
+      >
+    </form>
+  </section>
+  <script>
+    (function () {
+      var script = document.currentScript;
+      if (!script) {
+        return;
+      }
+      var section = script.previousElementSibling;
+      if (!section || !section.matches('[data-creative-balance]')) {
+        return;
+      }
+      if (section.dataset.creativeBalanceInit === 'true') {
+        return;
+      }
+      section.dataset.creativeBalanceInit = 'true';
+      var slider = section.querySelector('[data-creative-balance-input]');
+      var display = section.querySelector('[data-creative-balance-value]');
+      if (!slider || !display) {
+        return;
+      }
+      var update = function () {
+        display.textContent = slider.value + '/100';
+      };
+      slider.addEventListener('input', update);
+      update();
+    })();
+  </script>
+{% endwith %}

--- a/app/templates/_partials/restaurant_status.html
+++ b/app/templates/_partials/restaurant_status.html
@@ -1,38 +1,7 @@
 <div class="space-y-6">
   {% if restaurant_settings %}
-    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-wide text-[#B993D6]">Creativity balance</p>
-          <h2 class="text-lg font-semibold text-[#14080E]">Dial in classic versus adventurous ideas</h2>
-          <p class="text-sm text-slate-600">Adjust the slider to guide how Appertivo pitches new dishes.</p>
-        </div>
-        <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-500">
-          <i class="fa-solid fa-sliders" aria-hidden="true"></i>
-          {{ restaurant_settings.classic_creative_slider|default:50 }}/100
-        </span>
-      </div>
-      <form
-        hx-post="{% url 'update_creativity' restaurant.id %}"
-        hx-trigger="change delay:150ms"
-        hx-target="none"
-        class="mt-6 flex flex-col gap-3"
-      >
-        <div class="flex items-center gap-4 text-xs font-semibold uppercase tracking-wide text-slate-400">
-          <span>Classic</span>
-          <div class="h-px flex-1 bg-slate-200"></div>
-          <span>Creative</span>
-        </div>
-        <input
-          type="range"
-          name="classic_creative_slider"
-          min="0"
-          max="100"
-          value="{{ restaurant_settings.classic_creative_slider|default:50 }}"
-          class="w-full accent-[#B993D6]"
-        >
-      </form>
-    </section>
+    {% url 'update_creativity' restaurant.id as update_creativity_url %}
+    {% include "_partials/creative_balance_control.html" with action_url=update_creativity_url restaurant_settings=restaurant_settings eyebrow="Creativity balance" title="Dial in classic versus adventurous ideas" description="Adjust the slider to guide how Appertivo pitches new dishes." %}
   {% endif %}
 
   <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -19,29 +19,10 @@
 {% block page_content %}
   <div class="space-y-6">
       {% if restaurant_settings %}
-        <section class="rounded-xl bg-white p-6 m-4 shadow space-y-4">
-          <div>
-            <h2 class="text-xl font-bold text-[#49475B]">Creativity balance</h2>
-            <p class="text-sm text-slate-500">Choose how classic or adventurous your AI ideas should be.</p>
-          </div>
-          <form
-            hx-post="{% url 'update_creativity' restaurant.id %}"
-            hx-trigger="change delay:200ms"
-            hx-target="none"
-            class="flex items-center gap-4"
-          >
-            <span class="text-sm text-slate-600">Classic</span>
-            <input
-              type="range"
-              name="classic_creative_slider"
-              min="0"
-              max="100"
-              value="{{ restaurant_settings.classic_creative_slider|default:50 }}"
-              class="flex-1 accent-[#B993D6]"
-            >
-            <span class="text-sm text-slate-600">Creative</span>
-          </form>
-        </section>
+        <div class="m-4">
+          {% url 'update_creativity' restaurant.id as update_creativity_url %}
+          {% include "_partials/creative_balance_control.html" with action_url=update_creativity_url restaurant_settings=restaurant_settings eyebrow="Creativity balance" title="Creativity balance" description="Choose how classic or adventurous your AI ideas should be." %}
+        </div>
       {% endif %}
 
       <section class="space-y-6 rounded-xl bg-white p-6 m-4 shadow" data-menu-manager>


### PR DESCRIPTION
## Summary
- extract the dashboard creative balance control into a reusable partial
- reuse the shared partial on the dashboard status card and settings page so the gauge matches everywhere
- keep the displayed slider value in sync via a lightweight initializer script

## Testing
- pytest tests/test_appertivo_views.py::ViewSmokeTests::test_dashboard_displays_contextual_ai_component *(fails: Django settings module not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8600863bc8332b6acce11ae8ee30b