### PR TITLE
feat: replace django admin with branded dashboard

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,46 +1,120 @@
 
-from types import MethodType
+"""Admin registrations for the custom Appertivo admin site."""
+
+from typing import List
+
 from django.contrib import admin
-from django.template.response import TemplateResponse
-from django.urls import path
-from decimal import Decimal
-from django.contrib import admin
-from django.db.models import Count, Sum
-from django.db.models.functions import Coalesce
+from django.contrib.admin import ModelAdmin
+from django.contrib.auth import get_user_model
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
+from django.contrib.auth.models import Group
+from django.db import models as django_models
+from django.core.exceptions import FieldDoesNotExist
 
 from . import models
-from .qa_checklist import CHECKLIST_SECTIONS
+from .admin_site import appertivo_admin_site
 
 
-# Simple generic base
-class TimestampedAdmin(admin.ModelAdmin):
+def _model_has_field(model: type[django_models.Model], field_name: str) -> bool:
+    """Return ``True`` if ``field_name`` is a concrete model field."""
+
+    try:
+        model._meta.get_field(field_name)
+    except FieldDoesNotExist:
+        return False
+    return True
+
+
+class TimestampedAdmin(ModelAdmin):
+    """Base admin that favours human-readable list columns."""
+
     readonly_fields = ("id", "created_at")
-    list_display = ("id", "created_at")
+    list_display: tuple[str, ...] = ()
     ordering = ("-created_at",)
+
+    def display_label(self, obj):
+        """Return a descriptive label for list displays."""
+
+        for attr in ("name", "title", "code", "slug"):
+            if hasattr(obj, attr):
+                value = getattr(obj, attr)
+                if value:
+                    return value
+        return str(obj)
+
+    display_label.short_description = "Name"
+
+    def get_list_display(self, request):
+        display = list(super().get_list_display(request))
+        if not display:
+            display = ["display_label"]
+        if "display_label" not in display:
+            display.insert(0, "display_label")
+        if _model_has_field(self.model, "status") and "status" not in display:
+            display.append("status")
+        if _model_has_field(self.model, "created_at") and "created_at" not in display:
+            display.append("created_at")
+        return display
+
+    def get_list_display_links(self, request, list_display):
+        links = super().get_list_display_links(request, list_display)
+        if links is None and "display_label" in list_display:
+            return ("display_label",)
+        return links
+
+    def get_search_fields(self, request):
+        base = list(super().get_search_fields(request))
+        for field_name in ("name", "title", "description", "code", "slug"):
+            if _model_has_field(self.model, field_name):
+                base.append(field_name)
+        return tuple(dict.fromkeys(base))
+
+    def get_list_filter(self, request):
+        filters: List = list(super().get_list_filter(request))
+        if _model_has_field(self.model, "status") and "status" not in filters:
+            filters.append("status")
+        return tuple(filters)
 
 
 # Register core org/account/user models
-@admin.register(models.Account)
+@admin.register(models.Account, site=appertivo_admin_site)
 class AccountAdmin(TimestampedAdmin):
-    list_display = ("id", "name", "stripe_customer_id", "created_at")
+    list_display = ("name", "stripe_customer_id", "created_at")
 
 
-@admin.register(models.UserProfile)
+@admin.register(models.UserProfile, site=appertivo_admin_site)
 class UserProfileAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "timezone", "created_at")
+    list_display = ("user", "timezone", "created_at")
 
 
-@admin.register(models.Membership)
+@admin.register(models.Membership, site=appertivo_admin_site)
 class MembershipAdmin(TimestampedAdmin):
-    list_display = ("id", "account", "user", "role", "created_at")
+    list_display = ("account", "user", "role", "created_at")
+    list_filter = ("role", "account")
 
 
 # Restaurant + data
-@admin.register(models.Restaurant)
+class MenuVersionInline(admin.TabularInline):
+    model = models.MenuVersion
+    extra = 0
+    fields = ("source_kind", "status", "parsed_at")
+    readonly_fields = ("parsed_at",)
+
+
+class DishIdeaInline(admin.TabularInline):
+    model = models.DishIdea
+    extra = 0
+    fields = ("title", "description")
+    show_change_link = True
+
+
+@admin.register(models.Restaurant, site=appertivo_admin_site)
 class RestaurantAdmin(admin.ModelAdmin):
-    list_display = ("name", "location_text", "phone", "rating", "review_count")
+    list_display = ("name", "location_text", "phone", "rating", "review_count", "created_at")
     search_fields = ("name", "location_text", "phone")
+    list_filter = ("rating", "account")
     readonly_fields = ("context_json", "reviews_json")
+    inlines = (MenuVersionInline, DishIdeaInline)
 
     fieldsets = (
         ("Core Info", {
@@ -64,84 +138,103 @@ class RestaurantAdmin(admin.ModelAdmin):
         }),
     )
 
-@admin.register(models.RestaurantSettings)
+@admin.register(models.RestaurantSettings, site=appertivo_admin_site)
 class RestaurantSettingsAdmin(TimestampedAdmin):
-    list_display = ("restaurant", "classic_creative_slider", "default_currency", "updated_at")
+    list_display = (
+        "restaurant",
+        "classic_creative_slider",
+        "default_currency",
+        "updated_at",
+    )
 
 
-@admin.register(models.OutscraperPayload)
+@admin.register(models.OutscraperPayload, site=appertivo_admin_site)
 class OutscraperPayloadAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "status", "started_at", "finished_at")
+    list_display = ("restaurant", "status", "started_at", "finished_at")
+    list_filter = ("status", "restaurant")
 
 
-@admin.register(models.MenuVersion)
+@admin.register(models.MenuVersion, site=appertivo_admin_site)
 class MenuVersionAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "source_kind", "status", "parsed_at")
+    list_display = ("restaurant", "source_kind", "status", "parsed_at")
+    list_filter = ("status", "source_kind", "restaurant")
 
 
-@admin.register(models.Ingredient)
+@admin.register(models.Ingredient, site=appertivo_admin_site)
 class IngredientAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "name", "canonical_name", "confidence")
+    list_display = ("restaurant", "name", "canonical_name", "confidence")
+    search_fields = ("name", "canonical_name")
 
 
 # Ideation + results
-@admin.register(models.IdeationRun)
+@admin.register(models.IdeationRun, site=appertivo_admin_site)
 class IdeationRunAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "type", "model_name", "status", "created_at")
+    list_display = ("restaurant", "type", "model_name", "status", "created_at")
+    list_filter = ("status", "type", "restaurant")
 
 
-@admin.register(models.Concept)
+@admin.register(models.Concept, site=appertivo_admin_site)
 class ConceptAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "name", "rank_order", "created_at")
