### PR TITLE
Fix admin dashboard links to use namespaced reverse

### DIFF
--- a/articles/admin.py
+++ b/articles/admin.py
@@ -26,7 +26,7 @@ class ArticleRunAdmin(admin.ModelAdmin):
         extra_context = extra_context or {}
         extra_context.setdefault(
             "articles_dashboard_url",
-            reverse("articles_admin_dashboard"),
+            reverse("admin:articles_admin_dashboard"),
         )
         return super().changelist_view(request, extra_context=extra_context)
 
@@ -51,7 +51,7 @@ class ArticleAdmin(admin.ModelAdmin):
         extra_context = extra_context or {}
         extra_context.setdefault(
             "articles_dashboard_url",
-            reverse("articles_admin_dashboard"),
+            reverse("admin:articles_admin_dashboard"),
         )
         return super().changelist_view(request, extra_context=extra_context)
 
@@ -62,7 +62,11 @@ def _inject_dashboard_link(original_index):  # pragma: no cover - glue code
         extra_context = extra_context or {}
         extra_context.setdefault(
             "articles_dashboard",
-            format_html("<a href='{}'>{}</a>", reverse("articles_admin_dashboard"), _( "Articles")),
+            format_html(
+                "<a href='{}'>{}</a>",
+                reverse("admin:articles_admin_dashboard"),
+                _("Articles"),
+            ),
         )
         return original_index(request, extra_context=extra_context)
 

--- a/articles/admin_views.py
+++ b/articles/admin_views.py
@@ -57,4 +57,4 @@ def admin_dashboard(request):
 
 @staff_member_required
 def dashboard_redirect(request):  # pragma: no cover - convenience redirect
-    return redirect("articles_admin_dashboard")
+    return redirect("admin:articles_admin_dashboard")


### PR DESCRIPTION
## Summary
- update admin dashboard changelist links to reverse the namespaced dashboard URL
- adjust the dashboard redirect helper to target the admin namespace

## Testing
- python manage.py test articles.tests.test_admin --settings=specials.settings

------
https://chatgpt.com/codex/tasks/task_e_68d977420cbc8332ba086f323895f6b1