### PR TITLE
Add article run launcher to admin dashboard

### DIFF
--- a/articles/admin_views.py
+++ b/articles/admin_views.py
@@ -4,10 +4,15 @@ from typing import Callable, Iterable
 
 from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
+from django.views.decorators.http import require_POST
 
+
+from .models import ArticleRun, PromptTemplate
+from .pipeline import PIPELINE_STEPS, launch_article_run
 
 def extend_admin_urls(original_get_urls: Callable[[], Iterable]) -> Callable[[], Iterable]:
     """Attach the articles dashboard to the admin without disrupting defaults."""
@@ -19,7 +24,17 @@ def extend_admin_urls(original_get_urls: Callable[[], Iterable]) -> Callable[[],
                 "articles/dashboard/",
                 admin.site.admin_view(admin_dashboard),
                 name="articles_admin_dashboard",
-            )
+            ),
+            path(
+                "articles/dashboard/start-run/",
+                admin.site.admin_view(start_article_run),
+                name="articles_admin_start_run",
+            ),
+            path(
+                "articles/dashboard/run-status/<int:run_id>/",
+                admin.site.admin_view(run_status),
+                name="articles_admin_run_status",
+            ),
         ]
         return custom + urls
 
@@ -51,6 +66,8 @@ def admin_dashboard(request):
         **admin.site.each_context(request),
         "title": "Articles Pipeline",
         "tabs": tabs,
+        "start_run_url": reverse("admin:articles_admin_start_run"),
+        "run_status_url_base": _status_url_base(),
     }
     return TemplateResponse(request, "admin/articles/dashboard.html", context)
 
@@ -58,3 +75,73 @@ def admin_dashboard(request):
 @staff_member_required
 def dashboard_redirect(request):  # pragma: no cover - convenience redirect
     return redirect("admin:articles_admin_dashboard")
+
+
+def _status_url_base() -> str:
+    sample = reverse("admin:articles_admin_run_status", args=[0])
+    if sample.endswith("0/"):
+        return sample[:-2]
+    return sample.rsplit("/", 1)[0] + "/"
+
+
+def _serialize_run(run: ArticleRun) -> dict:
+    step_labels = dict(PromptTemplate.STEP_CHOICES)
+    step_map = {step.name: step for step in run.steps.all()}
+    steps = []
+    for step_name in PIPELINE_STEPS:
+        step = step_map.get(step_name)
+        status = step.status if step else "pending"
+        status_display = step.get_status_display() if step else "Pending"
+        steps.append(
+            {
+                "name": step_name,
+                "label": step_labels.get(step_name, step_name.replace("_", " ").title()),
+                "status": status,
+                "status_display": status_display,
+                "is_current": run.current_step == step_name and run.status in {"running", "queued"},
+                "has_run": step is not None,
+            }
+        )
+    return {
+        "id": run.id,
+        "status": run.status,
+        "status_display": run.get_status_display(),
+        "current_step": run.current_step,
+        "error_message": run.error_message or "",
+        "steps": steps,
+    }
+
+
+@staff_member_required
+@require_POST
+def start_article_run(request):
+    try:
+        run = launch_article_run(request.user)
+    except Exception as exc:  # pragma: no cover - defensive runtime fallback
+        run = (
+            ArticleRun.objects.filter(created_by=request.user).order_by("-id").first()
+            or ArticleRun.objects.create(created_by=request.user)
+        )
+        first_step = run.steps.order_by("started_at").first()
+        run.status = "failed"
+        run.error_message = str(exc)
+        if first_step:
+            run.current_step = first_step.name
+            run.can_resume_from_step = True
+            first_step.status = "failed"
+            first_step.error_message = str(exc)
+            first_step.save(update_fields=["status", "error_message"])
+        run.save(
+            update_fields=["status", "error_message", "current_step", "can_resume_from_step"]
+        )
+        return JsonResponse({"run": _serialize_run(run)})
+    return JsonResponse({"run": _serialize_run(run)})
+
+
+@staff_member_required
+def run_status(request, run_id: int):
+    try:
+        run = ArticleRun.objects.prefetch_related("steps").get(pk=run_id)
+    except ArticleRun.DoesNotExist:
+        return JsonResponse({"error": "Run not found."}, status=404)
+    return JsonResponse({"run": _serialize_run(run)})

