### PR TITLE
Add staff articles dashboard workflow

### DIFF
--- a/articles/openai_helpers.py
+++ b/articles/openai_helpers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional import guard for tests
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - handled during CI without openai installed
+    OpenAI = None  # type: ignore
+
+
+NANO_INPUT_RATE_PER_1K = Decimal("0.00015")
+NANO_OUTPUT_RATE_PER_1K = Decimal("0.0006")
+NANO_FALLBACK_RATE_PER_1K = NANO_INPUT_RATE_PER_1K
+
+
+def get_openai_client():
+    if OpenAI is None:
+        raise RuntimeError("openai package is not installed")
+    return OpenAI()
+
+
+def extract_output_text(response: Any) -> str:
+    if response is None:
+        return ""
+    text = getattr(response, "output_text", None)
+    if text:
+        return text
+    output = getattr(response, "output", None)
+    if output and isinstance(output, list):
+        texts = []
+        for item in output:
+            content = item.get("content") if isinstance(item, dict) else None
+            if isinstance(content, list):
+                for piece in content:
+                    if isinstance(piece, dict) and piece.get("type") == "output_text":
+                        texts.append(piece.get("text", ""))
+            elif isinstance(content, str):
+                texts.append(content)
+        return "\n".join(filter(None, texts))
+    dump_json = getattr(response, "model_dump_json", None)
+    if callable(dump_json):
+        try:
+            data = json.loads(dump_json())
+            return data.get("output_text", "")
+        except Exception:  # pragma: no cover - defensive
+            return ""
+    return ""
+
+
+def parse_structured_payload(text: str) -> Dict[str, Any]:
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return {}
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        lines = cleaned.splitlines()
+        if lines and lines[0].strip().startswith("json"):
+            cleaned = "\n".join(lines[1:])
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        return {"text": text}
+
+
+def calculate_nano_cost_cents(usage: Any) -> int:
+    if usage is None:
+        return 0
+
+    def _extract(field: str) -> int:
+        value = None
+        if hasattr(usage, field):
+            value = getattr(usage, field)
+        elif isinstance(usage, dict):
+            value = usage.get(field)
+        return int(value or 0)
+
+    input_tokens = _extract("input_tokens")
+    output_tokens = _extract("output_tokens")
+    total_tokens = _extract("total_tokens")
+
+    cost = Decimal("0")
+    if input_tokens or output_tokens:
+        cost += (Decimal(input_tokens) / Decimal(1000)) * NANO_INPUT_RATE_PER_1K
+        cost += (Decimal(output_tokens) / Decimal(1000)) * NANO_OUTPUT_RATE_PER_1K
+    elif total_tokens:
+        cost += (Decimal(total_tokens) / Decimal(1000)) * NANO_FALLBACK_RATE_PER_1K
+
+    if not cost:
+        return 0
+
+    cents = (cost * Decimal(100)).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return int(cents)

--- a/articles/tasks.py
+++ b/articles/tasks.py
@@ -6,63 +6,16 @@ from typing import Any, Dict, Optional
 
 from django.utils import timezone
 
-try:  # pragma: no cover - optional import guard for tests
-    from openai import OpenAI
-except ImportError:  # pragma: no cover - handled during CI without openai installed
-    OpenAI = None  # type: ignore
-
 from .models import PromptTemplate, RunStep
+from .openai_helpers import (
+    calculate_nano_cost_cents,
+    extract_output_text,
+    get_openai_client,
+    parse_structured_payload,
+)
 from .pipeline import build_next_input, finalize_run, next_step_name, schedule_step
 
 logger = logging.getLogger(__name__)
-
-
-def get_openai_client():
-    if OpenAI is None:
-        raise RuntimeError("openai package is not installed")
-    return OpenAI()
-
-
-def _extract_text(response: Any) -> str:
-    if response is None:
-        return ""
-    text = getattr(response, "output_text", None)
-    if text:
-        return text
-    output = getattr(response, "output", None)
-    if output and isinstance(output, list):
-        texts = []
-        for item in output:
-            content = item.get("content") if isinstance(item, dict) else None
-            if isinstance(content, list):
-                for piece in content:
-                    if isinstance(piece, dict) and piece.get("type") == "output_text":
-                        texts.append(piece.get("text", ""))
-            elif isinstance(content, str):
-                texts.append(content)
-        return "\n".join(filter(None, texts))
-    if hasattr(response, "model_dump_json"):
-        try:
-            data = json.loads(response.model_dump_json())
-            return data.get("output_text", "")
-        except Exception:  # pragma: no cover - defensive
-            return ""
-    return ""
-
-
-def _parse_payload(text: str) -> Dict[str, Any]:
-    cleaned = text.strip()
-    if not cleaned:
-        return {}
-    # Allow fenced code blocks from the model output.
-    if cleaned.startswith("```"):
-        cleaned = cleaned.strip("`")
-        if "json" in cleaned.splitlines()[0]:
-            cleaned = "\n".join(cleaned.splitlines()[1:])
-    try:
-        return json.loads(cleaned)
-    except json.JSONDecodeError:
-        return {"text": text}
 
 
 def run_step(step_id: int, *, client: Optional[Any] = None) -> None:
@@ -106,8 +59,8 @@ def run_step(step_id: int, *, client: Optional[Any] = None) -> None:
             if hasattr(response, "model_dump")
             else getattr(response, "to_dict", lambda: {})()
         )
-        output_text = _extract_text(response)
-        parsed_payload = _parse_payload(output_text)
+        output_text = extract_output_text(response)
+        parsed_payload = parse_structured_payload(output_text)
 
         step.status = "ok"
         step.output_payload = parsed_payload
@@ -116,9 +69,9 @@ def run_step(step_id: int, *, client: Optional[Any] = None) -> None:
         step.save(update_fields=["status", "output_payload", "raw_response", "ended_at"])
 
         usage = getattr(response, "usage", None)
