### PR TITLE
Handle Stripe onboarding checkout completion

### DIFF
--- a/app/stripe.py
+++ b/app/stripe.py
@@ -225,6 +225,36 @@ def retrieve_subscription(subscription_id: str) -> Optional[dict]:
         return None
 
 
+def complete_checkout_session(session_id: str) -> Optional[models.Account]:
+    """Sync the subscription tied to a completed checkout session."""
+
+    if not session_id:
+        return None
+
+    ensure_api_key()
+    try:
+        session = stripe.checkout.Session.retrieve(session_id)
+    except stripe.error.StripeError:
+        logger.exception(
+            "Unable to retrieve Stripe checkout session %s", session_id,
+            exc_info=True,
+        )
+        return None
+
+    subscription_id = getattr(session, "subscription", None)
+    if subscription_id is None and isinstance(session, dict):
+        subscription_id = session.get("subscription")
+    if not subscription_id:
+        return None
+
+    subscription = retrieve_subscription(subscription_id)
+    if not subscription:
+        return None
+
+    account = sync_subscription(subscription)
+    return account
+
+
 def process_webhook_event(event: dict) -> Optional[models.Account]:
     """Process a webhook event and return the affected account when available."""
 

--- a/app/views.py
+++ b/app/views.py
@@ -45,7 +45,7 @@ from itertools import islice
 from app.tasks import create_ideation_run
 from . import onboarding, stripe as stripe_service
 
-stripe.api_key = os.getenv('STRIPE_TEST_KEY')
+stripe_service.stripe.api_key = os.getenv("STRIPE_TEST_KEY")
 logger = logging.getLogger(__name__)
 
 
@@ -827,6 +827,13 @@ def onboarding_view(request):
     )
     account = membership.account if membership else None
     subscription = None
+
+    session_id = request.GET.get("session_id")
+    if session_id:
+        completed_account = stripe_service.complete_checkout_session(session_id)
+        if completed_account and (not account or completed_account.id == account.id):
+            onboarding.mark_checkout_paid(completed_account)
+            return redirect(reverse("onboarding"))
 
     if account:
         subscription = (
@@ -3116,8 +3123,10 @@ def billing_upgrade_view(request):
     next_path = request.POST.get("next") or reverse("billing")
     if not isinstance(next_path, str) or not next_path.startswith("/"):
         next_path = reverse("billing")
-    success_url = request.build_absolute_uri(next_path)
-    cancel_url = success_url
+    base_success_url = request.build_absolute_uri(next_path)
+    success_joiner = "&" if "?" in base_success_url else "?"
+    success_url = f"{base_success_url}{success_joiner}session_id={{CHECKOUT_SESSION_ID}}"
+    cancel_url = base_success_url
 
     session_url = stripe_service.create_checkout_session(
         account=account,

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -109,6 +109,43 @@ class ViewSmokeTests(TestCase):
         self.assertEqual(status_resp.status_code, 200)
         self.assertIn("Current state", status_resp.content.decode())
 
+    def test_billing_upgrade_starts_checkout(self):
+        onboarding.ensure_onboarding_for_user(self.user)
+        with patch(
+            "app.views.stripe_service.create_checkout_session",
+            return_value="https://stripe.test/session",
+        ) as mock_create:
+            resp = self.client.post(
+                reverse("billing-upgrade"), {"next": reverse("onboarding")}
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], "https://stripe.test/session")
+        self.assertTrue(mock_create.called)
+        kwargs = mock_create.call_args.kwargs
+        self.assertIn("success_url", kwargs)
+        self.assertIn("session_id={CHECKOUT_SESSION_ID}", kwargs["success_url"])
+
+    def test_onboarding_checkout_completion_marks_paid(self):
+        onboarding_record = onboarding.ensure_onboarding_for_user(self.user)
+        with patch(
+            "app.views.stripe_service.complete_checkout_session",
+            return_value=self.account,
+        ) as mock_complete, patch("app.onboarding.kickoff_after_payment") as mock_kickoff:
+            mock_kickoff.return_value = None
+            resp = self.client.get(
+                reverse("onboarding"), {"session_id": "cs_test_checkout"}
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("onboarding"))
+        mock_complete.assert_called_once_with("cs_test_checkout")
+        onboarding_record.refresh_from_db()
+        self.assertEqual(
+            onboarding_record.state, models.Onboarding.State.CHECKOUT_PAID
+        )
+        mock_kickoff.assert_called_once_with(onboarding_record.id)
+
     def test_manual_menu(self):
         resp = self.client.get(reverse("manual-menu"), HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- add a Stripe checkout session completion helper that syncs subscriptions locally after successful checkout
- process checkout session IDs in the onboarding view to mark billing complete and relaunch onboarding tasks, and include the session token in the billing upgrade success URL
- cover the new flow with view tests around starting checkout and handling the return from Stripe

## Testing
- python manage.py test tests.test_appertivo_views *(fails: NameError for build_prompt_suggestions and other pre-existing view routing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcfb828888332b2db5c2e3332b8f3