+    list_display = ("restaurant", "name", "rank_order", "created_at")
 
 
-@admin.register(models.DishIdea)
+@admin.register(models.DishIdea, site=appertivo_admin_site)
 class DishIdeaAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "title", "description")
+    list_display = ("restaurant", "title", "description", "created_at")
+    search_fields = ("title", "description")
 
 
-@admin.register(models.DishIdeaIngredient)
+@admin.register(models.DishIdeaIngredient, site=appertivo_admin_site)
 class DishIdeaIngredientAdmin(TimestampedAdmin):
-    list_display = ("id", "dish", "ingredient", "source", "confidence")
+    list_display = ("dish", "ingredient", "source", "confidence")
+    list_filter = ("source",)
 
 
 # Favorites
-@admin.register(models.FavoriteConcept)
+@admin.register(models.FavoriteConcept, site=appertivo_admin_site)
 class FavoriteConceptAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "concept", "favorited_at")
+    list_display = ("user", "concept", "favorited_at")
 
 
-@admin.register(models.FavoriteDish)
+@admin.register(models.FavoriteDish, site=appertivo_admin_site)
 class FavoriteDishAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "dish", "favorited_at")
+    list_display = ("user", "dish", "favorited_at")
 
 
 # Assets + enhancements
-@admin.register(models.Asset)
+@admin.register(models.Asset, site=appertivo_admin_site)
 class AssetAdmin(TimestampedAdmin):
-    list_display = ("id", "kind", "public_url", "created_at")
+    list_display = ("kind", "public_url", "created_at")
+    search_fields = ("public_url", "kind")
 
 
-@admin.register(models.Enhancement)
+@admin.register(models.Enhancement, site=appertivo_admin_site)
 class EnhancementAdmin(TimestampedAdmin):
-    list_display = ("id", "dish", "status", "suggested_price_cents", "currency")
+    list_display = (
+        "dish",
+        "status",
+        "suggested_price_cents",
+        "currency",
+        "created_at",
+    )
+    list_filter = ("status",)
 
 
 # Menus
-@admin.register(models.MenuCollection)
+@admin.register(models.MenuCollection, site=appertivo_admin_site)
 class MenuCollectionAdmin(TimestampedAdmin):
-    list_display = ("id", "restaurant", "name", "created_by_user")
+    list_display = ("restaurant", "name", "created_by_user", "created_at")
 
 
-@admin.register(models.MenuItem)
+@admin.register(models.MenuItem, site=appertivo_admin_site)
 class MenuItemAdmin(TimestampedAdmin):
-    list_display = ("id", "menu", "dish", "position")
+    list_display = ("menu", "dish", "position")
+    list_filter = ("menu",)
 
 
-@admin.register(models.CollaborationLink)
+@admin.register(models.CollaborationLink, site=appertivo_admin_site)
 class CollaborationLinkAdmin(TimestampedAdmin):
     list_display = (
-        "id",
         "menu",
         "is_active",
         "expires_at",
@@ -151,88 +244,83 @@ class CollaborationLinkAdmin(TimestampedAdmin):
     list_filter = ("is_active", "menu__restaurant")
 
 
-@admin.register(models.Feedback)
+@admin.register(models.Feedback, site=appertivo_admin_site)
 class FeedbackAdmin(TimestampedAdmin):
-    list_display = ("id", "menu", "dish", "type", "anon_id", "created_at")
+    list_display = ("menu", "dish", "type", "anon_id", "created_at")
     list_filter = ("type", "menu__restaurant")
 
 
-@admin.register(models.FeedbackAction)
+@admin.register(models.FeedbackAction, site=appertivo_admin_site)
 class FeedbackActionAdmin(TimestampedAdmin):
-    list_display = ("id", "feedback", "status", "decided_by", "decided_at")
+    list_display = ("feedback", "status", "decided_by", "decided_at")
     list_filter = ("status",)
 
 
 # Notifications
-@admin.register(models.NotificationPref)
+@admin.register(models.NotificationPref, site=appertivo_admin_site)
 class NotificationPrefAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "on_background_complete_email", "on_new_menu_version_email")
-
-
-def manual_testing_checklist_view(request):
-    """Render the manual QA checklist inside the Django admin."""
-
-    context = admin.site.each_context(request)
-    context.update(
-        {
-            "title": "Manual QA Checklist",
-            "checklist_sections": CHECKLIST_SECTIONS,
-            "checklist_storage_key": "manual-qa-checklist-v1",
-        }
+    list_display = (
+        "user",
+        "on_background_complete_email",
+        "on_new_menu_version_email",
     )
-    return TemplateResponse(request, "admin/testing_checklist.html", context)
 
 
-_original_get_urls = admin.site.get_urls
-
-
-def _get_urls(self):
-    urls = _original_get_urls()
-    custom_urls = [
-        path(
-            "qa-checklist/",
-            self.admin_view(manual_testing_checklist_view),
-            name="qa-checklist",
-        )
-    ]
-    return custom_urls + urls
-
-
-admin.site.get_urls = MethodType(_get_urls, admin.site)
-
-
-@admin.register(models.Notification)
+@admin.register(models.Notification, site=appertivo_admin_site)
 class NotificationAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "type", "channel", "status", "sent_at", "read_at")
+    list_display = ("user", "type", "channel", "status", "sent_at", "read_at")
+    list_filter = ("status", "channel")
 
 
 # Plans + subscriptions
-@admin.register(models.Plan)
+@admin.register(models.Plan, site=appertivo_admin_site)
 class PlanAdmin(TimestampedAdmin):
-    list_display = ("id", "code", "name")
+    list_display = ("code", "name")
 
 
-@admin.register(models.Subscription)
+@admin.register(models.Subscription, site=appertivo_admin_site)
 class SubscriptionAdmin(TimestampedAdmin):
-    list_display = ("id", "account", "plan", "status", "provider", "current_period_end")
+    list_display = (
+        "account",
+        "plan",
+        "status",
+        "provider",
+        "current_period_end",
+    )
+    list_filter = ("status", "provider")
 
 
-@admin.register(models.EntitlementCounter)
+@admin.register(models.EntitlementCounter, site=appertivo_admin_site)
 class EntitlementCounterAdmin(TimestampedAdmin):
-    list_display = ("id", "account", "period_start", "concept_runs", "dish_runs", "enhancements")
+    list_display = (
+        "account",
+        "period_start",
+        "concept_runs",
+        "dish_runs",
+        "enhancements",
+    )
 
 
 # Jobs, events, tags
