### PR TITLE
Surface disliked concepts in UI and prompt context

### DIFF
--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -18,6 +18,27 @@
       </div>
     </section>
 
+    {% if disliked_concepts %}
+      <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div class="space-y-3">
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="text-lg font-semibold text-[#14080E]">Passed on concepts</h2>
+            <span class="text-xs font-medium uppercase tracking-wide text-slate-400">We will remix these</span>
+          </div>
+          <p class="text-sm text-slate-600">Here are the ideas that didn&apos;t land. Future runs will keep them in mind and explore stronger angles.</p>
+          <ul class="space-y-2">
+            {% for name in disliked_concepts %}
+              <li class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+                <span aria-hidden="true" class="text-base leading-none">👎</span>
+                <span class="sr-only">Not a fit:</span>
+                <span class="font-medium text-[#49475B]">{{ name }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </section>
+    {% endif %}
+
     <div class="space-y-4">
       <div id="concepts-grid" class="grid grid-cols-2 gap-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
         {% include 'concepts/_concepts_grid.html' %}

--- a/app/views.py
+++ b/app/views.py
@@ -367,6 +367,19 @@ def _extend_session_list(session, key: str, new_items: Iterable[str]) -> None:
     session.modified = True
 
 
+def _record_unfavorited_concept(session, concept_name: str) -> None:
+    """Store a trimmed history of concept names the user removed from favorites."""
+
+    name = (concept_name or "").strip()
+    if not name:
+        return
+    _extend_session_list(session, "disliked_concepts", [name])
+    disliked = _get_session_list(session, "disliked_concepts")
+    if len(disliked) > 30:
+        session["disliked_concepts"] = disliked[-30:]
+        session.modified = True
+
+
 def _load_home_demo_favorites():
     """Return demo favorites (concept + dish) for the marketing homepage."""
 
@@ -1147,6 +1160,9 @@ def concepts_view(request):
     for concept in concepts:
         favorites = getattr(concept, "_favorites_for_request_user", [])
         concept.is_favorited_for_user = bool(favorites)
+
+    disliked_concepts = _get_session_list(request.session, "disliked_concepts")
+    recent_disliked = list(reversed(disliked_concepts[-6:])) if disliked_concepts else []
     return render(
         request,
         "concepts/grid.html",
@@ -1159,6 +1175,7 @@ def concepts_view(request):
             "classic_creative_slider": slider_value,
             "classic_creative_temperature": slider_temperature,
             "creative_bias_label": creative_bias_label,
+            "disliked_concepts": recent_disliked,
         },
     )
 
@@ -1239,6 +1256,8 @@ def concepts_generate_view(request):
         for name in (request.session.get("generated_concepts") or [])
         if name and str(name).strip()
     ]
+    disliked_concepts = _get_session_list(request.session, "disliked_concepts")
+    disliked_context = disliked_concepts[-15:]
 
     logger.info(f"previous concepts: {session_concepts}")
     if restaurant.active_menu_version:
@@ -1259,6 +1278,12 @@ def concepts_generate_view(request):
         context += (
             "\nPreviously generated concept names to avoid: "
             + ", ".join(session_concepts[:15])
+        )
+    if disliked_context:
+        context += (
+            "\nConcepts the team previously passed on: "
+            + ", ".join(disliked_context)
+            + ". Consider why they missed the mark and suggest improved twists or alternatives instead of repeating them."
         )
     if user_prompt:
         context += f"\nUser special instructions: {user_prompt}"
