### PR TITLE
Improve signup integrity error handling

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -608,6 +608,16 @@ def signup_view(request):
                 {"error": "Please complete all fields.", "form_data": form_data},
             )
 
+        if User.objects.filter(username__iexact=email).exists():
+            error_message = "An account with that email already exists."
+            if is_json:
+                return JsonResponse({"error": "email_in_use"}, status=400)
+            return render(
+                request,
+                "auth/signup.html",
+                {"error": error_message, "form_data": form_data},
+            )
+
         try:
             with transaction.atomic():
                 user = User.objects.create_user(
@@ -634,9 +644,10 @@ def signup_view(request):
                     )
                 )
         except IntegrityError:
-            error_message = "An account with that email already exists."
+            logger.exception("Signup failed due to database error", extra={"email": email})
+            error_message = "We couldn't sign you up right now. Please try again."
             if is_json:
-                return JsonResponse({"error": "email_in_use"}, status=400)
+                return JsonResponse({"error": "signup_failed"}, status=500)
             return render(
                 request,
                 "auth/signup.html",

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -156,6 +157,25 @@ class SignupViewTests(TestCase):
         self.assertContains(response, "already exists")
         # Ensure no duplicate accounts were created.
         self.assertEqual(User.objects.filter(username="owner@example.com").count(), 1)
+
+    @override_settings(SECURE_SSL_REDIRECT=False)
+    def test_form_signup_with_other_integrity_error_shows_generic_message(self):
+        """Unexpected integrity errors should surface a helpful generic message."""
+
+        with patch.object(models.Account.objects, "create", side_effect=IntegrityError("boom")):
+            form_data = {
+                "email": "owner@example.com",
+                "password1": "pw",
+                "password2": "pw",
+                "restaurant_name": "Tasty Place",
+                "location": "City, State",
+            }
+
+            response = self.client.post(reverse("signup"), data=form_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "We couldn&#x27;t sign you up right now")
+        self.assertFalse(User.objects.filter(username="owner@example.com").exists())
 
     def test_login_with_bad_credentials_returns_error(self):
         """Failed logins should re-render the form with an error message."""


### PR DESCRIPTION
## Summary
- prevent the signup view from entering the creation transaction when the email is already registered
- return a generic error when other database integrity errors occur during signup and log the failure
- add a regression test covering the generic error path

## Testing
- python manage.py test tests.test_signup.SignupViewTests.test_form_signup_with_other_integrity_error_shows_generic_message

------
https://chatgpt.com/codex/tasks/task_e_68db1ad7d80483328f2cf65221806571