-@admin.register(models.Job)
+@admin.register(models.Job, site=appertivo_admin_site)
 class JobAdmin(TimestampedAdmin):
-    list_display = ("id", "account", "kind", "status", "progress_pct")
+    list_display = ("account", "kind", "status", "progress_pct")
+    list_filter = ("status", "kind")
 
 
-@admin.register(models.UiEvent)
+@admin.register(models.UiEvent, site=appertivo_admin_site)
 class UiEventAdmin(TimestampedAdmin):
-    list_display = ("id", "user", "name", "entity_type", "created_at")
+    list_display = ("user", "name", "entity_type", "created_at")
+    list_filter = ("entity_type",)
 
 
-@admin.register(models.TagDictionary)
+@admin.register(models.TagDictionary, site=appertivo_admin_site)
 class TagDictionaryAdmin(TimestampedAdmin):
-    list_display = ("id", "kind", "name", "slug")
+    list_display = ("kind", "name", "slug")
+    list_filter = ("kind",)
+
+
+# Register auth models on the custom site so they inherit the new styling.
+User = get_user_model()
+appertivo_admin_site.register(User, UserAdmin)
+appertivo_admin_site.register(Group, GroupAdmin)

--- a/app/admin_site.py
+++ b/app/admin_site.py
@@ -1,0 +1,232 @@
+"""Custom Django admin site for the Appertivo dashboard."""
+
+from collections import OrderedDict
+from typing import Dict, Iterable, List, Tuple
+
+from django.contrib.admin import AdminSite
+from django.contrib.admin.utils import quote
+from django.http import HttpRequest
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+
+
+NavItem = Dict[str, str]
+
+
+class AppertivoAdminSite(AdminSite):
+    """Branded admin site with grouped navigation and global search."""
+
+    site_header = "Appertivo Control Center"
+    site_title = "Appertivo Admin"
+    index_title = "Operations overview"
+
+    #: Pre-defined navigation groups mapped to ``"app_label.ModelName"`` identifiers.
+    NAV_GROUPS = OrderedDict(
+        {
+            "Restaurant Data": [
+                "app.Restaurant",
+                "app.RestaurantSettings",
+                "app.MenuVersion",
+                "app.MenuCollection",
+                "app.MenuItem",
+                "app.Ingredient",
+                "app.DishIdea",
+                "app.DishIdeaIngredient",
+                "app.Enhancement",
+                "app.Feedback",
+                "app.FeedbackAction",
+                "app.OutscraperPayload",
+                "app.CollaborationLink",
+            ],
+            "Content & Ideas": [
+                "app.IdeationRun",
+                "app.Concept",
+                "app.FavoriteConcept",
+                "app.FavoriteDish",
+                "app.Asset",
+                "app.TagDictionary",
+                "app.Notification",
+            ],
+            "System": [
+                "app.Account",
+                "app.UserProfile",
+                "app.Membership",
+                "auth.User",
+                "auth.Group",
+                "app.Plan",
+                "app.Subscription",
+                "app.EntitlementCounter",
+                "app.Job",
+                "app.UiEvent",
+                "app.NotificationPref",
+            ],
+        }
+    )
+
+    #: Extra links that live alongside the grouped model navigation.
+    CUSTOM_LINKS = (
+        {
+            "group": "System",
+            "name": "Manual QA Checklist",
+            "url_name": "admin:qa-checklist",
+        },
+    )
+
+    BRAND_COLORS = {
+        "primary": "#B993D6",
+        "accent": "#f08000",
+        "secondary": "#58B09C",
+        "dark": "#49475B",
+        "background": "#14080E",
+    }
+
+    def each_context(self, request: HttpRequest) -> Dict[str, object]:
+        """Inject navigation groupings and branding colors into every view."""
+
+        context = super().each_context(request)
+        available_apps: List[Dict[str, object]] = context.get("available_apps", [])
+        available_lookup: Dict[Tuple[str, str], Dict[str, object]] = {}
+
+        for app_dict in available_apps:
+            app_label = app_dict.get("app_label")
+            for model in app_dict.get("models", []):
+                key = (app_label, model.get("object_name"))
+                available_lookup[key] = {"app": app_dict, "model": model}
+
+        grouped_navigation: List[Dict[str, object]] = []
+        used_models: set[Tuple[str, str]] = set()
+
+        for group_title, identifiers in self.NAV_GROUPS.items():
+            items: List[NavItem] = []
+            for identifier in identifiers:
+                app_label, model_name = identifier.split(".")
+                lookup_key = (app_label, model_name)
+                match = available_lookup.get(lookup_key)
+                if not match:
+                    continue
+                model_dict = match["model"]
+                items.append(
+                    {
+                        "name": model_dict.get("name"),
+                        "url": model_dict.get("admin_url"),
+                        "add_url": model_dict.get("add_url"),
+                    }
+                )
+                used_models.add(lookup_key)
+
+            for link in self._links_for_group(group_title):
+                items.append(link)
+
+            if items:
+                grouped_navigation.append({"title": group_title, "items": items})
+
+        leftovers = self._collect_unassigned_models(available_lookup, used_models)
+        if leftovers:
+            grouped_navigation.append({"title": "Other", "items": leftovers})
+
+        context["admin_nav_groups"] = grouped_navigation
+        context["admin_brand_colors"] = self.BRAND_COLORS
+        return context
+
+    def _collect_unassigned_models(
+        self,
+        available_lookup: Dict[Tuple[str, str], Dict[str, object]],
+        used_models: Iterable[Tuple[str, str]],
+    ) -> List[NavItem]:
+        """Return a list of models that were not mapped to a group."""
+
+        leftovers: List[NavItem] = []
+        used = set(used_models)
+        for (app_label, model_name), match in available_lookup.items():
+            if (app_label, model_name) in used:
+                continue
+            model_dict = match["model"]
+            leftovers.append(
+                {
+                    "name": model_dict.get("name"),
+                    "url": model_dict.get("admin_url"),
+                    "add_url": model_dict.get("add_url"),
+                }
+            )
+        return leftovers
+
+    def _links_for_group(self, group_title: str) -> List[NavItem]:
+        """Return configured custom links for the requested group."""
+
+        links: List[NavItem] = []
+        for link in self.CUSTOM_LINKS:
+            if link.get("group") != group_title:
+                continue
+            try:
+                url = reverse(link["url_name"])
+            except Exception:  # pragma: no cover - guard against stale links
+                continue
+            links.append({"name": link.get("name"), "url": url, "custom": "true"})
+        return links
+
+    def get_urls(self):
+        urls = super().get_urls()
+        from .admin_views import manual_testing_checklist_view
+
+        custom_urls = [
+            path("search/", self.admin_view(self.global_search_view), name="global-search"),
+            path(
+                "qa-checklist/",
+                self.admin_view(manual_testing_checklist_view),
+                name="qa-checklist",
+            ),
+        ]
+        return custom_urls + urls
+
+    def global_search_view(self, request: HttpRequest) -> TemplateResponse:
+        """Search across all registered models that expose search fields."""
+
+        query = (request.GET.get("q") or "").strip()
+        results: List[Dict[str, object]] = []
+
+        if query:
+            for model, model_admin in self._registry.items():
+                if not model_admin.get_search_fields(request):
+                    continue
+                if not model_admin.has_view_or_change_permission(request):
+                    continue
+
+                queryset = model_admin.get_queryset(request)
+                queryset, use_distinct = model_admin.get_search_results(request, queryset, query)
+
+                if use_distinct:
+                    queryset = queryset.distinct()
+
+                matches = list(queryset[:5])
+                if not matches:
+                    continue
+
+                opts = model._meta
+                results.append(
+                    {
+                        "model": model,
+                        "opts": opts,
+                        "items": [
+                            {
+                                "object": instance,
+                                "change_url": reverse(
+                                    f"admin:{opts.app_label}_{opts.model_name}_change",
+                                    args=(quote(instance.pk),),
+                                ),
+                            }
+                            for instance in matches
+                        ],
+                    }
+                )
+
+        context = {
+            **self.each_context(request),
+            "title": f"Search results for “{query}”" if query else "Search",
+            "query": query,
+            "search_results": results,
+        }
+        return TemplateResponse(request, "admin/global_search.html", context)
+
+
+appertivo_admin_site = AppertivoAdminSite(name="appertivo_admin")
+

