### PR TITLE
Enhance homepage SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,54 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Appertivo — Instantly Share Your Restaurant Specials</title>
   <meta name="description" content="Appertivo is the easiest way for restaurants to post daily specials, engage customers, and boost sales — all without logins or technical hassle." />
+  <meta name="keywords" content="restaurant specials software, restaurant marketing tool, daily specials widget, restaurant promotion platform" />
+  <meta name="author" content="Appertivo" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#ff7043" />
+  <link rel="canonical" href="https://appertivo.com/" />
+  <link rel="alternate" href="https://appertivo.com/" hreflang="en" />
+  <link rel="icon" type="image/png" href="https://images.example.com/appertivo-favicon.png" />
   <meta property="og:title" content="Appertivo — Instantly Share Your Restaurant Specials" />
   <meta property="og:description" content="Add a special, see it live. Appertivo lets you update and display your daily specials with a simple dashboard, live preview, and a copy-paste widget for your website." />
-  <meta property="og:image" content="https://yourdomain.com/og-image.png" />
+  <meta property="og:image" content="https://images.example.com/appertivo-og.png" />
+  <meta property="og:image:secure_url" content="https://images.example.com/appertivo-og.png" />
+  <meta property="og:image:alt" content="Appertivo dashboard preview showing restaurant specials" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://appertivo.com/" />
+  <meta property="og:site_name" content="Appertivo" />
+  <meta property="og:locale" content="en_US" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Appertivo — Instantly Share Your Restaurant Specials" />
   <meta name="twitter:description" content="Let your customers know what’s special today. Easy, mobile-first, and no logins required." />
-  <meta name="twitter:image" content="https://yourdomain.com/og-image.png" />
+  <meta name="twitter:image" content="https://images.example.com/appertivo-og.png" />
+  <meta name="twitter:image:alt" content="Appertivo dashboard preview showing restaurant specials" />
+  <meta name="twitter:site" content="@appertivo" />
+  <meta name="twitter:creator" content="@appertivo" />
   <link rel="stylesheet" href="static/style.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Appertivo",
+      "applicationCategory": "BusinessApplication",
+      "operatingSystem": "Web",
+      "url": "https://appertivo.com/",
+      "description": "Appertivo helps restaurants publish daily specials instantly with a live preview, customizable widgets, and mobile-first editing.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/PreOrder"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Appertivo"
+      }
+    }
+  </script>
 </head>
 <body class="landing-body">
-  <div class="landing-container" role="main">
+  <main class="landing-container" role="main">
     <h1>Appertivo is Coming Soon</h1>
     <div class="tagline">Add a Special. See It Live. Delight Your Customers.</div>
     <ul>
@@ -33,6 +68,6 @@
       Thank you for your patience & support.<br>
       <span class="small-note">Free for early adopters • Powered by Django & HTMX</span>
     </div>
-  </div>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add canonical, alternate, and social metadata to strengthen homepage search engine coverage
- include Schema.org SoftwareApplication structured data and updated placeholder social images for previews
- switch main content container to semantic <main> element for improved accessibility

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d95b7914e88332a5077a06757f60fe