### PR TITLE
Refactor creative balance slider usage

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -32,6 +32,13 @@
             autocomplete="off"
           />
           <div class="absolute inset-y-1.5 right-2 flex items-center gap-2">
+            <span
+              class="hidden sm:inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs font-semibold text-slate-500"
+              data-creative-balance-value
+            >
+              <i class="fa-solid fa-sliders text-[10px]" aria-hidden="true"></i>
+              {{ slider_value|default:50 }}/100
+            </span>
             <button
               type="submit"
               class="inline-flex items-center gap-1 rounded-full bg-[#58B09C] px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-[#43907d] focus:outline-none focus:ring-2 focus:ring-[#58B09C]/40"
@@ -48,22 +55,7 @@
             </button>
           </div>
         </div>
-        <div class="space-y-2">
-          <div class="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-            <span>Classic</span>
-            <span data-slider-value>{{ slider_value|default:50 }}/100</span>
-            <span>Creative</span>
-          </div>
-          <input
-            type="range"
-            name="classic_creative_slider"
-            id="{{ root_id }}-slider"
-            min="0"
-            max="100"
-            value="{{ slider_value|default:50 }}"
-            class="w-full accent-[#B993D6]"
-          >
-        </div>
+        {% include "_partials/creative_balance_slider.html" with slider_value=slider_value slider_id=root_id|add:'-slider' label_row_classes='flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-slate-400' %}
       </form>
       {% if creative_bias_label %}
         <p class="text-xs text-slate-500">
@@ -144,10 +136,13 @@
         }
 
         const slider = root.querySelector('#{{ root_id }}-slider');
-        const sliderValue = root.querySelector('[data-slider-value]');
-        if (slider && sliderValue) {
+        const displays = root.querySelectorAll('[data-creative-balance-value]');
+        if (slider && displays.length) {
           const updateSliderValue = function () {
-            sliderValue.textContent = slider.value + '/100';
+            const value = slider.value + '/100';
+            displays.forEach(function (el) {
+              el.textContent = value;
+            });
           };
           slider.addEventListener('input', updateSliderValue);
           updateSliderValue();

--- a/app/templates/_partials/creative_balance_control.html
+++ b/app/templates/_partials/creative_balance_control.html
@@ -26,20 +26,7 @@
       hx-target="{{ hx_target|default:'none' }}"
       class="mt-6 flex flex-col gap-3"
     >
-      <div class="flex items-center gap-4 text-xs font-semibold uppercase tracking-wide text-slate-400">
-        <span>Classic</span>
-        <div class="h-px flex-1 bg-slate-200"></div>
-        <span>Creative</span>
-      </div>
-      <input
-        type="range"
-        name="classic_creative_slider"
-        min="0"
-        max="100"
-        value="{{ slider_value }}"
-        class="w-full accent-[#B993D6]"
-        data-creative-balance-input
-      >
+      {% include "_partials/creative_balance_slider.html" with slider_value=slider_value %}
     </form>
   </section>
   <script>
@@ -57,12 +44,15 @@
       }
       section.dataset.creativeBalanceInit = 'true';
       var slider = section.querySelector('[data-creative-balance-input]');
-      var display = section.querySelector('[data-creative-balance-value]');
-      if (!slider || !display) {
+      var displays = section.querySelectorAll('[data-creative-balance-value]');
+      if (!slider || !displays.length) {
         return;
       }
       var update = function () {
-        display.textContent = slider.value + '/100';
+        var value = slider.value + '/100';
+        displays.forEach(function (el) {
+          el.textContent = value;
+        });
       };
       slider.addEventListener('input', update);
       update();

--- a/app/templates/_partials/creative_balance_slider.html
+++ b/app/templates/_partials/creative_balance_slider.html
@@ -1,0 +1,24 @@
+{% with slider_value=slider_value|default:50 %}
+  <div class="{{ wrapper_classes|default:'space-y-2' }}" {% if slider_wrapper_id %}id="{{ slider_wrapper_id }}"{% endif %} data-creative-balance-slider>
+    <div class="{{ label_row_classes|default:'flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-400' }}">
+      <span class="{{ label_classes|default:'' }}">{{ classic_label|default:'Classic' }}</span>
+      {% if show_value|default:True %}
+        <span data-creative-balance-value class="{{ value_classes|default:'' }}">{{ slider_value }}/100</span>
+      {% else %}
+        <div class="{{ divider_classes|default:'h-px flex-1 bg-slate-200' }}" aria-hidden="true"></div>
+      {% endif %}
+      <span class="{{ label_classes|default:'' }}">{{ creative_label|default:'Creative' }}</span>
+    </div>
+    <input
+      type="range"
+      name="{{ slider_name|default:'classic_creative_slider' }}"
+      {% if slider_id %}id="{{ slider_id }}"{% endif %}
+      min="0"
+      max="100"
+      value="{{ slider_value }}"
+      class="{{ input_classes|default:'w-full accent-[#B993D6]' }}"
+      data-creative-balance-input
+      {{ input_attrs|default:'' }}
+    >
+  </div>
+{% endwith %}


### PR DESCRIPTION
## Summary
- extract the classic/creative slider into a reusable partial and update both contextual AI input and creative balance control to use it
- add inline gauge display to contextual AI prompts so the dashboard, concepts, and settings pages share the same slider presentation

## Testing
- python manage.py check
- Manual verification: loaded dashboard, concepts, and settings in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d864a3d1048332b5ee2428f107c899