--- a/app/admin_views.py
+++ b/app/admin_views.py
@@ -1,0 +1,21 @@
+"""Supporting views that live inside the custom admin site."""
+
+from django.template.response import TemplateResponse
+
+from .admin_site import appertivo_admin_site
+from .qa_checklist import CHECKLIST_SECTIONS
+
+
+def manual_testing_checklist_view(request):
+    """Render the manual QA checklist inside the Django admin."""
+
+    context = appertivo_admin_site.each_context(request)
+    context.update(
+        {
+            "title": "Manual QA Checklist",
+            "checklist_sections": CHECKLIST_SECTIONS,
+            "checklist_storage_key": "manual-qa-checklist-v1",
+        }
+    )
+    return TemplateResponse(request, "admin/testing_checklist.html", context)
+

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -1,0 +1,122 @@
+{% load i18n static %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:'en-us' }}" class="appertivo-admin-html">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}{{ title }} | {{ site_title|default:_('Appertivo admin') }}{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'admin/css/appertivo-admin.css' %}" />
+    {% if admin_brand_colors %}
+      <style>
+        :root {
+          --color-primary: {{ admin_brand_colors.primary }};
+          --color-accent: {{ admin_brand_colors.accent }};
+          --color-secondary: {{ admin_brand_colors.secondary }};
+          --color-dark: {{ admin_brand_colors.dark }};
+          --color-background: {{ admin_brand_colors.background }};
+        }
+      </style>
+    {% endif %}
+    {% block extrastyle %}{% endblock %}
+    {% block extrahead %}{% endblock %}
+  </head>
+  <body class="appertivo-admin-body {% block bodyclass %}{% endblock %}">
+    <header class="admin-header" role="banner">
+      <button class="sidebar-toggle" type="button" data-sidebar-toggle aria-label="Toggle navigation">
+        <span aria-hidden="true">☰</span>
+      </button>
+      <a class="admin-brand" href="{% url 'admin:index' %}">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span class="brand-text">
+          <span class="brand-title">Appertivo</span>
+          <span class="brand-subtitle">Control Center</span>
+        </span>
+      </a>
+      {% if request.user.is_authenticated %}
+        <form class="admin-search" action="{% url 'admin:global-search' %}" method="get" role="search">
+          <label for="admin-global-search" class="sr-only">{% translate 'Search admin content' %}</label>
+          <input
+            id="admin-global-search"
+            type="search"
+            name="q"
+            value="{{ request.GET.q|default_if_none:'' }}"
+            placeholder="{% translate 'Search across models…' %}"
+            autocomplete="off"
+          />
+          <button type="submit" class="cta-button">{% translate 'Search' %}</button>
+        </form>
+        <nav class="admin-user-actions" aria-label="Account">
+          <span class="user-pill">{{ request.user.get_full_name|default:request.user.get_username }}</span>
+          <a href="{% url 'admin:logout' %}" class="link-muted">{% translate 'Log out' %}</a>
+        </nav>
+      {% else %}
+        <span class="login-helper">{% translate 'Sign in to manage content.' %}</span>
+      {% endif %}
+    </header>
+
+    <div class="admin-shell">
+      <aside class="admin-sidebar" data-collapsed="false">
+        <div class="sidebar-groups" role="navigation" aria-label="Primary">
+          {% if request.user.is_authenticated %}
+            {% for group in admin_nav_groups %}
+              <section class="sidebar-group">
+                <button
+                  class="group-toggle"
+                type="button"
+                data-group-index="{{ forloop.counter0 }}"
+                aria-expanded="true"
+              >
+                <span>{{ group.title }}</span>
+                <span class="toggle-icon" aria-hidden="true">⌄</span>
+              </button>
+              <ul id="sidebar-group-{{ forloop.counter0 }}" class="sidebar-links">
+                {% for item in group.items %}
+                  <li>
+                    <a href="{{ item.url }}" class="sidebar-link">
+                      <span>{{ item.name }}</span>
+                    </a>
+                    {% if item.add_url %}
+                      <a
+                        class="sidebar-add"
+                        href="{{ item.add_url }}"
+                        aria-label="{% blocktranslate with name=item.name %}Add new {{ name }}{% endblocktranslate %}"
+                      >+</a>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+              </section>
+            {% empty %}
+              <p class="sidebar-empty">{% translate 'No sections available.' %}</p>
+            {% endfor %}
+          {% else %}
+            <p class="sidebar-empty">{% translate 'Navigation is available after signing in.' %}</p>
+          {% endif %}
+        </div>
+      </aside>
+
+      <div class="admin-main">
+        <div class="admin-content">
+          <div class="content-header">
+            <div class="breadcrumbs">
+              {% block breadcrumbs %}{% include "admin/breadcrumbs.html" %}{% endblock %}
+            </div>
+            <div class="content-title">
+              {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+            </div>
+          </div>
+          {% block messages %}{% include "admin/includes/messages.html" %}{% endblock %}
+          <main class="content-body" role="main">
+            {% block content %}{% endblock %}
+          </main>
+        </div>
+        <footer class="admin-footer">
+          <p>© {% now "Y" %} Appertivo. Crafted for operators.</p>
+        </footer>
+      </div>
+    </div>
+
+    <script src="{% static 'admin/js/appertivo-admin.js' %}" defer></script>
+    {% block extrajs %}{% endblock %}
+  </body>
+</html>

--- a/app/templates/admin/base_site.html
+++ b/app/templates/admin/base_site.html
@@ -1,13 +1,7 @@
 {% extends "admin/base.html" %}
-{% load i18n static %}
+{% load i18n %}
 
-{% block title %}{{ site_title|default:_('Django site admin') }}{% endblock %}
-
-{% block branding %}
-<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% block title %}
+  {% if title %}{{ title }} | {% endif %}Appertivo Admin
 {% endblock %}
 