--- a/articles/templates/admin/articles/dashboard.html
+++ b/articles/templates/admin/articles/dashboard.html
@@ -5,6 +5,24 @@
 <div class="articles-dashboard">
   <h1>{% trans "Articles Pipeline" %}</h1>
   <p class="help">{% trans "Quick access to prompts, queued runs, and draft articles." %}</p>
+  <div class="run-launcher" style="margin:1.5rem 0; padding:1.5rem; border:1px solid #ddd; border-radius:6px; background-color:#fafafa;">
+    <h2 style="margin-top:0; font-size:1.15rem;">{% trans "Start a new automated run" %}</h2>
+    <p style="margin-bottom:1rem; max-width:540px;">{% trans "Launch the end-to-end article pipeline. Progress updates appear below so you can monitor each step." %}</p>
+    <button
+      id="start-run-button"
+      type="button"
+      data-start-url="{{ start_run_url }}"
+      data-status-base="{{ run_status_url_base }}"
+      class="button">
+      {% trans "Launch article run" %}
+    </button>
+    <div id="run-status-panel" style="margin-top:1rem;" hidden>
+      <p id="run-status-summary" style="font-weight:600; margin-bottom:0.75rem;"></p>
+      <ol id="run-steps" style="list-style:none; margin:0; padding:0; display:flex; flex-wrap:wrap; gap:0.5rem;">
+      </ol>
+      <p id="run-error" style="color:#b30000; margin-top:0.75rem; display:none;"></p>
+    </div>
+  </div>
   <div class="tabs" style="display:flex; gap:1rem; flex-wrap:wrap;">
     {% for tab in tabs %}
       <div style="flex:1 1 200px; border:1px solid #ddd; padding:1rem; border-radius:6px; background-color:#fff;">
@@ -16,4 +34,137 @@
     {% endfor %}
   </div>
 </div>
