### PR TITLE
Add thumbs-down indicator for unfavorited concepts

### DIFF
--- a/app/migrations/0011_concept_is_unfavorite.py
+++ b/app/migrations/0011_concept_is_unfavorite.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0010_llmcalllog"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="concept",
+            name="is_unfavorite",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -251,6 +251,7 @@ class Concept(TimestampedModel):
     tags = models.JSONField(default=list)  # array of descriptive tags
     rank_order = models.SmallIntegerField()
     sketch_image_url = models.TextField(null=True, blank=True)
+    is_unfavorite = models.BooleanField(default=False)
 
     class Meta:
         indexes = [models.Index(fields=["restaurant", "-created_at"])]

--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -23,6 +23,10 @@
                   🤍
                 {% endif %}
               </span>
+              {% if not is_favorited and concept.is_unfavorited_for_user|default:False %}
+                <span aria-hidden="true" class="ml-1 text-base leading-none">👎</span>
+                <span class="sr-only">Marked as not a fit</span>
+              {% endif %}
             </button>
           {% endwith %}
         {% else %}
@@ -47,6 +51,10 @@
                   🤍
                 {% endif %}
               </span>
+              {% if not is_favorited and concept.is_unfavorited_for_user|default:False %}
+                <span aria-hidden="true" class="ml-1 text-base leading-none">👎</span>
+                <span class="sr-only">Marked as not a fit</span>
+              {% endif %}
             </button>
           {% endwith %}
         {% endif %}

--- a/app/views.py
+++ b/app/views.py
@@ -367,17 +367,50 @@ def _extend_session_list(session, key: str, new_items: Iterable[str]) -> None:
     session.modified = True
 
 
-def _record_unfavorited_concept(session, concept_name: str) -> None:
-    """Store a trimmed history of concept names the user removed from favorites."""
+def _record_unfavorited_concept(session, concept: models.Concept) -> bool:
+    """Persist and surface a concept the user removed from favorites.
 
-    name = (concept_name or "").strip()
+    Returns True when the concept unfavorite state changed.
+    """
+
+    if not concept:
+        return False
+
+    changed = False
+    if not concept.is_unfavorite:
+        concept.is_unfavorite = True
+        changed = True
+
+    concept.is_unfavorited_for_user = True
+
+    name = (concept.name or "").strip()
     if not name:
-        return
+        return changed
+
     _extend_session_list(session, "disliked_concepts", [name])
     disliked = _get_session_list(session, "disliked_concepts")
     if len(disliked) > 30:
         session["disliked_concepts"] = disliked[-30:]
         session.modified = True
+    return changed
+
+
+def _get_unfavorited_concept_names(
+    restaurant: Optional[models.Restaurant], limit: int
+) -> List[str]:
+    """Return the most recent unfavorited concept names for a restaurant."""
+
+    if not restaurant:
+        return []
+
+    names = list(
+        models.Concept.objects.filter(
+            restaurant=restaurant, is_unfavorite=True
+        )
+        .order_by("-created_at")
+        .values_list("name", flat=True)[:limit]
+    )
+    return [name for name in names if name]
 
 
 def _load_home_demo_favorites():
@@ -431,6 +464,7 @@ def _load_home_demo_favorites():
 
         concept = concept_favorite.concept
         concept.is_favorited_for_user = True
+        concept.is_unfavorited_for_user = concept.is_unfavorite
         concept.has_dishes = bool(dish) or getattr(concept, "has_dishes", False)
         concept.favorited_at = concept_favorite.favorited_at
         restaurant = getattr(concept, "restaurant", None)
@@ -741,6 +775,7 @@ def dashboard(request, restaurant_id):
         )
         concept.generated_at = run_finished or concept.created_at
         concept.is_favorited_for_user = concept.id in favorite_concept_ids