-{% block nav-global %}
-{{ block.super }}
-<a class="manual-qa-nav-link" href="{% url 'admin:qa-checklist' %}">Manual QA Checklist</a>
-{% endblock %}

--- a/app/templates/admin/change_form.html
+++ b/app/templates/admin/change_form.html
@@ -1,0 +1,58 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static admin_urls admin_modify %}
+
+{% block content %}
+  <div class="change-form">
+    {% if change and has_view_permission %}
+      <div class="object-tools">
+        {% block object-tools-items %}
+          <a href="{% url opts|admin_urlname:'history' original.pk|admin_urlquote %}" class="link-muted">{% translate "History" %}</a>
+          {% if has_absolute_url %}
+            <a href="{{ absolute_url }}" class="link-muted">{% translate "View on site" %}</a>
+          {% endif %}
+        {% endblock %}
+      </div>
+    {% endif %}
+
+    <form {% if has_file_field %}enctype="multipart/form-data"{% endif %} method="post" novalidate>
+      {% csrf_token %}
+      {% block form_top %}{% endblock %}
+      <div class="form-sections">
+        {% for fieldset in adminform %}
+          <section class="form-card">
+            {% if fieldset.name %}<h2>{{ fieldset.name }}</h2>{% endif %}
+            {% if fieldset.description %}<p class="section-description">{{ fieldset.description|safe }}</p>{% endif %}
+            {% include "admin/includes/fieldset.html" with fieldset=fieldset %}
+          </section>
+        {% endfor %}
+      </div>
+
+      {% for inline_admin_formset in inline_admin_formsets %}
+        <section class="form-card related-card">
+          <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+          {% include inline_admin_formset.opts.template %}
+        </section>
+      {% endfor %}
+
+      {% block after_field_sets %}{% endblock %}
+
+      <div class="submit-row">
+        {% block submit_buttons_top %}{% endblock %}
+        {% submit_row %}
+        {% block submit_buttons_bottom %}{% endblock %}
+      </div>
+    </form>
+  </div>
+{% endblock %}
+
+{% block extrajs %}
+  {{ block.super }}
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll('.form-card input, .form-card select, .form-card textarea').forEach((field) => {
+        field.classList.add('form-control');
+      });
+    });
+  </script>
+{% endblock %}
+

