### PR TITLE
Improve discovery and favorites layouts

### DIFF
--- a/app/templates/concepts/_card_assets.html
+++ b/app/templates/concepts/_card_assets.html
@@ -299,7 +299,7 @@
         if (shouldShowConceptLoading(trigger)) {
           card.classList.remove('loading');
         }
-        if (isConceptGenerateButton(trigger)) {
+        if (isConceptGenerateButton(trigger) || isConceptFavoriteButton(trigger)) {
           card.classList.remove('concept-generating');
         }
       }
@@ -322,6 +322,10 @@
 
       if (isConceptFavoriteButton(trigger)) {
         trigger.classList.add('concept-favorite-btn--busy');
+        if (card) {
+          card.classList.remove('show-back');
+          card.classList.add('concept-generating');
+        }
       }
 
       if (isConceptGenerateButton(trigger)) {

--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -19,19 +19,18 @@
 <div class="max-w-7xl mx-auto px-4 py-6 space-y-6">
 
   <div class="space-y-6">
-    <div class="space-y-2">
-      <p class="text-xs font-semibold uppercase tracking-[0.35em] text-[#FF5C00]/70">Concept</p>
-      <h2 class="text-3xl font-semibold text-[#14080E]">{{ concept.name }}</h2>
+    <div class="rounded-3xl border border-[#FFD6B6]/70 bg-white/80 p-5 shadow-sm backdrop-blur-sm">
+      <p class="inline-flex items-center gap-2 rounded-full border border-[#FF5C00]/20 bg-[#FFF1E6] px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[#FF5C00]">
+        Concept
+      </p>
+      <h2 class="mt-3 text-3xl font-semibold text-[#14080E]">{{ concept.name }}</h2>
     </div>
 
-    <div class="space-y-3">
-      <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-[#4F4A50]/80">Current ideas</h3>
-      <div
-        id="dishes-grid"
-        class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-1 sm:gap-3 md:gap-4 lg:gap-4 xl:gap-5"
-      >
-        {% include "dishes/grid.html" %}
-      </div>
+    <div
+      id="dishes-grid"
+      class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-1 sm:gap-3 md:gap-4 lg:gap-4 xl:gap-5"
+    >
+      {% include "dishes/grid.html" %}
     </div>
 
     {% if dishes and dishes_generate_url %}
@@ -41,10 +40,16 @@
           hx-post="{{ dishes_generate_url }}"
           hx-target="#dishes-grid"
           hx-swap="beforeend"
-          class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
+          class="relative inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
         >
-          <span>More dishes like these</span>
-          <i class="fa-solid fa-chevron-down text-[10px]"></i>
+          <span class="inline-flex items-center gap-2">
+            <span>More dishes like these</span>
+            <i class="fa-solid fa-chevron-down text-[10px]"></i>
+          </span>
+          <span class="htmx-indicator absolute inset-y-0 right-3 inline-flex items-center gap-1 text-[#FF5C00]" style="display: none;">
+            <i class="fa-solid fa-circle-notch animate-spin text-[0.65rem]"></i>
+            <span class="text-[0.65rem] font-semibold uppercase tracking-widest">Loading</span>
+          </span>
         </button>
       </div>
     {% endif %}

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -85,66 +85,107 @@
               {% if concept %}
                 <li
                   id="favorite-concept-{{ concept.id }}"
-                  class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-4"
+                  class="rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4"
                 >
-                  <div class="h-14 w-14 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100 sm:h-16 sm:w-16">
-                    {% if concept.sketch_image_url %}
-                      <img
-                        src="{{ concept.sketch_image_url }}"
-                        alt="{{ concept.name }} sketch"
-                        class="h-full w-full object-cover"
-                        loading="lazy"
-                        decoding="async"
-                      />
-                    {% else %}
-                      <div class="flex h-full w-full items-center justify-center text-slate-400">
-                        <i class="fa-regular fa-image text-xl" aria-hidden="true"></i>
-                      </div>
-                    {% endif %}
-                  </div>
-                  <div class="flex-1 space-y-1">
-                    <h3 class="text-base font-semibold text-[#49475B]">{{ concept.name }}</h3>
-                    {% if concept.subtitle %}
-                      <p class="text-sm leading-snug text-slate-600">{{ concept.subtitle }}</p>
-                    {% endif %}
-                  </div>
-                  <div class="flex flex-col items-start gap-3 text-left sm:items-end sm:text-right">
-                    <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
-                      {% if concept_menus %}
-                        {% for menu_name in concept_menus %}
-                          {% with menu_color=menu_color_map|dict_lookup:menu_name %}
-                            <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
-                              <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
-                              {{ menu_name }}
-                            </span>
-                          {% endwith %}
-                        {% endfor %}
+                  <div class="flex items-start gap-3 sm:items-center sm:gap-4">
+                    <div class="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100 sm:h-16 sm:w-16">
+                      {% if concept.sketch_image_url %}
+                        <img
+                          src="{{ concept.sketch_image_url }}"
+                          alt="{{ concept.name }} sketch"
+                          class="h-full w-full object-cover"
+                          loading="lazy"
+                          decoding="async"
+                        />
                       {% else %}
-                        <span class="menu-assignment-pill menu-assignment-pill--empty">
-                          <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
-                          Not in a menu
-                        </span>
+                        <div class="flex h-full w-full items-center justify-center text-slate-400">
+                          <i class="fa-regular fa-image text-xl" aria-hidden="true"></i>
+                        </div>
                       {% endif %}
                     </div>
-                    <div class="flex flex-wrap items-center gap-2">
-                      <a
-                        href="{% url 'dish_detail' concept.id %}"
-                        class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5C00] text-white shadow hover:bg-[#e05400]"
-                      >
-                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
-                        <span class="sr-only">Open concept</span>
-                      </a>
-                      <button
-                        type="button"
-                        class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
-                        hx-post="{% url 'favorite-remove' 'concept' concept.id %}"
-                        hx-target="#favorite-concept-{{ concept.id }}"
-                        hx-swap="outerHTML"
-                        title="Remove from favorites"
-                      >
-                        <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
-                        <span class="sr-only">Remove {{ concept.name }} from favorites</span>
-                      </button>
+                    <div class="flex-1 space-y-3">
+                      <div class="space-y-1">
+                        <h3 class="text-base font-semibold text-[#49475B]">{{ concept.name }}</h3>
+                        {% if concept.subtitle %}
+                          <p class="text-sm leading-snug text-slate-600">{{ concept.subtitle }}</p>
+                        {% endif %}
+                      </div>
+                      <div class="flex flex-wrap items-center gap-1.5 sm:hidden">
+                        {% if concept_menus %}
+                          {% for menu_name in concept_menus %}
+                            {% with menu_color=menu_color_map|dict_lookup:menu_name %}
+                              <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
+                                <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                                {{ menu_name }}
+                              </span>
+                            {% endwith %}
+                          {% endfor %}
+                        {% else %}
+                          <span class="menu-assignment-pill menu-assignment-pill--empty">
+                            <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                            Not in a menu
+                          </span>
+                        {% endif %}
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2 sm:hidden">
+                        <a
+                          href="{% url 'dish_detail' concept.id %}"
+                          class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5C00] text-white shadow hover:bg-[#e05400]"
+                        >
+                          <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                          <span class="sr-only">Open concept</span>
+                        </a>
+                        <button
+                          type="button"
+                          class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                          hx-post="{% url 'favorite-remove' 'concept' concept.id %}"
+                          hx-target="#favorite-concept-{{ concept.id }}"
+                          hx-swap="outerHTML"
+                          title="Remove from favorites"
+                        >
+                          <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                          <span class="sr-only">Remove {{ concept.name }} from favorites</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="hidden sm:flex flex-col items-end gap-3 text-right">
+                      <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
+                        {% if concept_menus %}
+                          {% for menu_name in concept_menus %}
+                            {% with menu_color=menu_color_map|dict_lookup:menu_name %}
+                              <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
+                                <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                                {{ menu_name }}
+                              </span>
+                            {% endwith %}
+                          {% endfor %}
+                        {% else %}
+                          <span class="menu-assignment-pill menu-assignment-pill--empty">
+                            <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                            Not in a menu
+                          </span>
+                        {% endif %}
+                      </div>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <a
+                          href="{% url 'dish_detail' concept.id %}"
+                          class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5C00] text-white shadow hover:bg-[#e05400]"
+                        >
+                          <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                          <span class="sr-only">Open concept</span>
+                        </a>
+                        <button
+                          type="button"
+                          class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                          hx-post="{% url 'favorite-remove' 'concept' concept.id %}"
+                          hx-target="#favorite-concept-{{ concept.id }}"
+                          hx-swap="outerHTML"
+                          title="Remove from favorites"
+                        >
+                          <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                          <span class="sr-only">Remove {{ concept.name }} from favorites</span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </li>
@@ -179,72 +220,115 @@
                 {% with dish_menus=dish_menu_map|dict_lookup:dish.id %}
                   <li
                     id="favorite-dish-{{ dish.id }}"
-                    class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-4"
+                    class="rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4"
                   >
-                    <div class="h-14 w-14 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100 sm:h-16 sm:w-16">
-                      {% if dish.enhancement_image_url %}
-                        <img
-                          src="{{ dish.enhancement_image_url }}"
-                          alt="{{ dish.title }} image"
-                          class="h-full w-full object-cover"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      {% else %}
-                        <div class="flex h-full w-full items-center justify-center text-slate-400">
-                          <i class="fa-solid fa-utensils text-base" aria-hidden="true"></i>
-                        </div>
-                      {% endif %}
-                    </div>
-                    <div class="flex-1 space-y-1">
-                      <h3 class="text-base font-semibold text-[#49475B]">{{ dish.title }}</h3>
-                      {% if dish.description %}
-                        {% with description=dish.description %}
-                          <p class="text-sm text-slate-600 leading-snug">
-                            {{ description|slice:":120" }}{% if description|length > 120 %}…{% endif %}
-                          </p>
-                        {% endwith %}
-                      {% endif %}
-                    </div>
-                    <div class="flex flex-col items-start gap-3 text-left sm:items-end sm:text-right">
-                      <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
-                        {% if dish_menus %}
-                          {% for menu_name in dish_menus %}
-                            {% with menu_color=menu_color_map|dict_lookup:menu_name %}
-                              <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
-                                <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
-                                {{ menu_name }}
-                              </span>
-                            {% endwith %}
-                          {% endfor %}
+                    <div class="flex items-start gap-3 sm:items-center sm:gap-4">
+                      <div class="h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl bg-slate-100 sm:h-16 sm:w-16">
+                        {% if dish.enhancement_image_url %}
+                          <img
+                            src="{{ dish.enhancement_image_url }}"
+                            alt="{{ dish.title }} image"
+                            class="h-full w-full object-cover"
+                            loading="lazy"
+                            decoding="async"
+                          />
                         {% else %}
-                          <span class="menu-assignment-pill menu-assignment-pill--empty">
-                            <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
-                            Unassigned
-                          </span>
+                          <div class="flex h-full w-full items-center justify-center text-slate-400">
+                            <i class="fa-solid fa-utensils text-base" aria-hidden="true"></i>
+                          </div>
                         {% endif %}
                       </div>
-                      <div class="flex flex-wrap items-center gap-2">
-                        {% if dish.parent_concept_id %}
-                          <a
-                            href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
-                            class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#58B09C] text-white shadow hover:bg-[#4b9c8a]"
+                      <div class="flex-1 space-y-3">
+                        <div class="space-y-1">
+                          <h3 class="text-base font-semibold text-[#49475B]">{{ dish.title }}</h3>
+                          {% if dish.description %}
+                            {% with description=dish.description %}
+                              <p class="text-sm text-slate-600 leading-snug">
+                                {{ description|slice:":120" }}{% if description|length > 120 %}…{% endif %}
+                              </p>
+                            {% endwith %}
+                          {% endif %}
+                        </div>
+                        <div class="flex flex-wrap items-center gap-1.5 sm:hidden">
+                          {% if dish_menus %}
+                            {% for menu_name in dish_menus %}
+                              {% with menu_color=menu_color_map|dict_lookup:menu_name %}
+                                <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
+                                  <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                                  {{ menu_name }}
+                                </span>
+                              {% endwith %}
+                            {% endfor %}
+                          {% else %}
+                            <span class="menu-assignment-pill menu-assignment-pill--empty">
+                              <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                              Unassigned
+                            </span>
+                          {% endif %}
+                        </div>
+                        <div class="flex flex-wrap items-center gap-2 sm:hidden">
+                          {% if dish.parent_concept_id %}
+                            <a
+                              href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                              class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#58B09C] text-white shadow hover:bg-[#4b9c8a]"
+                            >
+                              <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                              <span class="sr-only">Open run</span>
+                            </a>
+                          {% endif %}
+                          <button
+                            type="button"
+                            class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                            hx-post="{% url 'favorite-remove' 'dish' dish.id %}"
+                            hx-target="#favorite-dish-{{ dish.id }}"
+                            hx-swap="outerHTML"
+                            title="Remove from favorites"
                           >
-                            <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
-                            <span class="sr-only">Open run</span>
-                          </a>
-                        {% endif %}
-                        <button
-                          type="button"
-                          class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
-                          hx-post="{% url 'favorite-remove' 'dish' dish.id %}"
-                          hx-target="#favorite-dish-{{ dish.id }}"
-                          hx-swap="outerHTML"
-                          title="Remove from favorites"
-                        >
-                          <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
-                          <span class="sr-only">Remove {{ dish.title }} from favorites</span>
-                        </button>
+                            <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                            <span class="sr-only">Remove {{ dish.title }} from favorites</span>
+                          </button>
+                        </div>
+                      </div>
+                      <div class="hidden sm:flex flex-col items-end gap-3 text-right">
+                        <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
+                          {% if dish_menus %}
+                            {% for menu_name in dish_menus %}
+                              {% with menu_color=menu_color_map|dict_lookup:menu_name %}
+                                <span class="menu-assignment-pill" {% if menu_color %}style="--menu-color: {{ menu_color }}"{% endif %}>
+                                  <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                                  {{ menu_name }}
+                                </span>
+                              {% endwith %}
+                            {% endfor %}
+                          {% else %}
+                            <span class="menu-assignment-pill menu-assignment-pill--empty">
+                              <i class="fa-solid fa-bookmark text-[0.65rem]" aria-hidden="true"></i>
+                              Unassigned
+                            </span>
+                          {% endif %}
+                        </div>
+                        <div class="flex flex-wrap items-center gap-2">
+                          {% if dish.parent_concept_id %}
+                            <a
+                              href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                              class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#58B09C] text-white shadow hover:bg-[#4b9c8a]"
+                            >
+                              <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
+                              <span class="sr-only">Open run</span>
+                            </a>
+                          {% endif %}
+                          <button
+                            type="button"
+                            class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-400 transition hover:text-red-500"
+                            hx-post="{% url 'favorite-remove' 'dish' dish.id %}"
+                            hx-target="#favorite-dish-{{ dish.id }}"
+                            hx-swap="outerHTML"
+                            title="Remove from favorites"
+                          >
+                            <i class="fa-solid fa-trash-can text-sm" aria-hidden="true"></i>
+                            <span class="sr-only">Remove {{ dish.title }} from favorites</span>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </li>


### PR DESCRIPTION
## Summary
- restyle the dish discovery header to highlight the concept title and remove the redundant "Current ideas" label
- add a loading indicator to the "More dishes like these" button and show progress when favoriting concepts
- reorganize favorites concept and dish cards for better small-screen layout with larger imagery and stacked controls

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabe316168833296b876f3d2a954f6