+        concept.is_unfavorited_for_user = concept.is_unfavorite
 
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(
@@ -1161,9 +1196,9 @@ def concepts_view(request):
     for concept in concepts:
         favorites = getattr(concept, "_favorites_for_request_user", [])
         concept.is_favorited_for_user = bool(favorites)
+        concept.is_unfavorited_for_user = concept.is_unfavorite
 
-    disliked_concepts = _get_session_list(request.session, "disliked_concepts")
-    recent_disliked = list(reversed(disliked_concepts[-6:])) if disliked_concepts else []
+    recent_disliked = _get_unfavorited_concept_names(restaurant, 6)
     return render(
         request,
         "concepts/grid.html",
@@ -1257,8 +1292,7 @@ def concepts_generate_view(request):
         for name in (request.session.get("generated_concepts") or [])
         if name and str(name).strip()
     ]
-    disliked_concepts = _get_session_list(request.session, "disliked_concepts")
-    disliked_context = disliked_concepts[-15:]
+    disliked_context = _get_unfavorited_concept_names(restaurant, 15)
 
     logger.info(f"previous concepts: {session_concepts}")
     if restaurant.active_menu_version:
@@ -1439,6 +1473,7 @@ def concepts_generate_view(request):
     for concept in concepts:
         concept.is_favorited_for_user = False
         concept.has_dishes = False
+        concept.is_unfavorited_for_user = concept.is_unfavorite
 
     if request.user.is_authenticated:
         _extend_session_list(
@@ -1476,10 +1511,20 @@ def concept_favorite_view(request, concept_id):
 
     if not created:
         fav.delete()
+        update_fields: List[str] = []
         if concept.sketch_image_url:
             concept.sketch_image_url = None
-            concept.save(update_fields=["sketch_image_url"])
-        _record_unfavorited_concept(request.session, concept.name)
+            update_fields.append("sketch_image_url")
+        unfavorite_changed = _record_unfavorited_concept(request.session, concept)
+        if unfavorite_changed:
+            update_fields.append("is_unfavorite")
+        if update_fields:
+            concept.save(update_fields=update_fields)
+    else:
+        concept.is_unfavorited_for_user = False
+        if concept.is_unfavorite:
+            concept.is_unfavorite = False
+            concept.save(update_fields=["is_unfavorite"])
 
     concept.is_favorited_for_user = favorited
     concept.has_dishes = models.DishIdea.objects.filter(
@@ -1525,6 +1570,7 @@ def concept_background_view(request, concept_id):
     concept.has_dishes = models.DishIdea.objects.filter(
         parent_concept=concept, is_deleted=False
     ).exists()
+    concept.is_unfavorited_for_user = concept.is_unfavorite
 
     return render(
         request,
@@ -1550,6 +1596,7 @@ def concepts_favorites_view(request):
         if concept is None:
             continue
         concept.is_favorited_for_user = True
+        concept.is_unfavorited_for_user = concept.is_unfavorite
         concepts.append(concept)
 
     concept_ids = [concept.id for concept in concepts]
@@ -2391,6 +2438,7 @@ def favorites_view(request):
         if not concept:
             continue
         concept.is_favorited_for_user = True
+        concept.is_unfavorited_for_user = concept.is_unfavorite
         favorite_concepts.append(favorite)
     favorite_dishes = list(
         models.FavoriteDish.objects.filter(user=request.user)
@@ -2486,10 +2534,14 @@ def favorite_remove_view(request, type, id):
         )
         concept = favorite.concept
         favorite.delete()
+        update_fields: List[str] = []
         if concept.sketch_image_url:
             concept.sketch_image_url = None
-            concept.save(update_fields=["sketch_image_url"])
-        _record_unfavorited_concept(request.session, concept.name)
+            update_fields.append("sketch_image_url")
+        if _record_unfavorited_concept(request.session, concept):
+            update_fields.append("is_unfavorite")
+        if update_fields:
+            concept.save(update_fields=update_fields)
     else:
         models.FavoriteDish.objects.filter(user=request.user, dish_id=id).delete()
     if request.headers.get("HX-Request"):

--- a/outscraper.py
+++ b/outscraper.py
@@ -1,0 +1,3 @@
+"""Compat shim for tests importing the legacy outscraper module."""
+
+from app.outscraper import outscraper_webhook  # noqa: F401

--- a/tests/test_concept_dislikes.py
+++ b/tests/test_concept_dislikes.py
@@ -48,22 +48,28 @@ class ConceptDislikeTests(TestCase):
             )
         return concepts
 
-    def _favorite_and_unfavorite(self, concept: models.Concept) -> None:
+    def _favorite_and_unfavorite(self, concept: models.Concept):
         self.client.post(
             reverse("concept-favorite", args=[concept.id]), HTTP_HX_REQUEST="true"
         )
-        self.client.post(
+        return self.client.post(
             reverse("concept-favorite", args=[concept.id]), HTTP_HX_REQUEST="true"
         )
 
     def test_unfavorite_records_concept_name_in_session(self):
         concept = self._create_concepts(1)[0]
-        self._favorite_and_unfavorite(concept)
+        response = self._favorite_and_unfavorite(concept)
         self.assertIn(concept.name, self.client.session.get("disliked_concepts", []))
+        concept.refresh_from_db()
+        self.assertTrue(concept.is_unfavorite)
+        self.assertIn("👎", response.content.decode())
 
     def test_concepts_page_displays_disliked_section(self):
         concept = self._create_concepts(1)[0]
         self._favorite_and_unfavorite(concept)
+        session = self.client.session
+        session["disliked_concepts"] = []
+        session.save()
 
         response = self.client.get(reverse("concepts"))
         self.assertContains(response, "Passed on concepts")
@@ -74,6 +80,9 @@ class ConceptDislikeTests(TestCase):
     def test_generation_context_mentions_disliked_concepts(self, mock_client):
         concept = self._create_concepts(1)[0]
         self._favorite_and_unfavorite(concept)
+        session = self.client.session
+        session["disliked_concepts"] = []
+        session.save()
 
         payload = {
             "concepts": [


### PR DESCRIPTION
## Summary
- add a persisted `is_unfavorite` flag on concepts with a migration and lightweight outscraper shim for tests
- surface unfavorited concepts from the database when generating concepts and render a thumbs-down icon on disliked cards
- update session helpers, concept views, and dislike tests to exercise the new behaviour

## Testing
- python manage.py test tests.test_concept_dislikes

------
https://chatgpt.com/codex/tasks/task_e_68dacdab5b648332bae453851e6cae33