--- a/app/templates/admin/change_list.html
+++ b/app/templates/admin/change_list.html
@@ -1,0 +1,67 @@
+{% extends "admin/base_site.html" %}
+{% load admin_list admin_urls i18n static admin_theme %}
+
+{% block content %}
+  <div class="change-list">
+    {% block object-tools %}
+      {% if has_add_permission %}
+        <div class="object-tools">
+          {% block object-tools-items %}
+            <a href="{% add_preserved_filters add_url is_popup %}" class="cta-button">{% blocktranslate %}Add {{ opts.verbose_name }}{% endblocktranslate %}</a>
+          {% endblock %}
+        </div>
+      {% endif %}
+    {% endblock %}
+
+    <div class="card">
+      {% block search %}
+        {% if cl.search_fields %}
+          <form id="changelist-search" method="get" role="search">
+            <div class="search-field">
+              {{ search_form.q.label_tag }}
+              {{ search_form.q }}
+              <button type="submit" class="cta-button">{% translate "Search" %}</button>
+              {% for hidden in search_form.hidden_fields %}{{ hidden }}{% endfor %}
+            </div>
+          </form>
+        {% endif %}
+      {% endblock %}
+
+      {% block filters %}
+        {% if cl.has_filters %}
+          <details class="filter-panel" open>
+            <summary>{% translate "Filters" %}</summary>
+            {% for spec in cl.filter_specs %}
+              {% admin_list_filter cl spec %}
+            {% endfor %}
+          </details>
+        {% endif %}
+      {% endblock %}
+
+      {% block result_list %}
+        {% if action_form and cl.show_admin_actions %}
+          <form id="changelist-form" method="post" novalidate>{% csrf_token %}
+            <div class="table-wrapper">
+              {% result_list cl %}
+            </div>
+            {% if cl.result_count %}
+              <div class="paginator">
+                {% pagination cl %}
+              </div>
+            {% endif %}
+          </form>
+        {% else %}
+          <div class="table-wrapper">
+            {% result_list cl %}
+          </div>
+          {% if cl.result_count %}
+            <div class="paginator">
+              {% pagination cl %}
+            </div>
+          {% endif %}
+        {% endif %}
+      {% endblock %}
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/templates/admin/global_search.html
+++ b/app/templates/admin/global_search.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+{% load admin_theme i18n %}
+
+{% block content %}
+  <section class="global-search">
+    <form action="" method="get" role="search" class="search-form">
+      <label for="global-search-input">{% translate "Search all models" %}</label>
+      <div class="search-row">
+        <input id="global-search-input" type="search" name="q" value="{{ query }}" placeholder="{% translate 'Search…' %}" />
+        <button class="cta-button" type="submit">{% translate "Search" %}</button>
+      </div>
+    </form>
+
+    {% if query %}
+      {% if search_results %}
+        <div class="search-results">
+          {% for result in search_results %}
+            <article class="search-result-card">
+              <header>
+                <h3>{{ result.opts.verbose_name_plural|capfirst }}</h3>
+                <a class="link-muted" href="{% url 'admin:app_list' result.opts.app_label %}">{% translate "View all" %}</a>
+              </header>
+              <ul>
+                {% for item in result.items %}
+                  <li>
+                    <a href="{{ item.change_url }}">{{ item.object|admin_object_display }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </article>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="empty-state">{% translate "No matches found." %}</p>
+      {% endif %}
+    {% else %}
+      <p class="empty-state">{% translate "Enter a keyword to search across admin models." %}</p>
+    {% endif %}
+  </section>
+{% endblock %}
+

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+  <section class="dashboard-intro">
+    <div class="intro-card">
+      <h2>{% translate "Welcome back" %}</h2>
+      <p>{% translate "Use the grouped navigation to jump between data domains or search from the header to get anywhere fast." %}</p>
+    </div>
+  </section>
+
+  <section class="dashboard-grid">
+    {% for group in admin_nav_groups %}
+      <article class="dashboard-card">
+        <header>
+          <h3>{{ group.title }}</h3>
+        </header>
+        <ul>
+          {% for item in group.items %}
+            <li>
+              <a href="{{ item.url }}">{{ item.name }}</a>
+              {% if item.add_url %}
+                <a class="link-muted" href="{{ item.add_url }}">{% translate "Create new" %}</a>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </article>
+    {% endfor %}
+  </section>
+{% endblock %}
+

--- a/app/templates/admin/testing_checklist.html
+++ b/app/templates/admin/testing_checklist.html
@@ -1,126 +1,43 @@
 {% extends "admin/base_site.html" %}
 {% load static %}
 
-{% block extrastyle %}
-{{ block.super }}
-<style>
-  .qa-checklist-wrapper {
-    max-width: 960px;
-  }
-  .qa-checklist-header {
-    margin-bottom: 1.5rem;
-    padding: 1rem;
-    background: #f6f6f6;
-    border: 1px solid #d9d9d9;
-    border-radius: 6px;
-  }
-  .qa-checklist-section {
-    margin-bottom: 2rem;
-  }
-  .qa-checklist-section h2 {
-    margin-bottom: 0.75rem;
-    font-size: 1.35rem;
-  }
-  .qa-checklist-tasks {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    border: 1px solid #d9d9d9;
-    border-radius: 6px;
-  }
-  .qa-checklist-tasks li {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid #d9d9d9;
-    background: #fff;
-  }
-  .qa-checklist-tasks li:last-child {
-    border-bottom: none;
-    border-radius: 0 0 6px 6px;
-  }
-  .qa-checklist-tasks label {
-    flex: 1 1 60%;
-    display: flex;
-    gap: 0.5rem;
-    align-items: flex-start;
-    font-weight: 500;
-  }
-  .qa-checklist-tasks span.qa-task-label {
-    font-weight: 400;
-  }
-  .qa-checklist-link {
-    white-space: nowrap;
-    font-size: 0.875rem;
-  }
-  .qa-checklist-controls {
-    display: flex;
-    justify-content: flex-end;
-    margin-bottom: 1.5rem;
-  }
-  .qa-reset-button {
-    background: #e5534b;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-  }
-  .qa-reset-button:hover {
-    background: #c13f38;
-  }
-  @media (max-width: 720px) {
-    .qa-checklist-tasks li {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-    .qa-checklist-link {
-      padding-left: 1.75rem;
-    }
-  }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="qa-checklist-wrapper" data-storage-key="{{ checklist_storage_key }}">
-  <div class="qa-checklist-header">
+<div class="qa-checklist" data-storage-key="{{ checklist_storage_key }}">
+  <section class="admin-card">
     <h1>{{ title }}</h1>
     <p>Track manual QA coverage inside the admin. Progress is stored locally in your browser so you can check items off as you go without affecting other teammates.</p>
     <p>Update or add new tasks by editing <code>app/qa_checklist.py</code>.</p>
-  </div>
-
-  <div class="qa-checklist-controls">
-    <button id="qa-checklist-reset" class="qa-reset-button" type="button">Reset progress</button>
-  </div>
+    <div class="actions">
+      <button id="qa-checklist-reset" class="cta-button" type="button">Reset progress</button>
+    </div>
+  </section>
 
   {% for section in checklist_sections %}
-  <section id="{{ section.id }}" class="qa-checklist-section">
-    <h2>{{ section.title }}</h2>
-    <ul class="qa-checklist-tasks">
-      {% for item in section.items %}
-      <li>
-        <label>
-          <input type="checkbox" data-task-id="{{ section.id }}::{{ item.id }}">
-          <span class="qa-task-label">{{ item.label }}</span>
-        </label>
-        {% if item.url %}
-        <a class="qa-checklist-link" href="{{ item.url }}" target="_blank" rel="noopener">Open page</a>
-        {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
-  </section>
+    <section id="{{ section.id }}" class="admin-card qa-section">
+      <h2>{{ section.title }}</h2>
+      <ul class="qa-task-list">
+        {% for item in section.items %}
+          <li>
+            <label>
+              <input type="checkbox" data-task-id="{{ section.id }}::{{ item.id }}" />
+              <span>{{ item.label }}</span>
+            </label>
+            {% if item.url %}
+              <a class="link-muted" href="{{ item.url }}" target="_blank" rel="noopener">Open page</a>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
   {% endfor %}
 </div>
 {% endblock %}
 
-{% block extrahead %}
-{{ block.super }}
-<script>
+{% block extrajs %}
+  {{ block.super }}
+  <script>
   document.addEventListener("DOMContentLoaded", function () {
-    const container = document.querySelector(".qa-checklist-wrapper");
+    const container = document.querySelector(".qa-checklist");
     if (!container) {
       return;
     }
@@ -171,5 +88,6 @@
       });
     }
   });
-</script>
+  });
+  </script>
 {% endblock %}

--- a/app/templatetags/admin_theme.py
+++ b/app/templatetags/admin_theme.py
@@ -1,0 +1,40 @@
+"""Template helpers for the custom admin dashboard."""
+
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def admin_object_display(obj):
+    """Return a readable label for an admin object."""
+
+    if obj is None:
+        return "—"
+    for attr in ("name", "title", "label", "code", "slug"):
+        if hasattr(obj, attr):
+            value = getattr(obj, attr)
+            if value:
+                return value
+    return str(obj)
+
+
+@register.filter
+def status_badge_class(value: str) -> str:
+    """Map common status values to themed badge classes."""
+
+    if not value:
+        return "badge-neutral"
+
+    normalized = str(value).lower()
+    if normalized in {"succeeded", "active", "complete", "completed", "ready"}:
+        return "badge-success"
+    if normalized in {"running", "in_progress", "processing"}:
+        return "badge-info"
+    if normalized in {"failed", "inactive", "error", "cancelled"}:
+        return "badge-danger"
+    if normalized in {"queued", "pending", "draft"}:
+        return "badge-warning"
+    return "badge-neutral"
+

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -1,12 +1,11 @@
-from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
-from django.contrib.auth import views as auth_views
 
 from app import outscraper, views as app_views
 from articles import admin_views as articles_admin_views
 from articles.sitemaps import ArticlesSitemap
 from app.outscraper import outscraper_webhook