-        if usage and hasattr(usage, "total_tokens"):
-            total_tokens = usage.total_tokens  # type: ignore[attr-defined]
-            run.cost_cents += int(total_tokens or 0)
+        cost_cents = calculate_nano_cost_cents(usage)
+        if cost_cents:
+            run.cost_cents += cost_cents
             run.save(update_fields=["cost_cents"])
 
         next_step = next_step_name(step.name)

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -1,0 +1,64 @@
+{% if form_errors %}
+  <div class="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+    <p class="font-semibold">We couldn't generate concepts yet.</p>
+    <ul class="mt-2 list-disc space-y-1 pl-5">
+      {% for field, errors in form_errors.items %}
+        {% for error in errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}
+
+{% if ideas %}
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h3 class="text-base font-semibold text-[#14080E]">Concepts ready for review</h3>
+      <p class="text-sm text-slate-500">Pick the best direction to launch research and a first draft.</p>
+    </div>
+    {% if active_run %}
+      <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">Run #{{ active_run.id }}</span>
+    {% endif %}
+  </div>
+  {% if ideas_payload.notes %}
+    <div class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+      <p class="font-semibold">Model notes</p>
+      <p class="mt-1 whitespace-pre-wrap">{{ ideas_payload.notes }}</p>
+    </div>
+  {% endif %}
+  <div class="grid gap-4 md:grid-cols-2">
+    {% for idea in ideas %}
+      <div class="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+        <div class="space-y-2">
+          <p class="text-xs uppercase font-semibold text-[#7B1FA2]">Idea {{ forloop.counter }}</p>
+          <h4 class="text-lg font-semibold text-[#14080E]">{{ idea.title }}</h4>
+          <p class="text-sm text-slate-500">{{ idea.subtitle }}</p>
+          {% if idea.angle %}
+            <p class="text-xs text-slate-500">Angle: {{ idea.angle }}</p>
+          {% endif %}
+        </div>
+        <form
+          method="post"
+          hx-post="{% url 'articles:staff_select_concept' %}"
+          hx-target="#draft-workflow"
+          hx-swap="innerHTML"
+          class="mt-4"
+        >
+          {% csrf_token %}
+          <input type="hidden" name="run_id" value="{{ active_run.id }}">
+          <input type="hidden" name="idea_index" value="{{ forloop.counter0 }}">
+          <button
+            type="submit"
+            class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]"
+          >
+            <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+            Research this concept
+          </button>
+        </form>
+      </div>
+    {% endfor %}
+  </div>
+{% else %}
+  <p class="text-sm text-slate-500">Use the form above to generate five article directions tailored to your research context.</p>
+{% endif %}

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -1,0 +1,73 @@
+{% if draft_form %}
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-[#14080E]">2. Research &amp; draft review</h2>
+        <p class="text-sm text-slate-500 max-w-xl">Review the AI-generated outline and citations, make edits inline, then continue to polish.</p>
+      </div>
+      {% if selected_idea %}
+        <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">{{ selected_idea.title }}</span>
+      {% endif %}
+    </div>
+    {% if draft_summary %}
+      <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+        <p class="font-semibold text-[#2E005D]">Research summary</p>
+        <p class="mt-2 whitespace-pre-wrap">{{ draft_summary }}</p>
+      </div>
+    {% endif %}
+    {% if citations %}
+      <div class="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+        <p class="text-sm font-semibold text-emerald-700">Citations gathered</p>
+        <ul class="mt-2 space-y-1 text-xs text-emerald-800">
+          {% for citation in citations %}
+            <li>
+              {% if citation.title %}<span class="font-semibold">{{ citation.title }}.</span>{% endif %}
+              {% if citation.url %}<a href="{{ citation.url }}" target="_blank" rel="noopener" class="underline">{{ citation.url }}</a>{% endif %}
+              {% if citation.note %}<span class="ml-1">({{ citation.note }})</span>{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+    <form
+      method="post"
+      hx-post="{% url 'articles:staff_finalize_article' %}"
+      hx-target="#final-article-panel"
+      hx-swap="innerHTML"
+      class="space-y-4"
+    >
+      {% csrf_token %}
+      {{ draft_form.run_id }}
+      <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+        {{ draft_form.draft_title.label }}
+        {{ draft_form.draft_title }}
+        {% for error in draft_form.draft_title.errors %}
+          <span class="text-xs text-red-600">{{ error }}</span>
+        {% endfor %}
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+        {{ draft_form.draft_body.label }}
+        {{ draft_form.draft_body }}
+        <span class="text-xs font-normal text-slate-500">Edit any section directly before continuing.</span>
+        {% for error in draft_form.draft_body.errors %}
+          <span class="text-xs text-red-600">{{ error }}</span>
+        {% endfor %}
+      </label>
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-xs text-slate-500">Continuing sends the edited draft to gpt-4.1-nano for professional polish and SEO metadata.</p>
+        <button
+          type="submit"
+          class="inline-flex items-center justify-center gap-2 rounded-full bg-[#2E005D] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#220045]"
+        >
+          <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+          Continue to final polish
+        </button>
+      </div>
+    </form>
+  </div>
+{% else %}
+  <div class="flex flex-col items-start gap-2">
+    <h2 class="text-lg font-semibold text-[#14080E]">2. Research &amp; draft review</h2>
+    <p class="text-sm text-slate-500">Select an article concept to generate a sourced outline and editable draft.</p>
+  </div>
+{% endif %}

--- a/articles/templates/articles/_final_article_panel.html
+++ b/articles/templates/articles/_final_article_panel.html
@@ -1,0 +1,87 @@
+{% if article and run %}
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-[#14080E]">3. Final article review</h2>
+        <p class="text-sm text-slate-500">The draft has been polished with SEO metadata. Review below and publish when approved.</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <span class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">Run #{{ run.id }}</span>
+        <span class="rounded-full {% if article.status == 'published' %}bg-emerald-100 text-emerald-700{% else %}bg-amber-100 text-amber-700{% endif %} px-3 py-1 text-xs font-semibold">
+          {{ article.get_status_display }}
+        </span>
+      </div>
+    </div>
+    <article class="space-y-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+      <header class="space-y-2">
+        <h3 class="text-xl font-semibold text-[#14080E]">{{ article.title }}</h3>
+        {% if final_payload.seo_title %}
+          <p class="text-sm text-slate-500">SEO Title: {{ final_payload.seo_title }}</p>
+        {% endif %}
+        {% if final_payload.seo_description %}
+          <p class="text-sm text-slate-500">SEO Description: {{ final_payload.seo_description }}</p>
+        {% endif %}
+        {% if final_payload.summary %}
+          <p class="text-sm text-slate-600">Summary: {{ final_payload.summary }}</p>
+        {% endif %}
+      </header>
+      <div class="prose prose-slate max-w-none">
+        {{ article.body_markdown|linebreaksbr }}
+      </div>
+      {% if sources %}
+        <footer class="border-t border-slate-200 pt-3">
+          <h4 class="text-sm font-semibold text-slate-700">Sources</h4>
+          <ul class="mt-1 space-y-1 text-xs text-slate-500">
+            {% for source in sources %}
+              <li>
+                {% if source.title %}<span class="font-semibold">{{ source.title }}</span>{% endif %}
+                {% if source.url %}<a href="{{ source.url }}" target="_blank" rel="noopener" class="underline">{{ source.url }}</a>{% endif %}
+                {% if source.citation %}<span class="ml-1">({{ source.citation }})</span>{% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </footer>
+      {% endif %}
+    </article>
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <p class="text-xs text-slate-500">
+        Total Nano 4.1 cost for this run: <span class="font-semibold text-[#2E005D]">${{ run_cost|default:0|floatformat:2 }}</span>
+      </p>
+      {% if article.status != 'published' %}
+        <form
+          method="post"
+          hx-post="{% url 'articles:staff_publish_article' %}"
+          hx-target="#final-article-panel"
+          hx-swap="innerHTML"
+          class="inline-flex"
+        >
+          {% csrf_token %}
+          <input type="hidden" name="run_id" value="{{ run.id }}">
+          <input type="hidden" name="article_id" value="{{ article.id }}">
+          <button
+            type="submit"
+            class="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+          >
+            <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+            Approve &amp; publish
+          </button>
+        </form>
+      {% else %}
+        <a href="{{ article.get_absolute_url }}" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700">
+          <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
+          View live article
+        </a>
+      {% endif %}
+    </div>
+  </div>
+{% elif run %}
+  <div class="flex flex-col items-start gap-2">
+    <h2 class="text-lg font-semibold text-[#14080E]">3. Final article review</h2>
+    <p class="text-sm text-slate-500">An article run is active (Run #{{ run.id }}). Approve the draft above to generate the final article.</p>
+  </div>
+{% else %}
+  <div class="flex flex-col items-start gap-2">
+    <h2 class="text-lg font-semibold text-[#14080E]">3. Final article review</h2>
+    <p class="text-sm text-slate-500">Approve the draft to generate SEO metadata and prepare the final article.</p>
+  </div>
+{% endif %}

--- a/articles/templates/articles/_run_list.html
+++ b/articles/templates/articles/_run_list.html
@@ -1,0 +1,31 @@
+{% if runs_with_meta %}
+  <ul class="space-y-3">
+    {% for item in runs_with_meta %}
+      {% with run=item.run article=item.article cost=item.cost %}
+        <li class="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p class="text-sm font-semibold text-[#14080E]">Run #{{ run.id }}</p>
+              <p class="text-xs text-slate-500">Started {{ run.created_at|date:"M j, Y g:i a" }}</p>
+            </div>
+            <div class="flex items-center gap-2 text-xs">
+              <span class="rounded-full px-2.5 py-1 font-semibold {% if run.status == 'completed' %}bg-emerald-100 text-emerald-700{% elif run.status == 'failed' %}bg-red-100 text-red-700{% else %}bg-amber-100 text-amber-700{% endif %}">{{ run.get_status_display }}</span>
+              <span class="rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-600">${{ cost|default:0|floatformat:2 }}</span>
+            </div>
+          </div>
+          {% if run.current_step %}
+            <p class="mt-2 text-xs text-slate-500">Current step: {{ run.current_step|capfirst }}</p>
+          {% endif %}
+          {% if article %}
+            <div class="mt-2 flex items-center gap-2 text-xs">
+              <span class="rounded-full bg-[#F0F4FF] px-2.5 py-1 font-semibold text-[#2E005D]">{{ article.get_status_display }}</span>
+              <a href="{% if article.status == 'published' %}{{ article.get_absolute_url }}{% else %}{% url 'admin:articles_article_change' article.id %}{% endif %}" class="text-[#5C008B] hover:underline">{{ article.title }}</a>
+            </div>
+          {% endif %}
+        </li>
+      {% endwith %}
+    {% endfor %}
+  </ul>
+{% else %}
+  <p class="text-sm text-slate-500">Runs will appear here after you generate your first article concepts.</p>
+{% endif %}

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -1,0 +1,134 @@
+{% extends "layouts/app.html" %}
+
+{% block title %}Articles Studio — Appertivo{% endblock %}
+
+{% block page_intro %}
+  <div class="space-y-2">
+    <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Articles Studio</p>
+    <h1 class="text-2xl font-semibold text-[#14080E]">AI Article Workflow</h1>
+    <p class="text-sm text-slate-500 max-w-2xl">
+      Generate research-backed article concepts, review drafts, and publish finished pieces for Appertivo's content library.
+    </p>
+  </div>
+{% endblock %}
+
+{% block page_content %}
+  <div class="px-4 py-6 space-y-6">
+    <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-[#14080E]">Workflow overview</h2>
+      <p class="mt-1 text-sm text-slate-500 max-w-3xl">
+        This dashboard guides staff-only article production. Start with research context, validate the AI draft, then approve the final SEO-optimized article.
+      </p>
+      <ol class="mt-4 grid gap-4 md:grid-cols-3">
+        <li class="rounded-2xl border border-[#E8D5FF] bg-[#F7F2FF] p-4">
+          <p class="text-xs font-semibold uppercase text-[#7B1FA2]">Step 1</p>
+          <h3 class="mt-2 text-base font-semibold text-[#2E005D]">Generate article concepts</h3>
+          <p class="mt-2 text-sm text-slate-600">Paste context from research papers or notes, then let AI propose five article directions.</p>
+        </li>
+        <li class="rounded-2xl border border-[#FFE3CC] bg-[#FFF7F0] p-4">
+          <p class="text-xs font-semibold uppercase text-[#FF5C00]">Step 2</p>
+          <h3 class="mt-2 text-base font-semibold text-[#B54D00]">Research &amp; draft</h3>
+          <p class="mt-2 text-sm text-slate-600">Pick the best concept to generate a sourced outline and editable draft. Make inline edits before continuing.</p>
+        </li>
+        <li class="rounded-2xl border border-[#C7F0D8] bg-[#F0FFF6] p-4">
+          <p class="text-xs font-semibold uppercase text-[#2F855A]">Step 3</p>
+          <h3 class="mt-2 text-base font-semibold text-[#1E6A45]">Finalize &amp; publish</h3>
+          <p class="mt-2 text-sm text-slate-600">Approve the polished article with SEO metadata and publish when ready. Costs are tracked from Nano 4.1 usage.</p>
+        </li>
+      </ol>
+    </section>
+
+    <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+      <section class="space-y-6">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-[#14080E]">1. Provide context &amp; generate concepts</h2>
+              <p class="text-sm text-slate-500 max-w-xl">Paste research context or upload excerpts to guide ideation. Only staff members can access this workflow.</p>
+            </div>
+          </div>
+          <form
+            id="article-concepts-form"
+            method="post"
+            hx-post="{% url 'articles:staff_generate_concepts' %}"
+            hx-target="#concepts-results"
+            hx-swap="innerHTML"
+            class="space-y-4"
+          >
+            {% csrf_token %}
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                {{ form.topic.label }}
+                {{ form.topic }}
+                {% if form.topic.help_text %}
+                  <span class="text-xs font-normal text-slate-500">{{ form.topic.help_text }}</span>
+                {% endif %}
+                {% for error in form.topic.errors %}
+                  <span class="text-xs text-red-600">{{ error }}</span>
+                {% endfor %}
+              </label>
+            </div>
+            <div class="grid gap-4">
+              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                {{ form.context.label }}
+                {{ form.context }}
+                <span class="text-xs font-normal text-slate-500">{{ form.context.help_text }}</span>
+                {% for error in form.context.errors %}
+                  <span class="text-xs text-red-600">{{ error }}</span>
+                {% endfor %}
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                {{ form.references.label }}
+                {{ form.references }}
+                <span class="text-xs font-normal text-slate-500">{{ form.references.help_text }}</span>
+                {% for error in form.references.errors %}
+                  <span class="text-xs text-red-600">{{ error }}</span>
+                {% endfor %}
+              </label>
+            </div>
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <p class="text-xs text-slate-500">AI cost is estimated from gpt-4.1-nano token usage and added to the run ledger.</p>
+              <button
+                type="submit"
+                class="inline-flex items-center justify-center gap-2 rounded-full bg-[#5C008B] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#460069]"
+              >
+                <i class="fa-solid fa-sparkles" aria-hidden="true"></i>
+                Generate concepts
+              </button>
+            </div>
+          </form>
+          <div id="concepts-results" class="space-y-4">
+            {% include "articles/_concept_results.html" with ideas=ideas active_run=active_run ideas_payload=ideas_payload only %}
+          </div>
+        </div>
+
+        <div id="draft-workflow" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          {% include "articles/_draft_workflow.html" with run=active_run draft_form=draft_form citations=citations draft_summary=draft_summary selected_index=selected_index ideas=ideas only %}
+        </div>
+
+        <div id="final-article-panel" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          {% include "articles/_final_article_panel.html" with article=final_article run=active_run final_payload=final_payload sources=citations only %}
+        </div>
+      </section>
+
+      <aside class="space-y-6">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-[#14080E]">Run activity</h2>
+            <span class="text-xs font-medium uppercase text-slate-400">Staff only</span>
+          </div>
+          <div
+            id="runs-panel"
+            hx-get="{% url 'articles:staff_runs_fragment' %}"
+            hx-trigger="load, articles:refresh-runs from:body"
+            hx-target="this"
+            hx-swap="innerHTML"
+            class="mt-4"
+          >
+            {% include "articles/_run_list.html" with runs_with_meta=runs_with_meta only %}
+          </div>
+        </div>
+      </aside>
+    </div>
+  </div>
+{% endblock %}

--- a/articles/tests/test_staff_dashboard.py
+++ b/articles/tests/test_staff_dashboard.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch
+
+from articles.models import Article, ArticleRun, RunStep
+
+
+class StaffDashboardTests(TestCase):
+    def setUp(self) -> None:
+        User = get_user_model()
+        self.staff_user = User.objects.create_user(
+            username="editor",
+            email="editor@example.com",
+            password="pass123",
+            is_staff=True,
+        )
+        self.client.force_login(self.staff_user)
+
+    def _make_openai_response(self, payload: dict, *, input_tokens: int = 10000, output_tokens: int = 10000):
+        usage = SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+        return SimpleNamespace(
+            model_dump=lambda: {"output": payload},
+            output_text=json.dumps(payload),
+            usage=usage,
+        )
+
+    def test_dashboard_requires_staff(self):
+        self.client.logout()
+        response = self.client.get(reverse("articles:staff_dashboard"))
+        self.assertEqual(response.status_code, 302)
+
+    @patch("articles.views.get_openai_client")
+    def test_generate_concepts_creates_run_and_partial(self, mock_client_factory):
+        ideas_payload = {
+            "ideas": [
+                {"title": "Idea One", "subtitle": "Subtitle", "angle": "Angle"},
+                {"title": "Idea Two", "subtitle": "Subtitle", "angle": "Angle"},
+            ],
+            "notes": "Focus on independent operators.",
+        }
+        mock_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=lambda **_: self._make_openai_response(ideas_payload)
+            )
+        )
+        mock_client_factory.return_value = mock_client
+
+        response = self.client.post(
+            reverse("articles:staff_generate_concepts"),
+            {
+                "topic": "Inventory tactics",
+                "context": "Recent interviews about food waste.",
+                "references": "Research note",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Concepts ready for review")
+        run = ArticleRun.objects.get()
+        self.assertEqual(run.created_by, self.staff_user)
+        self.assertEqual(run.current_step, "ideas")
+        ideas_step = RunStep.objects.get(run=run, name="ideas")
+        self.assertEqual(len(ideas_step.output_payload["ideas"]), 2)
+        self.assertGreater(run.cost_cents, 0)
+
+    @patch("articles.views.get_openai_client")
+    def test_select_concept_creates_draft_step(self, mock_client_factory):
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="ideas")
+        RunStep.objects.create(
+            run=run,
+            name="ideas",
+            status="ok",
+            input_payload={"topic": "Inventory", "context": "Inventory", "references": "Research"},
+            output_payload={
+                "ideas": [
+                    {"title": "Idea One", "subtitle": "Subtitle"},
+                    {"title": "Idea Two", "subtitle": "Subtitle"},
+                ],
+                "notes": "Notes",
+            },
+        )
+        draft_payload = {
+            "summary": "Outline summary",
+            "citations": [{"title": "Source", "url": "https://example.com"}],
+            "draft": {
+                "title": "Idea One",
+                "sections": [
+                    {"heading": "Intro", "paragraphs": ["Paragraph text"]},
+                ],
+            },
+        }
+        mock_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=lambda **_: self._make_openai_response(draft_payload)
+            )
+        )
+        mock_client_factory.return_value = mock_client
+
+        response = self.client.post(
+            reverse("articles:staff_select_concept"),
+            {"run_id": run.id, "idea_index": 0},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Research summary")
+        run.refresh_from_db()
+        draft_step = RunStep.objects.get(run=run, name="draft")
+        self.assertEqual(draft_step.output_payload["summary"], "Outline summary")
+        self.assertGreater(run.cost_cents, 0)
+
+    @patch("articles.views.get_openai_client")
+    def test_finalize_article_creates_article(self, mock_client_factory):
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="draft")
+        RunStep.objects.create(
+            run=run,
+            name="ideas",
+            status="ok",
+            input_payload={},
+            output_payload={"ideas": [{"title": "Idea One", "subtitle": ""}]},
+        )
+        RunStep.objects.create(
+            run=run,
+            name="draft",
+            status="ok",
+            input_payload={"selected": {"title": "Idea One"}},
+            output_payload={
+                "summary": "Draft summary",
+                "citations": [{"title": "Source", "url": "https://example.com"}],
+                "draft_markdown": "## Intro\nBody",
+                "idea_index": 0,
+            },
+        )
+        final_payload = {
+            "title": "Final Title",
+            "summary": "Final summary",
+            "body_markdown": "## Intro\nBody",
+            "seo_title": "SEO Title",
+            "seo_description": "SEO Description",
+            "sources": [{"title": "Source", "url": "https://example.com"}],
+        }
+        mock_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=lambda **_: self._make_openai_response(final_payload)
+            )
+        )
+        mock_client_factory.return_value = mock_client
+
+        response = self.client.post(
+            reverse("articles:staff_finalize_article"),
+            {
+                "run_id": run.id,
+                "draft_title": "Final Title",
+                "draft_body": "## Intro\nBody",
+            },
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Final article review")
+        run.refresh_from_db()
+        article = Article.objects.get(run=run)
+        self.assertEqual(article.title, "Final Title")
+        self.assertEqual(article.status, "draft")
+        self.assertEqual(run.status, "completed")
+
+    def test_publish_article_sets_published(self):
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="completed")
+        article = Article.objects.create(
+            title="Draft",
+            slug="draft",
+            body_markdown="Body",
+            run=run,
+        )
+
+        response = self.client.post(
+            reverse("articles:staff_publish_article"),
+            {"run_id": run.id, "article_id": article.id},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        article.refresh_from_db()
+        self.assertEqual(article.status, "published")
+
+    def test_runs_fragment_renders(self):
+        ArticleRun.objects.create(created_by=self.staff_user)
+        response = self.client.get(reverse("articles:staff_runs_fragment"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Run #")

--- a/articles/urls.py
+++ b/articles/urls.py
@@ -5,6 +5,12 @@ from . import views
 app_name = "articles"
 
 urlpatterns = [
+    path("staff/articles/", views.staff_dashboard, name="staff_dashboard"),
+    path("staff/articles/generate/", views.staff_generate_concepts, name="staff_generate_concepts"),
+    path("staff/articles/concept/", views.staff_select_concept, name="staff_select_concept"),
+    path("staff/articles/finalize/", views.staff_finalize_article, name="staff_finalize_article"),
+    path("staff/articles/publish/", views.staff_publish_article, name="staff_publish_article"),
+    path("staff/articles/runs/", views.staff_runs_fragment, name="staff_runs_fragment"),
     path("articles/", views.article_index, name="article_index"),
     path(
         "articles/<int:year>/<int:month>/<slug:slug>/",

--- a/articles/views.py
+++ b/articles/views.py
@@ -1,9 +1,153 @@
 from __future__ import annotations
 
-from django.http import Http404
-from django.shortcuts import get_object_or_404, render
+import json
+from typing import Any, Dict, List, Tuple
 
-from .models import Article
+from django import forms
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.shortcuts import get_object_or_404, render
+from django.utils import timezone
+from django.views.decorators.http import require_GET, require_POST
+
+from .models import Article, ArticleRun, RunStep
+from .openai_helpers import (
+    calculate_nano_cost_cents,
+    extract_output_text,
+    get_openai_client,
+    parse_structured_payload,
+)
+
+
+class ArticleConceptForm(forms.Form):
+    topic = forms.CharField(
+        label="Working focus",
+        required=False,
+        max_length=200,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "Example: Sustainability in independent restaurants",
+                "class": "rounded-xl border border-slate-200 px-3 py-2",
+            }
+        ),
+        help_text="Optional working angle for the article concepts.",
+    )
+    context = forms.CharField(
+        label="Research context",
+        widget=forms.Textarea(attrs={"rows": 6, "class": "rounded-xl border border-slate-200 p-3"}),
+        help_text="Paste summaries, insights, or research notes to ground the concepts.",
+    )
+    references = forms.CharField(
+        label="Reference excerpts",
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 4, "class": "rounded-xl border border-slate-200 p-3"}),
+        help_text="Optional copy/paste of key quotes, statistics, or paper abstracts.",
+    )
+
+
+class ArticleConceptChoiceForm(forms.Form):
+    run_id = forms.IntegerField()
+    idea_index = forms.IntegerField(min_value=0, max_value=20)
+
+
+class ArticleDraftReviewForm(forms.Form):
+    run_id = forms.IntegerField(widget=forms.HiddenInput())
+    draft_title = forms.CharField(
+        label="Draft title",
+        max_length=255,
+        widget=forms.TextInput(attrs={"class": "rounded-xl border border-slate-200 px-3 py-2"}),
+    )
+    draft_body = forms.CharField(
+        label="Editable draft",
+        widget=forms.Textarea(attrs={"rows": 16, "class": "font-mono text-sm rounded-xl border border-slate-200 p-3"}),
+    )
+
+
+class ArticlePublishForm(forms.Form):
+    run_id = forms.IntegerField()
+    article_id = forms.IntegerField()
+
+
+def _ensure_dict(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            data = json.loads(value)
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        try:
+            data = json.loads(value)
+            if isinstance(data, list):
+                return data
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def _get_run_for_request(request, run_id: int) -> ArticleRun:
+    return get_object_or_404(
+        ArticleRun.objects.prefetch_related("steps"),
+        pk=run_id,
+        created_by=request.user,
+    )
+
+
+def _gather_run_context(
+    run: ArticleRun,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+    ideas_step = None
+    draft_step = None
+    final_step = None
+    for step in run.steps.all():
+        if step.name == "ideas":
+            ideas_step = step
+        elif step.name == "draft":
+            draft_step = step
+        elif step.name == "seo":
+            final_step = step
+    ideas_payload = _ensure_dict(ideas_step.output_payload if ideas_step else {})
+    draft_payload = _ensure_dict(draft_step.output_payload if draft_step else {})
+    final_payload = _ensure_dict(final_step.output_payload if final_step else {})
+    ideas = _ensure_list(ideas_payload.get("ideas"))
+    return ideas, ideas_payload, draft_payload, final_payload
+
+
+def _sections_to_markdown(sections: Any) -> str:
+    if not isinstance(sections, list):
+        return ""
+    lines: List[str] = []
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        heading = section.get("heading") or section.get("h2")
+        if heading:
+            lines.append(f"## {heading}".strip())
+        paragraphs = section.get("paragraphs")
+        if isinstance(paragraphs, list):
+            for paragraph in paragraphs:
+                if paragraph:
+                    lines.append(str(paragraph).strip())
+        elif section.get("body"):
+            lines.append(str(section["body"]).strip())
+        lines.append("")
+    return "\n".join(line for line in lines if line is not None).strip()
+
+
+def _apply_usage_cost(run: ArticleRun, usage: Any) -> None:
+    cost_cents = calculate_nano_cost_cents(usage)
+    if cost_cents:
+        run.cost_cents += cost_cents
+        run.save(update_fields=["cost_cents"])
 
 
 def article_index(request):
@@ -35,6 +179,446 @@ def article_detail(request, year: int, month: int, slug: str):
         request,
         "articles/detail.html",
         {
-            "article": article,
+        "article": article,
         },
     )
+
+
+@staff_member_required
+@require_GET
+def staff_dashboard(request):
+    concept_form = ArticleConceptForm()
+    runs = list(
+        ArticleRun.objects.filter(created_by=request.user)
+        .prefetch_related("steps")
+        .order_by("-created_at")[:10]
+    )
+    articles_by_run = {
+        article.run_id: article
+        for article in Article.objects.filter(run__in=runs)
+    }
+    run_costs = {run.id: (run.cost_cents or 0) / 100 for run in runs}
+    runs_with_meta = [
+        {
+            "run": run,
+            "article": articles_by_run.get(run.id),
+            "cost": run_costs.get(run.id, 0),
+        }
+        for run in runs
+    ]
+
+    active_run = None
+    for run in runs:
+        if run.status in {"running", "queued", "failed"} or run.steps.exists():
+            active_run = run
+            break
+    if not active_run and runs:
+        active_run = runs[0]
+
+    ideas: List[Dict[str, Any]] = []
+    ideas_payload: Dict[str, Any] = {}
+    draft_payload: Dict[str, Any] = {}
+    final_payload: Dict[str, Any] = {}
+    draft_markdown = ""
+    draft_title = ""
+    selected_index = None
+    citations: List[Dict[str, Any]] = []
+    final_article = None
+    draft_summary = ""
+    selected_idea = None
+
+    if active_run:
+        ideas, ideas_payload, draft_payload, final_payload = _gather_run_context(active_run)
+        selected_index = draft_payload.get("idea_index")
+        citations = _ensure_list(draft_payload.get("citations"))
+        draft_markdown = draft_payload.get("draft_markdown") or ""
+        draft_data = _ensure_dict(draft_payload.get("draft"))
+        if not draft_markdown:
+            sections = draft_data.get("sections")
+            if sections:
+                draft_markdown = _sections_to_markdown(sections)
+            elif draft_data.get("text"):
+                draft_markdown = str(draft_data.get("text"))
+        if selected_index is not None and 0 <= selected_index < len(ideas):
+            draft_title = draft_payload.get("title") or ideas[selected_index].get("title", "")
+            selected_idea = ideas[selected_index]
+        else:
+            draft_title = draft_payload.get("title", "")
+        draft_summary = draft_payload.get("summary", "")
+        final_article = articles_by_run.get(active_run.id)
+
+    draft_form = None
+    if active_run and draft_markdown:
+        draft_form = ArticleDraftReviewForm(
+            initial={
+                "run_id": active_run.id,
+                "draft_title": draft_title or "",
+                "draft_body": draft_markdown,
+            }
+        )
+
+    context = {
+        "form": concept_form,
+        "runs": runs,
+        "run_articles": articles_by_run,
+        "run_costs": run_costs,
+        "runs_with_meta": runs_with_meta,
+        "active_run": active_run,
+        "ideas": ideas,
+        "ideas_payload": ideas_payload,
+        "selected_index": selected_index,
+        "draft_form": draft_form,
+        "draft_payload": draft_payload,
+        "citations": citations,
+        "draft_summary": draft_summary,
+        "final_payload": final_payload,
+        "final_article": final_article,
+        "selected_idea": selected_idea,
+        "run_cost": (active_run.cost_cents or 0) / 100 if active_run else 0,
+    }
+    return render(request, "articles/staff_dashboard.html", context)
+
+
+def _render_partial(request, template: str, context: Dict[str, Any], *, status: int = 200) -> HttpResponse:
+    response = render(request, template, context, status=status)
+    return response
+
+
+def _create_run_with_ideas(
+    request,
+    input_payload: Dict[str, Any],
+    ideas: List[Dict[str, Any]],
+    *,
+    model_payload: Dict[str, Any],
+    response_dict: Dict[str, Any],
+    usage: Any,
+) -> ArticleRun:
+    run = ArticleRun.objects.create(
+        created_by=request.user,
+        status="running",
+        current_step="ideas",
+        model_info="gpt-4.1-nano",
+    )
+    RunStep.objects.create(
+        run=run,
+        name="ideas",
+        status="ok",
+        input_payload=input_payload,
+        output_payload={
+            "ideas": ideas,
+            "notes": model_payload.get("notes", ""),
+            "raw": model_payload,
+        },
+        raw_response=response_dict,
+        ended_at=timezone.now(),
+    )
+    _apply_usage_cost(run, usage)
+    return run
+
+
+@staff_member_required
+@require_POST
+def staff_generate_concepts(request):
+    form = ArticleConceptForm(request.POST)
+    if not form.is_valid():
+        return _render_partial(
+            request,
+            "articles/_concept_results.html",
+            {"form_errors": form.errors, "ideas": [], "active_run": None},
+            status=400,
+        )
+
+    topic = form.cleaned_data.get("topic") or "Independent restaurant operations"
+    context_text = form.cleaned_data["context"]
+    references = form.cleaned_data.get("references", "")
+
+    client = get_openai_client()
+    prompt = (
+        "You are an editorial strategist for independent restaurants. "
+        "Provide five distinct article concepts with a compelling title and subtitle. "
+        "Return JSON with an 'ideas' list where each idea has 'title', 'subtitle', and 'angle'. "
+        "Use the research context and references to ground the suggestions."
+        f"\n\nContext:\n{context_text}\n\nReferences:\n{references}\n\n"
+        f"Working focus: {topic}"
+    )
+    response = client.responses.create(model="gpt-4.1-nano", input=prompt)
+    response_dict = (
+        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
+    )
+    payload = parse_structured_payload(extract_output_text(response))
+    ideas = _ensure_list(payload.get("ideas"))
+    normalized_ideas: List[Dict[str, Any]] = []
+    for idea in ideas:
+        if isinstance(idea, dict):
+            normalized_ideas.append(
+                {
+                    "title": idea.get("title", "Untitled concept"),
+                    "subtitle": idea.get("subtitle", idea.get("summary", "")),
+                    "angle": idea.get("angle", ""),
+                }
+            )
+    run_payload = {
+        "topic": topic,
+        "context": context_text,
+        "references": references,
+    }
+    run = _create_run_with_ideas(
+        request,
+        run_payload,
+        normalized_ideas,
+        model_payload=payload,
+        response_dict=response_dict,
+        usage=getattr(response, "usage", None),
+    )
+
+    context = {
+        "ideas": normalized_ideas,
+        "active_run": run,
+        "ideas_payload": run_payload,
+    }
+    response = _render_partial(request, "articles/_concept_results.html", context)
+    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
+    return response
+
+
+@staff_member_required
+@require_POST
+def staff_select_concept(request):
+    form = ArticleConceptChoiceForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid concept selection")
+
+    run = _get_run_for_request(request, form.cleaned_data["run_id"])
+    ideas, ideas_payload, draft_payload, _ = _gather_run_context(run)
+    ideas_step = run.steps.filter(name="ideas").first()
+    context_details = _ensure_dict(ideas_step.input_payload if ideas_step else {})
+
+    idea_index = form.cleaned_data["idea_index"]
+    if idea_index >= len(ideas):
+        return HttpResponseBadRequest("Concept not found for this run")
+
+    selected_idea = ideas[idea_index]
+    client = get_openai_client()
+    prompt = (
+        "You are a research assistant with access to live search. "
+        "Given an article concept, the context, and references, compile supporting citations "
+        "and draft a structured outline with section headings and bullet paragraphs. "
+        "Return JSON with keys: summary, citations (list with title and url), draft (with title, sections, and optional text)."
+        f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
+        f"\n\nContext notes: {context_details.get('context', '')}"
+        f"\n\nReferences: {context_details.get('references', '')}"
+        f"\n\nTopic focus: {context_details.get('topic', '')}"
+    )
+    response = client.responses.create(model=run.model_info or "gpt-4.1-nano", input=prompt)
+    response_dict = (
+        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
+    )
+    payload = parse_structured_payload(extract_output_text(response))
+    citations = _ensure_list(payload.get("citations"))
+    draft_data = _ensure_dict(payload.get("draft"))
+    draft_markdown = payload.get("draft_markdown") or draft_data.get("markdown") or ""
+    if not draft_markdown:
+        sections = draft_data.get("sections")
+        if sections:
+            draft_markdown = _sections_to_markdown(sections)
+        elif draft_data.get("text"):
+            draft_markdown = str(draft_data.get("text"))
+
+    RunStep.objects.update_or_create(
+        run=run,
+        name="draft",
+        defaults={
+            "status": "ok",
+            "input_payload": {
+                "selected": selected_idea,
+                "idea_index": idea_index,
+                "context": context_details,
+            },
+            "output_payload": {
+                "summary": payload.get("summary", ""),
+                "citations": citations,
+                "draft": draft_data,
+                "draft_markdown": draft_markdown,
+                "idea_index": idea_index,
+                "title": draft_data.get("title", selected_idea.get("title", "")),
+            },
+            "raw_response": response_dict,
+            "status": "ok",
+            "error_message": "",
+            "ended_at": timezone.now(),
+        },
+    )
+    run.current_step = "draft"
+    run.status = "running"
+    run.can_resume_from_step = False
+    run.save(update_fields=["current_step", "status", "can_resume_from_step"])
+    _apply_usage_cost(run, getattr(response, "usage", None))
+
+    draft_form = ArticleDraftReviewForm(
+        initial={
+            "run_id": run.id,
+            "draft_title": draft_data.get("title", selected_idea.get("title", "")),
+            "draft_body": draft_markdown,
+        }
+    )
+    context = {
+        "run": run,
+        "selected": selected_idea,
+        "citations": citations,
+        "idea_index": idea_index,
+        "draft_form": draft_form,
+        "draft_summary": payload.get("summary", ""),
+        "selected_idea": selected_idea,
+        "run_cost": (run.cost_cents or 0) / 100,
+    }
+    response = _render_partial(request, "articles/_draft_workflow.html", context)
+    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
+    return response
+
+
+@staff_member_required
+@require_POST
+def staff_finalize_article(request):
+    form = ArticleDraftReviewForm(request.POST)
+    if not form.is_valid():
+        return _render_partial(
+            request,
+            "articles/_draft_workflow.html",
+            {"form_errors": form.errors, "draft_form": form},
+            status=400,
+        )
+
+    run = _get_run_for_request(request, form.cleaned_data["run_id"])
+    draft_step = run.steps.filter(name="draft").first()
+    if not draft_step:
+        return HttpResponseBadRequest("Draft step missing for this run")
+
+    draft_payload = _ensure_dict(draft_step.output_payload)
+    draft_input = _ensure_dict(draft_step.input_payload)
+    citations = _ensure_list(draft_payload.get("citations"))
+    selected_idea = draft_input.get("selected", {})
+    summary = draft_payload.get("summary", "")
+
+    draft_body = form.cleaned_data["draft_body"]
+    draft_title = form.cleaned_data["draft_title"]
+
+    client = get_openai_client()
+    prompt = (
+        "You are a senior editor. Take the refined draft below, preserve approved citations, "
+        "and produce a polished markdown article ready for publication with SEO metadata. "
+        "Return JSON with keys: title, seo_title, seo_description, summary, body_markdown, sources (list)."
+        f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
+        f"\n\nEditor summary: {summary}"
+        f"\n\nCitations: {json.dumps(citations, ensure_ascii=False)}"
+        f"\n\nDraft title: {draft_title}\nDraft body:\n{draft_body}"
+    )
+    response = client.responses.create(model=run.model_info or "gpt-4.1-nano", input=prompt)
+    response_dict = (
+        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
+    )
+    payload = parse_structured_payload(extract_output_text(response))
+    body_markdown = payload.get("body_markdown") or draft_body
+    sources = _ensure_list(payload.get("sources")) or citations
+
+    RunStep.objects.update_or_create(
+        run=run,
+        name="seo",
+        defaults={
+            "status": "ok",
+            "input_payload": {
+                "draft": draft_body,
+                "title": draft_title,
+                "citations": citations,
+                "selected": selected_idea,
+            },
+            "output_payload": payload,
+            "raw_response": response_dict,
+            "error_message": "",
+            "ended_at": timezone.now(),
+        },
+    )
+    _apply_usage_cost(run, getattr(response, "usage", None))
+
+    article_defaults = {
+        "title": payload.get("title") or draft_title,
+        "summary": payload.get("summary", summary),
+        "body_markdown": body_markdown,
+        "outline_json": draft_payload.get("draft", {}),
+        "sources_json": sources,
+        "seo_title": payload.get("seo_title", ""),
+        "seo_description": payload.get("seo_description", ""),
+        "status": "draft",
+    }
+    article, _created = Article.objects.update_or_create(run=run, defaults=article_defaults)
+    run.status = "completed"
+    run.current_step = None
+    run.save(update_fields=["status", "current_step"])
+
+    context = {
+        "article": article,
+        "run": run,
+        "final_payload": payload,
+        "sources": sources,
+        "run_cost": (run.cost_cents or 0) / 100,
+    }
+    response = _render_partial(request, "articles/_final_article_panel.html", context)
+    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
+    return response
+
+
+@staff_member_required
+@require_POST
+def staff_publish_article(request):
+    form = ArticlePublishForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid publish request")
+
+    run = _get_run_for_request(request, form.cleaned_data["run_id"])
+    article = get_object_or_404(Article, pk=form.cleaned_data["article_id"], run=run)
+    article.status = "published"
+    article.save(update_fields=["status", "published_at"])
+    run.status = "completed"
+    run.save(update_fields=["status"])
+
+    seo_step = run.steps.filter(name="seo").first()
+    final_payload = _ensure_dict(seo_step.output_payload) if seo_step else {}
+    context = {
+        "article": article,
+        "run": run,
+        "final_payload": final_payload,
+        "sources": _ensure_list(article.sources_json),
+        "run_cost": (run.cost_cents or 0) / 100,
+    }
+    response = _render_partial(request, "articles/_final_article_panel.html", context)
+    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
+    return response
+
+
+@staff_member_required
+@require_GET
+def staff_runs_fragment(request):
+    runs = list(
+        ArticleRun.objects.filter(created_by=request.user)
+        .prefetch_related("steps")
+        .order_by("-created_at")[:10]
+    )
+    articles_by_run = {
+        article.run_id: article
+        for article in Article.objects.filter(run__in=runs)
+    }
+    run_costs = {run.id: (run.cost_cents or 0) / 100 for run in runs}
+    runs_with_meta = [
+        {
+            "run": run,
+            "article": articles_by_run.get(run.id),
+            "cost": run_costs.get(run.id, 0),
+        }
+        for run in runs
+    ]
+    context = {
+        "runs": runs,
+        "run_articles": articles_by_run,
+        "run_costs": run_costs,
+        "runs_with_meta": runs_with_meta,
+    }
+    return render(request, "articles/_run_list.html", context)


### PR DESCRIPTION
## Summary
- add reusable OpenAI helpers for structured parsing and nano 4.1 cost tracking
- build a staff-only article workflow dashboard with HTMX interactions for concept generation, draft review, and publishing
- record recent run activity and implement tests covering each workflow step

## Testing
- python manage.py test articles.tests.test_staff_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dbf82cbe088332a6eec62e66592c89