+<script>
+  (function () {
+    const button = document.getElementById('start-run-button');
+    if (!button) {
+      return;
+    }
+
+    const panel = document.getElementById('run-status-panel');
+    const summary = document.getElementById('run-status-summary');
+    const stepsList = document.getElementById('run-steps');
+    const errorBlock = document.getElementById('run-error');
+    const startUrl = button.dataset.startUrl;
+    const statusBase = button.dataset.statusBase;
+    let pollTimer = null;
+
+    function getCookie(name) {
+      if (!document.cookie) {
+        return null;
+      }
+      const csrfToken = document.cookie
+        .split(';')
+        .map(part => part.trim())
+        .find(part => part.startsWith(name + '='));
+      return csrfToken ? decodeURIComponent(csrfToken.split('=').slice(1).join('=')) : null;
+    }
+
+    function setButtonState(isBusy) {
+      button.disabled = isBusy;
+      button.textContent = isBusy ? '{% trans "Launching…" %}' : '{% trans "Launch article run" %}';
+    }
+
+    function renderSteps(run) {
+      panel.hidden = false;
+      summary.textContent = `Run #${run.id} · ${run.status_display}`;
+      errorBlock.style.display = run.error_message ? 'block' : 'none';
+      errorBlock.textContent = run.error_message || '';
+
+      while (stepsList.firstChild) {
+        stepsList.removeChild(stepsList.firstChild);
+      }
+
+      run.steps.forEach(step => {
+        const item = document.createElement('li');
+        item.style.flex = '1 1 140px';
+        item.style.border = '1px solid #ddd';
+        item.style.borderRadius = '6px';
+        item.style.padding = '0.75rem';
+        item.style.backgroundColor = step.status === 'ok' ? '#f0fff4' : step.status === 'failed' ? '#fff0f0' : '#fff';
+        const title = document.createElement('div');
+        title.textContent = step.label;
+        title.style.fontWeight = '600';
+        title.style.marginBottom = '0.35rem';
+        const status = document.createElement('div');
+        status.textContent = step.status_display;
+        status.style.color = step.status === 'failed' ? '#b30000' : '#555';
+        if (step.is_current && (run.status === 'running' || run.status === 'queued')) {
+          status.textContent += ' {% trans "(in progress)" %}';
+        }
+        item.appendChild(title);
+        item.appendChild(status);
+        stepsList.appendChild(item);
+      });
+    }
+
+    function shouldContinue(run) {
+      return run.status === 'queued' || run.status === 'running';
+    }
+
+    function schedulePoll(runId) {
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+      pollTimer = window.setTimeout(() => {
+        fetchStatus(runId);
+      }, 4000);
+    }
+
+    function fetchStatus(runId) {
+      const url = `${statusBase}${runId}/`;
+      fetch(url, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+        .then(response => response.ok ? response.json() : Promise.reject(response))
+        .then(data => {
+          const { run } = data;
+          renderSteps(run);
+          if (shouldContinue(run)) {
+            schedulePoll(run.id);
+          } else {
+            setButtonState(false);
+          }
+        })
+        .catch(() => {
+          setButtonState(false);
+        });
+    }
+
+    button.addEventListener('click', () => {
+      if (!startUrl) {
+        return;
+      }
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+      setButtonState(true);
+      errorBlock.style.display = 'none';
+      errorBlock.textContent = '';
+
+      fetch(startUrl, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': getCookie('csrftoken') || '',
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+        .then(response => response.ok ? response.json() : Promise.reject(response))
+        .then(data => {
+          const { run } = data;
+          renderSteps(run);
+          if (shouldContinue(run)) {
+            schedulePoll(run.id);
+          } else {
+            setButtonState(false);
+          }
+        })
+        .catch(() => {
+          setButtonState(false);
+        });
+    });
+  })();
+</script>
 {% endblock %}

--- a/articles/tests/test_admin_dashboard.py
+++ b/articles/tests/test_admin_dashboard.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from articles.models import ArticleRun, RunStep
+
+
+class AdminDashboardViewTests(TestCase):
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.staff_user = user_model.objects.create_user(
+            username="staff", email="staff@example.com", password="pass", is_staff=True
+        )
+
+    @patch("articles.pipeline.async_task")
+    def test_start_article_run_returns_initial_progress(self, mock_async_task):
+        self.client.force_login(self.staff_user)
+
+        response = self.client.post(reverse("admin:articles_admin_start_run"))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertIn("run", data)
+        run_data = data["run"]
+        self.assertEqual(run_data["status"], "queued")
+        self.assertEqual(run_data["steps"][0]["name"], "ideas")
+        self.assertEqual(run_data["steps"][0]["status"], "queued")
+        self.assertTrue(any(step["status"] == "pending" for step in run_data["steps"][1:]))
+
+        run = ArticleRun.objects.get(pk=run_data["id"])
+        self.assertEqual(run.steps.count(), 1)
+        mock_async_task.assert_called_once()
+
+    def test_run_status_includes_existing_steps(self):
+        self.client.force_login(self.staff_user)
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="outline")
+        RunStep.objects.create(run=run, name="ideas", status="ok")
+        RunStep.objects.create(run=run, name="scoring", status="ok")
+        RunStep.objects.create(run=run, name="outline", status="running")
+
+        response = self.client.get(reverse("admin:articles_admin_run_status", args=[run.id]))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["run"]
+        outline_step = next(step for step in data["steps"] if step["name"] == "outline")
+        scoring_step = next(step for step in data["steps"] if step["name"] == "scoring")
+
+        self.assertEqual(scoring_step["status"], "ok")
+        self.assertEqual(outline_step["status"], "running")
+        self.assertTrue(outline_step["is_current"])
+
+    def test_run_status_handles_missing_run(self):
+        self.client.force_login(self.staff_user)
+
+        response = self.client.get(reverse("admin:articles_admin_run_status", args=[9999]))
+
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Summary
- add admin endpoints to launch article runs and poll their status
- enhance the dashboard template with a launch button and live status display
- cover the new endpoints with admin dashboard view tests

## Testing
- python manage.py test articles.tests.test_admin_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68d97a3316c88332b20de0cdf87d15e0