+from app.admin_site import appertivo_admin_site
 
 urlpatterns = [
     path("", app_views.home_view, name="home"),
@@ -72,5 +71,5 @@ urlpatterns = [
     path("sitemap.xml",sitemap,{"sitemaps": {"articles": ArticlesSitemap()}},name="sitemap",),
     # Existing API and sample views
     path("api/signup/", app_views.signup_view, name="api-signup"),
-    path("admin/", admin.site.urls),
+    path("admin/", appertivo_admin_site.urls),
 ]

--- a/static/admin/css/appertivo-admin.css
+++ b/static/admin/css/appertivo-admin.css
@@ -1,0 +1,690 @@
+:root {
+  --color-primary: #b993d6;
+  --color-primary-strong: #9a79c9;
+  --color-accent: #f08000;
+  --color-secondary: #58b09c;
+  --color-dark: #49475b;
+  --color-background: #14080e;
+  --color-surface: #1f1520;
+  --color-surface-alt: #2d2032;
+  --color-border: rgba(185, 147, 214, 0.35);
+  --color-text: #f5f1f9;
+  --color-muted: #c5bdd1;
+  --radius: 12px;
+  --shadow-lg: 0 24px 48px rgba(20, 8, 14, 0.35);
+  --shadow-sm: 0 6px 18px rgba(20, 8, 14, 0.25);
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body,
+.appertivo-admin-html {
+  background: radial-gradient(circle at top left, rgba(185, 147, 214, 0.15), transparent),
+    var(--color-background);
+  color: var(--color-text);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.link-muted {
+  color: var(--color-muted);
+}
+
+.link-muted:hover,
+.link-muted:focus-visible {
+  color: var(--color-text);
+}
+
+.cta-button {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  padding: var(--space-2) var(--space-4);
+  transition: transform var(--transition), box-shadow var(--transition);
+  box-shadow: 0 10px 20px rgba(240, 128, 0, 0.25);
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(240, 128, 0, 0.35);
+}
+
+.cta-button:active {
+  transform: translateY(0);
+}
+
+.appertivo-admin-body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-header {
+  align-items: center;
+  background: linear-gradient(120deg, rgba(185, 147, 214, 0.85), rgba(240, 128, 0, 0.9));
+  color: #fff;
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: auto auto 1fr auto;
+  padding: var(--space-3) var(--space-5);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow-sm);
+}
+
+.sidebar-toggle {
+  background: rgba(255, 255, 255, 0.18);
+  border: none;
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.admin-brand {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: var(--space-3);
+  font-weight: 600;
+}
+
+.admin-brand:hover {
+  color: inherit;
+}
+
+.brand-mark {
+  background: radial-gradient(circle at 30% 30%, #fff, rgba(255, 255, 255, 0));
+  border-radius: 12px;
+  height: 2.5rem;
+  width: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.brand-mark::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 10px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.35), rgba(88, 176, 156, 0.65));
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.brand-title {
+  font-size: 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.admin-search {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-3);
+}
+
+.admin-search input {
+  background: transparent;
+  border: none;
+  color: #fff;
+  min-width: 18rem;
+  outline: none;
+}
+
+.admin-search input::placeholder {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.admin-user-actions {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--space-3);
+}
+
+.login-helper {
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+}
+
+.user-pill {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: var(--space-1) var(--space-3);
+}
+
+.admin-shell {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  flex: 1;
+  width: 100%;
+}
+
+.admin-sidebar {
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  height: calc(100vh - 5.5rem);
+  position: sticky;
+  top: 5.5rem;
+  overflow-y: auto;
+  transition: transform var(--transition);
+}
+
+.sidebar-groups {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sidebar-group {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.group-toggle {
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  display: flex;
+  font-weight: 600;
+  justify-content: space-between;
+  padding: var(--space-3);
+  width: 100%;
+}
+
+.sidebar-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar-links li {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+}
+
+.sidebar-link {
+  color: var(--color-muted);
+  flex: 1;
+}
+
+.sidebar-link:hover,
+.sidebar-link:focus-visible {
+  color: #fff;
+}
+
+.sidebar-add {
+  align-items: center;
+  background: rgba(240, 128, 0, 0.15);
+  border-radius: 999px;
+  color: var(--color-accent);
+  display: inline-flex;
+  font-weight: 700;
+  height: 1.75rem;
+  justify-content: center;
+  width: 1.75rem;
+}
+
+.admin-main {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 5.5rem);
+  background: transparent;
+}
+
+.admin-content {
+  flex: 1;
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.content-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  justify-content: space-between;
+}
+
+.content-title h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.content-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.admin-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-3) var(--space-5);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.card,
+.admin-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-5);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: calc(var(--radius) - 6px);
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  color: inherit;
+}
+
+table thead {
+  background: rgba(185, 147, 214, 0.15);
+}
+
+th,
+td {
+  padding: var(--space-3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+tr:hover {
+  background: rgba(88, 176, 156, 0.08);
+}
+
+thead th {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.paginator {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--space-4);
+}
+
+.paginator a,
+.paginator span {
+  color: var(--color-muted);
+}
+
+.change-form form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.form-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-sm);
+}
+
+.form-card h2 {
+  margin-top: 0;
+  margin-bottom: var(--space-3);
+}
+
+.form-control,
+.form-row input,
+.form-row select,
+.form-row textarea {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: var(--color-text);
+  padding: var(--space-2) var(--space-3);
+}
+
+.submit-row {
+  align-items: center;
+  background: rgba(185, 147, 214, 0.12);
+  border-radius: var(--radius);
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+  padding: var(--space-3) var(--space-4);
+}
+
+.submit-row input[type="submit"] {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  padding: var(--space-2) var(--space-4);
+}
+
+.object-tools {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--space-3);
+}
+
+.object-tools .cta-button,
+.object-tools a {
+  margin-left: var(--space-2);
+}
+
+.filter-panel {
+  background: rgba(185, 147, 214, 0.08);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.filter-panel summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.filter-panel .filter {
+  margin-bottom: var(--space-2);
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dashboard-card header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-2);
+}
+
+.dashboard-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.dashboard-card li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.global-search .search-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.search-row {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.search-row input[type="search"] {
+  flex: 1;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: var(--space-2) var(--space-3);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.search-results {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.search-result-card {
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-sm);
+}
+
+.search-result-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-2);
+}
+
+.search-result-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.badge-success {
+  background: rgba(88, 176, 156, 0.18);
+  color: #bdf2de;
+}
+
+.badge-info {
+  background: rgba(185, 147, 214, 0.18);
+  color: #dfc8f0;
+}
+
+.badge-danger {
+  background: rgba(255, 92, 92, 0.2);
+  color: #ffbcbc;
+}
+
+.badge-warning {
+  background: rgba(240, 128, 0, 0.2);
+  color: #ffd1a1;
+}
+
+.badge-neutral {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-muted);
+}
+
+.status-pill {
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: var(--space-1) var(--space-3);
+  text-transform: uppercase;
+}
+
+.qa-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.qa-task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.qa-task-list li {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius);
+  display: flex;
+  gap: var(--space-3);
+  justify-content: space-between;
+  padding: var(--space-3);
+}
+
+.qa-task-list label {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.qa-task-list input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.empty-state {
+  color: var(--color-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .admin-shell {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .admin-header {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "toggle brand"
+      "search search"
+      "user user";
+  }
+
+  .admin-search {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 820px) {
+  .admin-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-sidebar {
+    height: calc(100vh - 4.5rem);
+    position: fixed;
+    top: 4.5rem;
+    left: 0;
+    width: 260px;
+    transform: translateX(-100%);
+    z-index: 90;
+  }
+
+  .admin-sidebar[data-open="true"] {
+    transform: translateX(0);
+  }
+
+  .admin-main {
+    margin-left: 0;
+  }
+
+  .admin-header {
+    grid-template-columns: auto 1fr;
+  }
+
+  .admin-search input {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-search {
+    flex-wrap: wrap;
+    padding: var(--space-2);
+  }
+
+  .admin-user-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .content-header {
+    align-items: flex-start;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .paginator {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .search-row {
+    flex-direction: column;
+  }
+}

--- a/static/admin/js/appertivo-admin.js
+++ b/static/admin/js/appertivo-admin.js
@@ -1,0 +1,72 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const sidebar = document.querySelector(".admin-sidebar");
+  const toggle = document.querySelector("[data-sidebar-toggle]");
+  const groups = document.querySelectorAll(".group-toggle");
+  const storageKey = "appertivo-admin-sidebar";
+
+  const savedState = (() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      return raw ? JSON.parse(raw) : {};
+    } catch (error) {
+      console.warn("Unable to read sidebar state", error);
+      return {};
+    }
+  })();
+
+  groups.forEach((group, index) => {
+    const groupId = `group-${index}`;
+    const list = document.getElementById(`sidebar-group-${index}`);
+    const initialOpen = savedState[groupId] !== false;
+    list.style.display = initialOpen ? "block" : "none";
+    group.setAttribute("aria-expanded", initialOpen);
+
+    group.addEventListener("click", () => {
+      const isExpanded = group.getAttribute("aria-expanded") === "true";
+      const nextState = !isExpanded;
+      group.setAttribute("aria-expanded", String(nextState));
+      list.style.display = nextState ? "block" : "none";
+      savedState[groupId] = nextState;
+      try {
+        window.localStorage.setItem(storageKey, JSON.stringify(savedState));
+      } catch (error) {
+        console.warn("Unable to persist sidebar state", error);
+      }
+    });
+  });
+
+  if (toggle && sidebar) {
+    toggle.addEventListener("click", () => {
+      const isOpen = sidebar.getAttribute("data-open") === "true";
+      sidebar.setAttribute("data-open", String(!isOpen));
+    });
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && sidebar?.getAttribute("data-open") === "true") {
+      sidebar.setAttribute("data-open", "false");
+    }
+  });
+
+  const statusCells = document.querySelectorAll("td.field-status");
+  statusCells.forEach((cell) => {
+    const value = cell.textContent.trim();
+    if (!value) {
+      return;
+    }
+    const normalized = value.toLowerCase();
+    let badgeClass = "badge-neutral";
+    if (["succeeded", "active", "complete", "completed", "ready"].includes(normalized)) {
+      badgeClass = "badge-success";
+    } else if (["running", "in_progress", "processing"].includes(normalized)) {
+      badgeClass = "badge-info";
+    } else if (["failed", "inactive", "error", "cancelled"].includes(normalized)) {
+      badgeClass = "badge-danger";
+    } else if (["queued", "pending", "draft"].includes(normalized)) {
+      badgeClass = "badge-warning";
+    }
+
+    cell.innerHTML = `<span class="status-pill ${badgeClass}">${value}</span>`;
+  });
+});
+

--- a/tests/test_admin_theme.py
+++ b/tests/test_admin_theme.py
@@ -1,0 +1,45 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app import models
+
+
+class AdminThemeTests(TestCase):
+    def setUp(self):
+        self.user_model = get_user_model()
+
+    def _login_superuser(self, username: str, email: str) -> None:
+        user = self.user_model.objects.create_superuser(
+            username=username,
+            email=email,
+            password="pass12345",
+        )
+        self.client.force_login(user)
+
+    def test_admin_dashboard_groups_displayed(self):
+        self._login_superuser("admin1", "admin@example.com")
+
+        response = self.client.get(reverse("admin:index"))
+
+        self.assertEqual(response.status_code, 200)
+        nav_titles = [group["title"] for group in response.context["admin_nav_groups"]]
+        self.assertIn("Restaurant Data", nav_titles)
+        self.assertIn("Content & Ideas", nav_titles)
+
+    def test_admin_global_search_returns_results(self):
+        self._login_superuser("admin2", "admin2@example.com")
+
+        account = models.Account.objects.create(name="Searchable Group")
+        models.Restaurant.objects.create(
+            account=account,
+            name="Sunset Bistro",
+            location_text="Portland",
+        )
+
+        response = self.client.get(reverse("admin:global-search"), {"q": "Sunset"})
+
+        self.assertEqual(response.status_code, 200)
+        rendered = response.content.decode()
+        self.assertIn("Search results", rendered)
+        self.assertIn("Sunset Bistro", rendered)


### PR DESCRIPTION
## Summary
- implement a branded `AppertivoAdminSite` with grouped navigation and a global search view
- rebuild the admin templates, styles, and scripts to deliver the custom Appertivo control-center experience
- streamline admin registrations and add coverage to verify the themed dashboard and global search

## Testing
- python manage.py test tests.test_admin_theme


------
https://chatgpt.com/codex/tasks/task_e_68dad2f4fd808332af4fc61389111940