### PR TITLE
Refactor Stripe integration into dedicated module

### DIFF
--- a/app/onboarding.py
+++ b/app/onboarding.py
@@ -178,12 +178,19 @@ def record_consent(
         onboarding.mark(models.Onboarding.State.EMAIL_CONFIRMED, progress=10)
 
 
-def mark_checkout_started(user) -> None:
+def mark_checkout_started(user, checkout_url: Optional[str] = None) -> None:
     onboarding = ensure_onboarding_for_user(user)
     if _state_index(onboarding.state) < _state_index(
         models.Onboarding.State.CHECKOUT_STARTED
     ):
-        onboarding.mark(models.Onboarding.State.CHECKOUT_STARTED, progress=15)
+        message = None
+        if checkout_url:
+            message = f"Stripe checkout started: {checkout_url}"
+        onboarding.mark(
+            models.Onboarding.State.CHECKOUT_STARTED,
+            progress=15,
+            message=message,
+        )
 
 
 def mark_checkout_paid(account: models.Account) -> None:

--- a/app/stripe.py
+++ b/app/stripe.py
@@ -1,0 +1,252 @@
+"""Stripe billing and subscription helpers."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import Optional
+
+from django.conf import settings
+from django.utils import timezone
+import stripe as stripe_sdk
+
+from . import models
+
+logger = logging.getLogger(__name__)
+stripe = stripe_sdk
+
+
+class InvalidWebhookPayload(Exception):
+    """Raised when a webhook payload cannot be parsed."""
+
+
+class InvalidWebhookSignature(Exception):
+    """Raised when a webhook signature fails validation."""
+
+
+def ensure_api_key() -> None:
+    """Refresh the Stripe API key from settings for the current process."""
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY or ""
+
+
+def stripe_timestamp(value: Optional[int]) -> datetime.datetime:
+    """Convert a Stripe timestamp into an aware datetime."""
+
+    if not value:
+        return timezone.now()
+    return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+
+
+def get_default_plan() -> models.Plan:
+    """Fetch or create the default plan used for subscriptions."""
+
+    defaults = {
+        "name": "Pro",
+        "limits": {"concept_runs": 100, "dish_runs": 100, "price": "199"},
+        "features": [
+            "Unlimited menu scrapes",
+            "Concept and dish generation",
+            "Team collaboration",
+        ],
+    }
+    plan, _ = models.Plan.objects.get_or_create(
+        code=getattr(settings, "STRIPE_PLAN_CODE", "pro"), defaults=defaults
+    )
+    return plan
+
+
+def latest_subscription_for_account(
+    account: models.Account,
+) -> Optional[models.Subscription]:
+    """Return the most recent subscription for an account."""
+
+    return (
+        models.Subscription.objects.filter(account=account)
+        .order_by("-created_at")
+        .first()
+    )
+
+
+def sync_subscription(subscription_data: dict) -> Optional[models.Account]:
+    """Create or update a subscription based on Stripe payload."""
+
+    sub_id = subscription_data.get("id")
+    if not sub_id:
+        return None
+
+    account: Optional[models.Account] = None
+    local = models.Subscription.objects.filter(provider_sub_id=sub_id).first()
+    if local:
+        account = local.account
+
+    metadata = subscription_data.get("metadata") or {}
+    if not account:
+        account_id = metadata.get("account_id")
+        if account_id:
+            account = models.Account.objects.filter(id=account_id).first()
+
+    if not account:
+        customer_id = subscription_data.get("customer")
+        if customer_id:
+            account = models.Account.objects.filter(
+                stripe_customer_id=customer_id
+            ).first()
+
+    if not account:
+        return None
+
+    customer_id = subscription_data.get("customer")
+    if customer_id and account.stripe_customer_id != customer_id:
+        account.stripe_customer_id = customer_id
+        account.save(update_fields=["stripe_customer_id"])
+
+    plan = get_default_plan()
+    status = subscription_data.get("status", models.Subscription.Status.TRIALING)
+    defaults = {
+        "plan": plan,
+        "provider": models.Subscription.Provider.STRIPE,
+        "provider_customer_id": customer_id or "",
+        "status": status,
+        "current_period_start": stripe_timestamp(
+            subscription_data.get("current_period_start")
+        ),
+        "current_period_end": stripe_timestamp(
+            subscription_data.get("current_period_end")
+        ),
+        "cancel_at_period_end": subscription_data.get(
+            "cancel_at_period_end", False
+        ),
+    }
+
+    subscription_obj, _ = models.Subscription.objects.update_or_create(
+        account=account,
+        provider=models.Subscription.Provider.STRIPE,
+        provider_sub_id=sub_id,
+        defaults=defaults,
+    )
+    if subscription_obj.account_id != account.id:
+        subscription_obj.account = account
+        subscription_obj.save(update_fields=["account"])
+    return account
+
+
+def create_checkout_session(
+    *,
+    account: models.Account,
+    user_email: str,
+    success_url: str,
+    cancel_url: str,
+    price_id: str,
+    metadata: dict,
+    trial_days: int,
+) -> Optional[str]:
+    """Create a Stripe Checkout session and return its URL."""
+
+    if not price_id:
+        return None
+
+    ensure_api_key()
+    session_kwargs = {
+        "mode": "subscription",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "subscription_data": {
+            "trial_period_days": trial_days,
+            "metadata": metadata,
+        },
+        "metadata": metadata,
+    }
+
+    if account.stripe_customer_id:
+        session_kwargs["customer"] = account.stripe_customer_id
+    else:
+        session_kwargs["customer_email"] = user_email
+
+    try:
+        session = stripe.checkout.Session.create(**session_kwargs)
+    except stripe.error.StripeError:
+        logger.exception("Unable to create Stripe Checkout session", exc_info=True)
+        return None
+
+    return getattr(session, "url", None)
+
+
+def cancel_subscription(subscription: models.Subscription) -> None:
+    """Request cancellation for the provided subscription if it is Stripe based."""
+
+    if subscription.provider != models.Subscription.Provider.STRIPE:
+        return
+    if not getattr(settings, "STRIPE_SECRET_KEY", ""):
+        return
+
+    ensure_api_key()
+    try:
+        stripe.Subscription.modify(subscription.provider_sub_id, cancel_at_period_end=True)
+    except stripe.error.StripeError:
+        logger.exception("Unable to cancel Stripe subscription", exc_info=True)
+
+
+def construct_webhook_event(payload: bytes, signature: str) -> dict:
+    """Parse the incoming webhook payload into a Stripe event dict."""
+
+    secret = getattr(settings, "STRIPE_WEBHOOK_SECRET", "")
+    if secret:
+        try:
+            return stripe.Webhook.construct_event(payload, signature, secret)
+        except ValueError as exc:
+            raise InvalidWebhookPayload from exc
+        except stripe.error.SignatureVerificationError as exc:
+            raise InvalidWebhookSignature from exc
+
+    try:
+        if not payload:
+            return {}
+        return json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise InvalidWebhookPayload from exc
+
+
+def retrieve_subscription(subscription_id: str) -> Optional[dict]:
+    """Fetch a subscription from Stripe safely."""
+
+    if not subscription_id:
+        return None
+
+    ensure_api_key()
+    try:
+        return stripe.Subscription.retrieve(subscription_id)
+    except stripe.error.StripeError:
+        logger.exception(
+            "Unable to retrieve subscription %s from Stripe", subscription_id
+        )
+        return None
+
+
+def process_webhook_event(event: dict) -> Optional[models.Account]:
+    """Process a webhook event and return the affected account when available."""
+
+    if not isinstance(event, dict):
+        return None
+
+    event_type = event.get("type")
+    data_object = (event.get("data") or {}).get("object", {})
+
+    if event_type == "checkout.session.completed":
+        subscription_id = data_object.get("subscription")
+        subscription = retrieve_subscription(subscription_id)
+        if subscription:
+            return sync_subscription(subscription)
+        return None
+
+    if event_type in {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }:
+        if isinstance(data_object, dict):
+            return sync_subscription(data_object)
+
+    return None

--- a/app/views.py
+++ b/app/views.py
@@ -27,7 +27,6 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 import requests
-import stripe
 from pydantic import BaseModel
 from django.core.cache import cache
 import hashlib
@@ -44,10 +43,7 @@ from itertools import islice
 
 
 from app.tasks import create_ideation_run
-from . import onboarding
-
-
-stripe.api_key = settings.STRIPE_SECRET_KEY or ""
+from . import onboarding, stripe as stripe_service
 logger = logging.getLogger(__name__)
 
 
@@ -150,30 +146,6 @@ def _queue_outscraper_payload(
 
 class ConceptList(BaseModel):
     concepts: List[str]
-
-
-def _ensure_stripe_api_key() -> None:
-    """Refresh the Stripe API key from settings for the current process."""
-
-    stripe.api_key = settings.STRIPE_SECRET_KEY or ""
-
-
-def _get_default_plan() -> models.Plan:
-    """Fetch or create the default plan used for subscriptions."""
-
-    defaults = {
-        "name": "Pro",
-        "limits": {"concept_runs": 100, "dish_runs": 100, "price": "199"},
-        "features": [
-            "Unlimited menu scrapes",
-            "Concept and dish generation",
-            "Team collaboration",
-        ],
-    }
-    plan, _ = models.Plan.objects.get_or_create(
-        code=getattr(settings, "STRIPE_PLAN_CODE", "pro"), defaults=defaults
-    )
-    return plan
 
 
 def _current_season(current_date: Optional[datetime.date] = None) -> str:
@@ -297,89 +269,6 @@ def _footer_articles(limit: int = 4) -> List[Any]:
     )
     cache.set(cache_key, articles, timeout=DEFAULT_CACHE_TIMEOUT)
     return articles
-
-
-def _stripe_timestamp(value: Optional[int]) -> datetime.datetime:
-    """Convert a Stripe timestamp into an aware datetime."""
-
-    if not value:
-        return timezone.now()
-    return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
-
-
-def _sync_subscription(subscription_data: dict) -> Optional[models.Account]:
-    """Create or update a subscription based on Stripe payload."""
-
-    sub_id = subscription_data.get("id")
-    if not sub_id:
-        return None
-
-    account: Optional[models.Account] = None
-    local = models.Subscription.objects.filter(provider_sub_id=sub_id).first()
-    if local:
-        account = local.account
-
-    metadata = subscription_data.get("metadata") or {}
-    if not account:
-        account_id = metadata.get("account_id")
-        if account_id:
-            account = models.Account.objects.filter(id=account_id).first()
-
-    if not account:
-        customer_id = subscription_data.get("customer")
-        if customer_id:
-            account = models.Account.objects.filter(
-                stripe_customer_id=customer_id
-            ).first()
-
-    if not account:
-        return None
-
-    customer_id = subscription_data.get("customer")
-    if customer_id and account.stripe_customer_id != customer_id:
-        account.stripe_customer_id = customer_id
-        account.save(update_fields=["stripe_customer_id"])
-
-    plan = _get_default_plan()
-    status = subscription_data.get("status", models.Subscription.Status.TRIALING)
-    defaults = {
-        "plan": plan,
-        "provider": models.Subscription.Provider.STRIPE,
-        "provider_customer_id": customer_id or "",
-        "status": status,
-        "current_period_start": _stripe_timestamp(
-            subscription_data.get("current_period_start")
-        ),
-        "current_period_end": _stripe_timestamp(
-            subscription_data.get("current_period_end")
-        ),
-        "cancel_at_period_end": subscription_data.get(
-            "cancel_at_period_end", False
-        ),
-    }
-
-    subscription_obj, _ = models.Subscription.objects.update_or_create(
-        account=account,
-        provider=models.Subscription.Provider.STRIPE,
-        provider_sub_id=sub_id,
-        defaults=defaults,
-    )
-    if subscription_obj.account_id != account.id:
-        subscription_obj.account = account
-        subscription_obj.save(update_fields=["account"])
-    return account
-
-
-def _latest_subscription_for_account(
-    account: models.Account,
-) -> Optional[models.Subscription]:
-    """Return the most recent subscription for an account."""
-
-    return (
-        models.Subscription.objects.filter(account=account)
-        .order_by("-created_at")
-        .first()
-    )
 
 
 def _get_session_list(session, key: str) -> List[str]:
@@ -3266,8 +3155,10 @@ def billing_view(request):
         .first()
     )
     account = membership.account if membership else None
-    subscription = _latest_subscription_for_account(account) if account else None
-    plan = _get_default_plan() if account else None
+    subscription = (
+        stripe_service.latest_subscription_for_account(account) if account else None
+    )
+    plan = stripe_service.get_default_plan() if account else None
     trial_days = getattr(settings, "STRIPE_TRIAL_DAYS", 14)
     trial_end = subscription.current_period_end if subscription else None
     trial_days_remaining = None
@@ -3305,7 +3196,6 @@ def billing_upgrade_view(request):
         return redirect("billing")
 
     account = membership.account
-    _ensure_stripe_api_key()
     metadata = {"account_id": str(account.id)}
     next_path = request.POST.get("next") or reverse("billing")
     if not isinstance(next_path, str) or not next_path.startswith("/"):
@@ -3313,32 +3203,21 @@ def billing_upgrade_view(request):
     success_url = request.build_absolute_uri(next_path)
     cancel_url = success_url
 
-    session_kwargs = {
-        "mode": "subscription",
-        "line_items": [{"price": price_id, "quantity": 1}],
-        "success_url": success_url,
-        "cancel_url": cancel_url,
-        "subscription_data": {
-            "trial_period_days": getattr(settings, "STRIPE_TRIAL_DAYS", 14),
-            "metadata": metadata,
-        },
-        "metadata": metadata,
-    }
+    session_url = stripe_service.create_checkout_session(
+        account=account,
+        user_email=request.user.email,
+        success_url=success_url,
+        cancel_url=cancel_url,
+        price_id=price_id,
+        metadata=metadata,
+        trial_days=getattr(settings, "STRIPE_TRIAL_DAYS", 14),
+    )
 
-    if account.stripe_customer_id:
-        session_kwargs["customer"] = account.stripe_customer_id
-    else:
-        session_kwargs["customer_email"] = request.user.email
-
-    onboarding.mark_checkout_started(request.user)
-
-    try:
-        checkout_session = stripe.checkout.Session.create(**session_kwargs)
-    except stripe.error.StripeError:
-        logger.exception("Unable to create Stripe Checkout session", exc_info=True)
+    if not session_url:
         return redirect("billing")
 
-    return redirect(checkout_session.url)
+    onboarding.mark_checkout_started(request.user, checkout_url=session_url)
+    return redirect(session_url)
 
 
 @login_required
@@ -3355,21 +3234,11 @@ def billing_cancel_view(request):
         return redirect("billing")
 
     account = membership.account
-    subscription = _latest_subscription_for_account(account)
+    subscription = stripe_service.latest_subscription_for_account(account)
     if not subscription:
         return redirect("billing")
 
-    if (
-        subscription.provider == models.Subscription.Provider.STRIPE
-        and getattr(settings, "STRIPE_SECRET_KEY", "")
-    ):
-        _ensure_stripe_api_key()
-        try:
-            stripe.Subscription.modify(
-                subscription.provider_sub_id, cancel_at_period_end=True
-            )
-        except stripe.error.StripeError:
-            logger.exception("Unable to cancel Stripe subscription", exc_info=True)
+    stripe_service.cancel_subscription(subscription)
 
     if not subscription.cancel_at_period_end:
         subscription.cancel_at_period_end = True
@@ -3385,46 +3254,16 @@ def stripe_webhook_view(request):
 
     payload = request.body
     sig_header = request.META.get("HTTP_STRIPE_SIGNATURE", "")
-    secret = getattr(settings, "STRIPE_WEBHOOK_SECRET", "")
+    try:
+        event = stripe_service.construct_webhook_event(payload, sig_header)
+    except stripe_service.InvalidWebhookPayload:
+        return HttpResponseBadRequest("invalid_payload")
+    except stripe_service.InvalidWebhookSignature:
+        return HttpResponseForbidden("invalid_signature")
 
-    if secret:
-        try:
-            event = stripe.Webhook.construct_event(payload, sig_header, secret)
-        except ValueError:
-            return HttpResponseBadRequest("invalid_payload")
-        except stripe.error.SignatureVerificationError:
-            return HttpResponseForbidden("invalid_signature")
-    else:
-        try:
-            event = json.loads(payload or "{}")
-        except json.JSONDecodeError:
-            return HttpResponseBadRequest("invalid_json")
-
-    event_type = event.get("type")
-    data_object = event.get("data", {}).get("object", {})
-
-    if event_type == "checkout.session.completed":
-        subscription_id = data_object.get("subscription")
-        if subscription_id:
-            _ensure_stripe_api_key()
-            try:
-                subscription = stripe.Subscription.retrieve(subscription_id)
-            except stripe.error.StripeError:
-                logger.exception(
-                    "Unable to retrieve subscription %s from Stripe", subscription_id
-                )
-            else:
-                account = _sync_subscription(subscription)
-                if account:
-                    onboarding.mark_checkout_paid(account)
-    elif event_type in {
-        "customer.subscription.created",
-        "customer.subscription.updated",
-        "customer.subscription.deleted",
-    }:
-        account = _sync_subscription(data_object)
-        if account:
-            onboarding.mark_checkout_paid(account)
+    account = stripe_service.process_webhook_event(event)
+    if account:
+        onboarding.mark_checkout_paid(account)
 
     return HttpResponse(status=200)
 

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -1153,8 +1153,8 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(mv.source_kind, models.MenuVersion.SourceKind.IMAGE_OCR)
         mock_parse.assert_called_once()
 
-    @patch("app.views.stripe.Subscription.modify")
-    @patch("app.views.stripe.checkout.Session.create")
+    @patch("app.stripe.stripe.Subscription.modify")
+    @patch("app.stripe.stripe.checkout.Session.create")
     def test_billing_views(self, mock_checkout, mock_modify):
         mock_checkout.return_value = SimpleNamespace(url="https://stripe.test/session")
 

--- a/tests/test_stripe_flow.py
+++ b/tests/test_stripe_flow.py
@@ -24,7 +24,7 @@ class StripeFlowTests(TestCase):
         )
         self.client.login(username="stripe@example.com", password="pw")
 
-    @patch("app.views.stripe.checkout.Session.create")
+    @patch("app.stripe.stripe.checkout.Session.create")
     def test_start_trial_checkout_metadata(self, mock_checkout):
         mock_checkout.return_value = SimpleNamespace(url="https://stripe.test/session")
 
@@ -39,8 +39,8 @@ class StripeFlowTests(TestCase):
         self.assertEqual(kwargs["subscription_data"]["trial_period_days"], 14)
         self.assertEqual(kwargs["customer_email"], self.user.email)
 
-    @patch("app.views.stripe.Subscription.retrieve")
-    @patch("app.views.stripe.Webhook.construct_event")
+    @patch("app.stripe.stripe.Subscription.retrieve")
+    @patch("app.stripe.stripe.Webhook.construct_event")
     def test_webhook_checkout_creates_subscription(self, mock_construct, mock_retrieve):
         event = {
             "type": "checkout.session.completed",

--- a/tests/test_trial_subscription.py
+++ b/tests/test_trial_subscription.py
@@ -15,8 +15,8 @@ class TrialSubscriptionTests(TestCase):
         self.restaurant = "TrialResto"
         self.location = "City"
 
-    @patch("app.views.stripe.Subscription.create")
-    @patch("app.views.stripe.Customer.create")
+    @patch("app.stripe.stripe.Subscription.create")
+    @patch("app.stripe.stripe.Customer.create")
     def test_registration_creates_trial_subscription(self, mock_customer_create, mock_sub_create):
         mock_customer_create.return_value = {"id": "cus_123"}
         mock_sub_create.return_value = {"id": "sub_123"}


### PR DESCRIPTION
## Summary
- extract Stripe billing and webhook helpers into `app/stripe.py`
- update onboarding to store the checkout URL when Stripe sessions are created
- adjust billing views and tests to use the new Stripe helper module

## Testing
- ⚠️ `PYTHONPATH=/workspace/Appertivo3 DJANGO_SETTINGS_MODULE=specials.settings pytest tests/test_stripe_flow.py -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcb89c5ec8332aa8843ca3d865fa4