### PR TITLE
Fix admin dashboard wrapper to accept request argument

### DIFF
--- a/articles/admin.py
+++ b/articles/admin.py
@@ -58,13 +58,13 @@ class ArticleAdmin(admin.ModelAdmin):
 
 # Hook the custom dashboard into the default admin site navigation.
 def _inject_dashboard_link(original_index):  # pragma: no cover - glue code
-    def wrapped(self, request, extra_context=None):
+    def wrapped(request, extra_context=None):
         extra_context = extra_context or {}
         extra_context.setdefault(
             "articles_dashboard",
             format_html("<a href='{}'>{}</a>", reverse("articles_admin_dashboard"), _( "Articles")),
         )
-        return original_index(self, request, extra_context=extra_context)
+        return original_index(request, extra_context=extra_context)
 
     return wrapped
 


### PR DESCRIPTION
## Summary
- correct the admin dashboard injection wrapper to match the Django admin index signature
- ensure the custom dashboard link is added without causing a TypeError

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d9725032148332a7e2de2c158bb6cc