### PR TITLE
Align outscraper queueing and polish dashboards

### DIFF
--- a/app/templates/concepts/_card_assets.html
+++ b/app/templates/concepts/_card_assets.html
@@ -353,6 +353,13 @@
       clearConceptTriggerState(trigger);
     });
 
+    document.body.addEventListener('htmx:afterRequest', function (evt) {
+      const trigger = evt.detail && evt.detail.elt;
+      if (isMoreIdeasButton(trigger)) {
+        clearConceptTriggerState(trigger);
+      }
+    });
+
     document.body.addEventListener('htmx:afterSwap', function (evt) {
       const trigger = evt.detail && evt.detail.elt;
       const target = evt.detail && evt.detail.target;

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -18,27 +18,6 @@
       </div>
     </section>
 
-    {% if disliked_concepts %}
-      <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div class="space-y-3">
-          <div class="flex items-center justify-between gap-2">
-            <h2 class="text-lg font-semibold text-[#14080E]">Passed on concepts</h2>
-            <span class="text-xs font-medium uppercase tracking-wide text-slate-400">We will remix these</span>
-          </div>
-          <p class="text-sm text-slate-600">Here are the ideas that didn&apos;t land. Future runs will keep them in mind and explore stronger angles.</p>
-          <ul class="space-y-2">
-            {% for name in disliked_concepts %}
-              <li class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
-                <span aria-hidden="true" class="text-base leading-none">👎</span>
-                <span class="sr-only">Not a fit:</span>
-                <span class="font-medium text-[#49475B]">{{ name }}</span>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      </section>
-    {% endif %}
-
     <div class="space-y-4">
       <div id="concepts-grid" class="grid grid-cols-2 gap-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
         {% include 'concepts/_concepts_grid.html' %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -215,16 +215,12 @@
               </summary>
               <div class="mt-3 rounded-2xl bg-white/70 p-4 shadow-sm">
                 {% if menu.menu_items %}
-                  <ul class="grid gap-2 text-sm text-[#49475B] sm:grid-cols-2">
+                  <ul class="space-y-1 text-sm text-[#49475B]">
                     {% for item in menu.menu_items %}
-                      <li class="flex items-center justify-between gap-3 rounded-xl border border-white/70 bg-white/80 px-3 py-2 shadow-sm">
-                        <div class="flex flex-col">
-                          <span class="font-medium">{{ item.dish.title }}</span>
-                          <span class="text-[11px] text-slate-500">{{ item.dish.parent_concept.name }}</span>
-                        </div>
-                        <a href="{% url 'dish_detail' item.dish.parent_concept.id %}" class="inline-flex items-center gap-1 text-xs font-semibold text-[#2E005D] hover:text-[#250047]">
-                          Open
-                          <i class="fa-solid fa-arrow-up-right-from-square text-[9px]" aria-hidden="true"></i>
+                      {% url 'dish_detail' item.dish.parent_concept.id as menu_dish_url %}
+                      <li>
+                        <a href="{{ menu_dish_url }}#dish-{{ item.dish.id }}" class="block rounded-lg border border-white/60 bg-white px-3 py-2 font-medium text-[#14080E] transition hover:border-[#2E005D]/40 hover:text-[#2E005D]">
+                          {{ item.dish.title }}
                         </a>
                       </li>
                     {% endfor %}

--- a/app/templates/favorites/dashboard.html
+++ b/app/templates/favorites/dashboard.html
@@ -268,8 +268,9 @@
                         </div>
                         <div class="flex flex-wrap items-center gap-2 sm:hidden">
                           {% if dish.parent_concept_id %}
+                            {% url 'dish_detail' dish.parent_concept_id as dish_detail_url %}
                             <a
-                              href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                              href="{{ dish_detail_url }}{% if dish.ideation_run_id %}?run={{ dish.ideation_run_id }}{% endif %}#dish-{{ dish.id }}"
                               class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#58B09C] text-white shadow hover:bg-[#4b9c8a]"
                             >
                               <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>
@@ -309,8 +310,9 @@
                         </div>
                         <div class="flex flex-wrap items-center gap-2">
                           {% if dish.parent_concept_id %}
+                            {% url 'dish_detail' dish.parent_concept_id as dish_detail_url %}
                             <a
-                              href="{% url 'dish_detail' dish.parent_concept_id %}#dish-{{ dish.id }}"
+                              href="{{ dish_detail_url }}{% if dish.ideation_run_id %}?run={{ dish.ideation_run_id }}{% endif %}#dish-{{ dish.id }}"
                               class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#58B09C] text-white shadow hover:bg-[#4b9c8a]"
                             >
                               <i class="fa-solid fa-arrow-up-right-from-square text-[0.65rem]" aria-hidden="true"></i>

--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -25,6 +25,25 @@
         </div>
       {% endif %}
 
+      {% if disliked_concepts %}
+        <section class="space-y-4 rounded-xl bg-white p-6 m-4 shadow">
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="text-lg font-semibold text-[#14080E]">Passed on concepts</h2>
+            <span class="text-xs font-medium uppercase tracking-wide text-slate-400">We will remix these</span>
+          </div>
+          <p class="text-sm text-slate-600">We&apos;ll remember the ideas that missed and tilt future generations toward better fits.</p>
+          <ul class="space-y-2">
+            {% for name in disliked_concepts %}
+              <li class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+                <span aria-hidden="true" class="text-base leading-none">👎</span>
+                <span class="sr-only">Not a fit:</span>
+                <span class="font-medium text-[#49475B]">{{ name }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+
       <section class="space-y-6 rounded-xl bg-white p-6 m-4 shadow" data-menu-manager>
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div class="space-y-1">

--- a/app/views.py
+++ b/app/views.py
@@ -117,6 +117,35 @@ def _persist_slider_value(
     setattr(restaurant, "restaurantsettings", settings)
     return settings
 
+
+def _queue_outscraper_payload(
+    restaurant: "models.Restaurant",
+    *,
+    restaurant_name: Optional[str] = None,
+    location: Optional[str] = None,
+) -> "models.OutscraperPayload":
+    """Create a queued Outscraper payload for the given restaurant."""
+
+    name = (restaurant_name or getattr(restaurant, "name", "") or "").strip()
+    location_text = (
+        location if location is not None else getattr(restaurant, "location_text", "")
+    )
+    location_text = (location_text or "").strip()
+    query_parts = [part for part in (name, location_text) if part]
+    query = " ".join(query_parts) if query_parts else name
+
+    payload = models.OutscraperPayload.objects.create(
+        restaurant=restaurant,
+        status=models.OutscraperPayload.Status.QUEUED,
+        request_params={
+            "query": query,
+            "async": "false",
+            "limit": 1,
+            "fields": "query,name,place_id,full_address,latitude,longitude,site,phone,type,description,category,subtypes,about,menu_link,order_links",
+        },
+    )
+    return payload
+
 class ConceptList(BaseModel):
     concepts: List[str]
 
@@ -554,15 +583,10 @@ def signup_view(request):
                     name=restaurant_name,
                     location_text=location,
                 )
-                payload = models.OutscraperPayload.objects.create(
-                    restaurant=restaurant,
-                    status=models.OutscraperPayload.Status.QUEUED,
-                    request_params={
-                        "query": f"{restaurant_name} {location}",
-                        "async": "false",
-                        "limit": 1,
-                        "fields":"query,name,place_id,full_address,latitude,longitude,site,phone,type,description,category,subtypes,about,menu_link,order_links"
-                    },
+                payload = _queue_outscraper_payload(
+                    restaurant,
+                    restaurant_name=restaurant_name,
+                    location=location,
                 )
                 transaction.on_commit(
                     lambda payload_id=str(payload.id): run_outscraper_search.delay(
@@ -777,19 +801,22 @@ def dashboard(request, restaurant_id):
         .prefetch_related(
             Prefetch(
                 "menuitem_set",
-                queryset=models.MenuItem.objects.select_related(
+                queryset=models.MenuItem.objects.filter(
+                    dish__is_deleted=False
+                )
+                .select_related(
                     "dish",
                     "dish__parent_concept",
-                ).order_by("position", "created_at"),
+                )
+                .order_by("position", "created_at"),
+                to_attr="prefetched_menu_items",
             )
         )
         .order_by("-created_at")[:4]
     )
     for menu in menus:
         items = [
-            item
-            for item in menu.menuitem_set.all()
-            if item.dish and not item.dish.is_deleted
+            item for item in getattr(menu, "prefetched_menu_items", []) if item.dish
         ]
         menu.menu_items = items
 
@@ -1993,8 +2020,27 @@ def dish_detail_view(request, concept_id):
         id=concept_id,
     )
 
+    run_param = (request.GET.get("run") or "").strip()
+    selected_run = None
+    if run_param:
+        try:
+            uuid.UUID(run_param)
+        except (TypeError, ValueError):
+            run_param = ""
+        else:
+            selected_run = (
+                models.IdeationRun.objects.filter(
+                    id=run_param,
+                    parent_concept=concept,
+                    type=models.IdeationRun.RunType.DISHES,
+                    status=models.IdeationRun.Status.SUCCEEDED,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+
     # Get the most recent ideation run for this concept
-    latest_run = (
+    latest_run = selected_run or (
         models.IdeationRun.objects.filter(
             parent_concept=concept,
             type=models.IdeationRun.RunType.DISHES,
@@ -2394,7 +2440,11 @@ def favorites_view(request):
         favorite_concepts.append(favorite)
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(user=request.user)
-        .select_related("dish__parent_concept", "dish__restaurant")
+        .select_related(
+            "dish__parent_concept",
+            "dish__restaurant",
+            "dish__ideation_run",
+        )
         .order_by("-favorited_at")
     )
 
@@ -2407,11 +2457,17 @@ def favorites_view(request):
             .prefetch_related(
                 Prefetch(
                     "menuitem_set",
-                    queryset=models.MenuItem.objects.select_related(
+                    queryset=models.MenuItem.objects.filter(
+                        dish__is_deleted=False
+                    )
+                    .select_related(
                         "dish",
                         "dish__parent_concept",
                         "dish__restaurant",
-                    ).order_by("position", "created_at"),
+                        "dish__ideation_run",
+                    )
+                    .order_by("position", "created_at"),
+                    to_attr="prefetched_menu_items",
                 )
             )
             .order_by("created_at")
@@ -2419,7 +2475,11 @@ def favorites_view(request):
         menu_palette = ["#F9F7FF", "#F3FAFF", "#FFF6F1", "#F4FFF5", "#FFF5FA"]
         for index, menu in enumerate(menus):
             menu_color_map[menu.name] = menu_palette[index % len(menu_palette)]
-            items = list(menu.menuitem_set.all())
+            items = [
+                item
+                for item in getattr(menu, "prefetched_menu_items", [])
+                if item.dish
+            ]
             menu.menu_items = items
             for item in items:
                 menu_dishes.append(item.dish)
@@ -2972,12 +3032,15 @@ def settings_view(request):
     )
     prefs = getattr(request.user, "notificationpref", None)
     active_menu = restaurant.active_menu_version if restaurant else None
+    disliked_concepts = _get_session_list(request.session, "disliked_concepts")
+    recent_disliked = list(reversed(disliked_concepts[-6:])) if disliked_concepts else []
     return render(request, "settings/main.html", {
         "restaurant": restaurant,
         "ingredients": ingredients,
         "prefs": prefs,
         "restaurant_settings": getattr(restaurant, "restaurantsettings", None),
         "active_menu_version": active_menu,
+        "disliked_concepts": recent_disliked,
     })
 
 
@@ -3035,11 +3098,7 @@ def update_restaurant_info(request):
 @require_POST
 def rescrape_restaurant(request, restaurant_id):
     restaurant = get_object_or_404(models.Restaurant, id=restaurant_id)
-    payload = models.OutscraperPayload.objects.create(
-        restaurant=restaurant,
-        status=models.OutscraperPayload.Status.QUEUED,
-        request_params={"query": restaurant.name, "limit": 1, "async": "false"},
-    )
+    payload = _queue_outscraper_payload(restaurant)
     run_outscraper_search.delay(str(payload.id))
     return HttpResponse("rescrape_complete", content_type="text/plain")
 

--- a/tests/test_concept_dislikes.py
+++ b/tests/test_concept_dislikes.py
@@ -61,11 +61,11 @@ class ConceptDislikeTests(TestCase):
         self._favorite_and_unfavorite(concept)
         self.assertIn(concept.name, self.client.session.get("disliked_concepts", []))
 
-    def test_concepts_page_displays_disliked_section(self):
+    def test_settings_page_displays_disliked_section(self):
         concept = self._create_concepts(1)[0]
         self._favorite_and_unfavorite(concept)
 
-        response = self.client.get(reverse("concepts"))
+        response = self.client.get(reverse("settings"))
         self.assertContains(response, "Passed on concepts")
         self.assertContains(response, "👎")
         self.assertContains(response, concept.name)


### PR DESCRIPTION
## Summary
- add a shared helper for Outscraper payload creation and reuse it in signup and rescrape flows
- surface "Passed on concepts" in the settings view while simplifying the concepts grid interactions
- tighten menu and favorites dish displays and ensure dish detail pages can deep-link to older runs

## Testing
- python manage.py test tests.test_concept_dislikes tests.test_appertivo_views *(fails: AttributeError: module 'outscraper' has no attribute 'outscraper_webhook')*


------
https://chatgpt.com/codex/tasks/task_e_68dacc1b211883329aee6d8f981b8471