@@ -1345,6 +1370,7 @@ def concepts_generate_view(request):
     context_snapshot = {
         "prompt": user_prompt,
         "session_concepts": session_concepts[:15],
+        "disliked_concepts": disliked_context,
         "context": context,
         "classic_creative_slider": slider_value,
         "temperature": temperature_float,
@@ -1457,6 +1483,7 @@ def concept_favorite_view(request, concept_id):
         if concept.sketch_image_url:
             concept.sketch_image_url = None
             concept.save(update_fields=["sketch_image_url"])
+        _record_unfavorited_concept(request.session, concept.name)
 
     concept.is_favorited_for_user = favorited
     concept.has_dishes = models.DishIdea.objects.filter(
@@ -2442,6 +2469,7 @@ def favorite_remove_view(request, type, id):
         if concept.sketch_image_url:
             concept.sketch_image_url = None
             concept.save(update_fields=["sketch_image_url"])
+        _record_unfavorited_concept(request.session, concept.name)
     else:
         models.FavoriteDish.objects.filter(user=request.user, dish_id=id).delete()
     if request.headers.get("HX-Request"):

--- a/tests/test_concept_dislikes.py
+++ b/tests/test_concept_dislikes.py
@@ -1,0 +1,108 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from app import models
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class ConceptDislikeTests(TestCase):
+    """Tests for tracking and surfacing concepts users removed from favorites."""
+
+    def setUp(self):
+        self.user = User.objects.create_user("chef@example.com", password="pw")
+        self.account = models.Account.objects.create(name="Acc")
+        models.Membership.objects.create(account=self.account, user=self.user)
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="R",
+            location_text="City",
+        )
+        models.RestaurantSettings.objects.create(restaurant=self.restaurant)
+        self.client.login(username="chef@example.com", password="pw")
+
+    def _create_concepts(self, count: int = 3):
+        run = models.IdeationRun.objects.create(
+            restaurant=self.restaurant,
+            initiated_by_user=self.user,
+            type=models.IdeationRun.RunType.CONCEPTS,
+            model_name="test",
+            temperature=0,
+            classic_creative=50,
+            context_snapshot={},
+            status=models.IdeationRun.Status.SUCCEEDED,
+        )
+        concepts = []
+        for idx in range(count):
+            concepts.append(
+                models.Concept.objects.create(
+                    restaurant=self.restaurant,
+                    ideation_run=run,
+                    name=f"C{idx}",
+                    rank_order=idx,
+                )
+            )
+        return concepts
+
+    def _favorite_and_unfavorite(self, concept: models.Concept) -> None:
+        self.client.post(
+            reverse("concept-favorite", args=[concept.id]), HTTP_HX_REQUEST="true"
+        )
+        self.client.post(
+            reverse("concept-favorite", args=[concept.id]), HTTP_HX_REQUEST="true"
+        )
+
+    def test_unfavorite_records_concept_name_in_session(self):
+        concept = self._create_concepts(1)[0]
+        self._favorite_and_unfavorite(concept)
+        self.assertIn(concept.name, self.client.session.get("disliked_concepts", []))
+
+    def test_concepts_page_displays_disliked_section(self):
+        concept = self._create_concepts(1)[0]
+        self._favorite_and_unfavorite(concept)
+
+        response = self.client.get(reverse("concepts"))
+        self.assertContains(response, "Passed on concepts")
+        self.assertContains(response, "👎")
+        self.assertContains(response, concept.name)
+
+    @patch("app.views.client")
+    def test_generation_context_mentions_disliked_concepts(self, mock_client):
+        concept = self._create_concepts(1)[0]
+        self._favorite_and_unfavorite(concept)
+
+        payload = {
+            "concepts": [
+                {
+                    "title": f"New {idx}",
+                    "subtitle": "",
+                    "reasoning": "",
+                    "tags": ["tag"],
+                }
+                for idx in range(9)
+            ]
+        }
+        mock_client.responses.create.return_value = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    content=[SimpleNamespace(text=json.dumps(payload))]
+                )
+            ]
+        )
+
+        response = self.client.post(
+            reverse("concepts-generate"),
+            {"prompt": ""},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        _, kwargs = mock_client.responses.create.call_args
+        context_text = kwargs["input"][1]["content"]
+        self.assertIn(concept.name, context_text)
+        self.assertIn("passed on", context_text.lower())
+


### PR DESCRIPTION
## Summary
- track concept names when a user removes a favorite and store a short history in the session
- show a "Passed on concepts" list with thumbs-down indicators on the concepts page
- include previously disliked concepts in the LLM prompt context and snapshot for generation
- add regression tests covering dislike tracking, UI rendering, and prompt updates

## Testing
- python manage.py test tests.test_concept_dislikes

------
https://chatgpt.com/codex/tasks/task_e_68d8671bc2e88332a4c281f0e867ffda