### PR TITLE
Add PDF context and research indicators to staff article workflow

### DIFF
--- a/app/templates/layouts/app.html
+++ b/app/templates/layouts/app.html
@@ -63,6 +63,9 @@
         <a href="{% url 'concepts' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Concepts</a>
         <a href="{% url 'favorites' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Favorites</a>
         <a href="{% url 'menus' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Menus</a>
+        {% if request.user.is_staff %}
+          <a href="{% url 'articles:staff_dashboard' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Article Studio</a>
+        {% endif %}
 
         <a href="{% url 'settings' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Settings</a>
         <div class="my-2 border-t border-slate-200"></div>

--- a/articles/pdf_utils.py
+++ b/articles/pdf_utils.py
@@ -1,0 +1,50 @@
+"""Utilities for handling PDF uploads within the article workflow."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import List
+
+from django.core.files.uploadedfile import UploadedFile
+
+_PYPDF_SPEC = importlib.util.find_spec("pypdf")
+if _PYPDF_SPEC is not None:
+    from pypdf import PdfReader  # type: ignore
+else:  # pragma: no cover - falls back when dependency is missing
+    PdfReader = None  # type: ignore
+
+
+def extract_pdf_text(upload: UploadedFile, *, max_chars: int = 12000) -> str:
+    """Return extracted text from a PDF upload truncated to ``max_chars`` characters."""
+
+    if not upload:
+        return ""
+
+    try:
+        upload.seek(0)
+    except (AttributeError, OSError):  # pragma: no cover - defensive guard
+        pass
+
+    if PdfReader is None:
+        return ""
+
+    reader = PdfReader(upload)
+    excerpts: List[str] = []
+    current_length = 0
+
+    for page in reader.pages:
+        page_text = page.extract_text() or ""
+        cleaned = page_text.strip()
+        if not cleaned:
+            continue
+        remaining = max_chars - current_length
+        if remaining <= 0:
+            break
+        excerpts.append(cleaned[:remaining])
+        current_length += len(excerpts[-1])
+
+    if not excerpts:
+        return ""
+
+    return "\n\n".join(excerpts)
+

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -15,7 +15,7 @@
   <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
     <div>
       <h3 class="text-base font-semibold text-[#14080E]">Concepts ready for review</h3>
-      <p class="text-sm text-slate-500">Pick the best direction to launch research and a first draft.</p>
+      <p class="text-sm text-slate-500">Pick the best direction to launch research and a first draft. Need to tweak context? Reopen the panel above and regenerate.</p>
     </div>
     {% if active_run %}
       <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">Run #{{ active_run.id }}</span>
@@ -43,6 +43,8 @@
           hx-post="{% url 'articles:staff_select_concept' %}"
           hx-target="#draft-workflow"
           hx-swap="innerHTML"
+          hx-indicator="#research-loading"
+          hx-on::after-request="if (event.detail.successful) { document.getElementById('research-accordion').setAttribute('open', 'open'); }"
           class="mt-4"
         >
           {% csrf_token %}

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -34,6 +34,7 @@
       hx-post="{% url 'articles:staff_finalize_article' %}"
       hx-target="#final-article-panel"
       hx-swap="innerHTML"
+      hx-indicator="#finalize-loading"
       class="space-y-4"
     >
       {% csrf_token %}
@@ -63,6 +64,10 @@
           Continue to final polish
         </button>
       </div>
+      <span id="finalize-loading" class="htmx-indicator inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <i class="fa-solid fa-circle-notch animate-spin" aria-hidden="true"></i>
+        Polishing…
+      </span>
     </form>
   </div>
 {% else %}

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -40,71 +40,101 @@
 
     <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
       <section class="space-y-6">
-        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <details
+          id="concepts-accordion"
+          class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5"
+          {% if not ideas %}open{% endif %}
+        >
+          <summary class="flex cursor-pointer list-none flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 class="text-lg font-semibold text-[#14080E]">1. Provide context &amp; generate concepts</h2>
-              <p class="text-sm text-slate-500 max-w-xl">Paste research context or upload excerpts to guide ideation. Only staff members can access this workflow.</p>
+              <p class="text-sm text-slate-500 max-w-xl">Paste research context or upload supporting PDFs to guide ideation.</p>
             </div>
+            <span id="concepts-loading" class="htmx-indicator inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <i class="fa-solid fa-circle-notch animate-spin" aria-hidden="true"></i>
+              Generating…
+            </span>
+          </summary>
+          <div class="space-y-4 pt-4">
+            <form
+              id="article-concepts-form"
+              method="post"
+              enctype="multipart/form-data"
+              hx-post="{% url 'articles:staff_generate_concepts' %}"
+              hx-target="#concepts-results"
+              hx-swap="innerHTML"
+              hx-encoding="multipart/form-data"
+              hx-indicator="#concepts-loading"
+              hx-on::after-request="if (event.detail.successful) { document.getElementById('concepts-accordion').removeAttribute('open'); }"
+              class="space-y-4"
+            >
+              {% csrf_token %}
+              <div class="grid gap-4 md:grid-cols-2">
+                <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                  {{ form.topic.label }}
+                  {{ form.topic }}
+                  {% if form.topic.help_text %}
+                    <span class="text-xs font-normal text-slate-500">{{ form.topic.help_text }}</span>
+                  {% endif %}
+                  {% for error in form.topic.errors %}
+                    <span class="text-xs text-red-600">{{ error }}</span>
+                  {% endfor %}
+                </label>
+              </div>
+              <div class="grid gap-4">
+                <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                  {{ form.context.label }}
+                  {{ form.context }}
+                  <span class="text-xs font-normal text-slate-500">{{ form.context.help_text }}</span>
+                  {% for error in form.context.errors %}
+                    <span class="text-xs text-red-600">{{ error }}</span>
+                  {% endfor %}
+                </label>
+                <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+                  {{ form.pdf_upload.label }}
+                  {{ form.pdf_upload }}
+                  <span class="text-xs font-normal text-slate-500">{{ form.pdf_upload.help_text }}</span>
+                  {% for error in form.pdf_upload.errors %}
+                    <span class="text-xs text-red-600">{{ error }}</span>
+                  {% endfor %}
+                </label>
+              </div>
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <p class="text-xs text-slate-500">AI cost is estimated from gpt-4.1-nano token usage and added to the run ledger.</p>
+                <button
+                  type="submit"
+                  class="inline-flex items-center justify-center gap-2 rounded-full bg-[#5C008B] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#460069]"
+                >
+                  <i class="fa-solid fa-sparkles" aria-hidden="true"></i>
+                  Generate concepts
+                </button>
+              </div>
+            </form>
           </div>
-          <form
-            id="article-concepts-form"
-            method="post"
-            hx-post="{% url 'articles:staff_generate_concepts' %}"
-            hx-target="#concepts-results"
-            hx-swap="innerHTML"
-            class="space-y-4"
-          >
-            {% csrf_token %}
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
-                {{ form.topic.label }}
-                {{ form.topic }}
-                {% if form.topic.help_text %}
-                  <span class="text-xs font-normal text-slate-500">{{ form.topic.help_text }}</span>
-                {% endif %}
-                {% for error in form.topic.errors %}
-                  <span class="text-xs text-red-600">{{ error }}</span>
-                {% endfor %}
-              </label>
-            </div>
-            <div class="grid gap-4">
-              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
-                {{ form.context.label }}
-                {{ form.context }}
-                <span class="text-xs font-normal text-slate-500">{{ form.context.help_text }}</span>
-                {% for error in form.context.errors %}
-                  <span class="text-xs text-red-600">{{ error }}</span>
-                {% endfor %}
-              </label>
-              <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
-                {{ form.references.label }}
-                {{ form.references }}
-                <span class="text-xs font-normal text-slate-500">{{ form.references.help_text }}</span>
-                {% for error in form.references.errors %}
-                  <span class="text-xs text-red-600">{{ error }}</span>
-                {% endfor %}
-              </label>
-            </div>
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-xs text-slate-500">AI cost is estimated from gpt-4.1-nano token usage and added to the run ledger.</p>
-              <button
-                type="submit"
-                class="inline-flex items-center justify-center gap-2 rounded-full bg-[#5C008B] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#460069]"
-              >
-                <i class="fa-solid fa-sparkles" aria-hidden="true"></i>
-                Generate concepts
-              </button>
-            </div>
-          </form>
-          <div id="concepts-results" class="space-y-4">
-            {% include "articles/_concept_results.html" with ideas=ideas active_run=active_run ideas_payload=ideas_payload only %}
-          </div>
+        </details>
+        <div id="concepts-results" class="space-y-4">
+          {% include "articles/_concept_results.html" with ideas=ideas active_run=active_run ideas_payload=ideas_payload only %}
         </div>
 
-        <div id="draft-workflow" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          {% include "articles/_draft_workflow.html" with run=active_run draft_form=draft_form citations=citations draft_summary=draft_summary selected_index=selected_index ideas=ideas only %}
-        </div>
+        <details
+          id="research-accordion"
+          class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+          {% if draft_form %}open{% endif %}
+        >
+          <summary class="flex cursor-pointer list-none flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-[#14080E]">2. Research &amp; draft review</h2>
+              <p class="text-sm text-slate-500 max-w-xl">Select a concept to gather citations, then edit the draft before final polish.</p>
+            </div>
+            <span id="research-loading" class="htmx-indicator inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <i class="fa-solid fa-circle-notch animate-spin" aria-hidden="true"></i>
+              Researching…
+            </span>
+          </summary>
+          <div class="mt-4" id="draft-workflow">
+            {% include "articles/_draft_workflow.html" with run=active_run draft_form=draft_form citations=citations draft_summary=draft_summary selected_index=selected_index ideas=ideas only %}
+          </div>
+        </details>
 
         <div id="final-article-panel" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
           {% include "articles/_final_article_panel.html" with article=final_article run=active_run final_payload=final_payload sources=citations only %}

--- a/articles/tests/test_staff_dashboard.py
+++ b/articles/tests/test_staff_dashboard.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+from django.core.files.uploadedfile import SimpleUploadedFile
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -56,7 +58,6 @@ class StaffDashboardTests(TestCase):
             {
                 "topic": "Inventory tactics",
                 "context": "Recent interviews about food waste.",
-                "references": "Research note",
             },
             HTTP_HX_REQUEST="true",
         )
@@ -68,6 +69,7 @@ class StaffDashboardTests(TestCase):
         ideas_step = RunStep.objects.get(run=run, name="ideas")
         self.assertEqual(len(ideas_step.output_payload["ideas"]), 2)
         self.assertGreater(run.cost_cents, 0)
+        self.assertEqual(ideas_step.input_payload.get("pdf_context"), "")
 
     @patch("articles.views.get_openai_client")
     def test_select_concept_creates_draft_step(self, mock_client_factory):
@@ -76,7 +78,7 @@ class StaffDashboardTests(TestCase):
             run=run,
             name="ideas",
             status="ok",
-            input_payload={"topic": "Inventory", "context": "Inventory", "references": "Research"},
+            input_payload={"topic": "Inventory", "context": "Inventory", "pdf_context": "Research"},
             output_payload={
                 "ideas": [
                     {"title": "Idea One", "subtitle": "Subtitle"},
@@ -113,6 +115,39 @@ class StaffDashboardTests(TestCase):
         draft_step = RunStep.objects.get(run=run, name="draft")
         self.assertEqual(draft_step.output_payload["summary"], "Outline summary")
         self.assertGreater(run.cost_cents, 0)
+
+    @patch("articles.views.extract_pdf_text", return_value="PDF insights")
+    @patch("articles.views.get_openai_client")
+    def test_generate_concepts_uses_pdf_upload(self, mock_client_factory, mock_extract):
+        ideas_payload = {
+            "ideas": [
+                {"title": "Idea One", "subtitle": "Subtitle", "angle": "Angle"},
+            ],
+        }
+        mock_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=lambda **_: self._make_openai_response(ideas_payload)
+            )
+        )
+        mock_client_factory.return_value = mock_client
+
+        pdf_file = SimpleUploadedFile("notes.pdf", b"%PDF-1.4 sample", content_type="application/pdf")
+
+        response = self.client.post(
+            reverse("articles:staff_generate_concepts"),
+            {
+                "topic": "Inventory tactics",
+                "context": "Recent interviews about food waste.",
+                "pdf_upload": pdf_file,
+            },
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_extract.assert_called_once()
+        run = ArticleRun.objects.get()
+        ideas_step = RunStep.objects.get(run=run, name="ideas")
+        self.assertEqual(ideas_step.input_payload.get("pdf_context"), "PDF insights")
 
     @patch("articles.views.get_openai_client")
     def test_finalize_article_creates_article(self, mock_client_factory):

--- a/articles/views.py
+++ b/articles/views.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Tuple
 
 from django import forms
 from django.contrib.admin.views.decorators import staff_member_required
+from django.core.validators import FileExtensionValidator
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
@@ -17,6 +18,59 @@ from .openai_helpers import (
     get_openai_client,
     parse_structured_payload,
 )
+from .pdf_utils import extract_pdf_text
+
+
+RESEARCH_RESPONSE_SCHEMA = {
+    "name": "article_research",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "summary": {"type": "string"},
+            "citations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "title": {"type": "string"},
+                        "url": {"type": "string"},
+                        "snippet": {"type": "string"},
+                        "source": {"type": "string"},
+                    },
+                    "required": ["title", "url"],
+                },
+            },
+            "draft": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "title": {"type": "string"},
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "heading": {"type": "string"},
+                                "paragraphs": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "body": {"type": "string"},
+                            },
+                            "required": ["heading"],
+                        },
+                    },
+                    "text": {"type": "string"},
+                },
+            },
+        },
+        "required": ["summary", "citations", "draft"],
+    },
+}
 
 
 class ArticleConceptForm(forms.Form):
@@ -37,11 +91,17 @@ class ArticleConceptForm(forms.Form):
         widget=forms.Textarea(attrs={"rows": 6, "class": "rounded-xl border border-slate-200 p-3"}),
         help_text="Paste summaries, insights, or research notes to ground the concepts.",
     )
-    references = forms.CharField(
-        label="Reference excerpts",
+    pdf_upload = forms.FileField(
+        label="Attach PDF research",
         required=False,
-        widget=forms.Textarea(attrs={"rows": 4, "class": "rounded-xl border border-slate-200 p-3"}),
-        help_text="Optional copy/paste of key quotes, statistics, or paper abstracts.",
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        widget=forms.ClearableFileInput(
+            attrs={
+                "accept": "application/pdf",
+                "class": "rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+            }
+        ),
+        help_text="Optional. Upload a PDF to extract text for the research context.",
     )
 
 
@@ -209,11 +269,15 @@ def staff_dashboard(request):
 
     active_run = None
     for run in runs:
-        if run.status in {"running", "queued", "failed"} or run.steps.exists():
+        article = articles_by_run.get(run.id)
+        if run.status in {"running", "queued", "failed"}:
             active_run = run
             break
-    if not active_run and runs:
-        active_run = runs[0]
+        if article and article.status == "published":
+            continue
+        if run.steps.exists():
+            active_run = run
+            break
 
     ideas: List[Dict[str, Any]] = []
     ideas_payload: Dict[str, Any] = {}
@@ -319,7 +383,7 @@ def _create_run_with_ideas(
 @staff_member_required
 @require_POST
 def staff_generate_concepts(request):
-    form = ArticleConceptForm(request.POST)
+    form = ArticleConceptForm(request.POST, request.FILES)
     if not form.is_valid():
         return _render_partial(
             request,
@@ -330,17 +394,20 @@ def staff_generate_concepts(request):
 
     topic = form.cleaned_data.get("topic") or "Independent restaurant operations"
     context_text = form.cleaned_data["context"]
-    references = form.cleaned_data.get("references", "")
+    pdf_upload = form.cleaned_data.get("pdf_upload")
+    pdf_text = extract_pdf_text(pdf_upload) if pdf_upload else ""
 
     client = get_openai_client()
     prompt = (
         "You are an editorial strategist for independent restaurants. "
         "Provide five distinct article concepts with a compelling title and subtitle. "
         "Return JSON with an 'ideas' list where each idea has 'title', 'subtitle', and 'angle'. "
-        "Use the research context and references to ground the suggestions."
-        f"\n\nContext:\n{context_text}\n\nReferences:\n{references}\n\n"
-        f"Working focus: {topic}"
+        "Use the research context and any extracted PDF insights to ground the suggestions."
+        f"\n\nContext:\n{context_text}\n\n"
     )
+    if pdf_text:
+        prompt += f"Extracted PDF notes:\n{pdf_text}\n\n"
+    prompt += f"Working focus: {topic}"
     response = client.responses.create(model="gpt-4.1-nano", input=prompt)
     response_dict = (
         response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
@@ -360,7 +427,7 @@ def staff_generate_concepts(request):
     run_payload = {
         "topic": topic,
         "context": context_text,
-        "references": references,
+        "pdf_context": pdf_text,
     }
     run = _create_run_with_ideas(
         request,
@@ -368,7 +435,7 @@ def staff_generate_concepts(request):
         normalized_ideas,
         model_payload=payload,
         response_dict=response_dict,
-        usage=getattr(response, "usage", None),
+        usage=getattr(response, "usage", None) or response_dict.get("usage"),
     )
 
     context = {
@@ -400,16 +467,21 @@ def staff_select_concept(request):
     selected_idea = ideas[idea_index]
     client = get_openai_client()
     prompt = (
-        "You are a research assistant with access to live search. "
-        "Given an article concept, the context, and references, compile supporting citations "
+        "You are a research assistant with access to live web search. "
+        "Given an article concept and research context, compile supporting citations "
         "and draft a structured outline with section headings and bullet paragraphs. "
-        "Return JSON with keys: summary, citations (list with title and url), draft (with title, sections, and optional text)."
+        "Return structured JSON with keys: summary, citations (list with title, url, and snippet), draft (with title, sections)."
         f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
         f"\n\nContext notes: {context_details.get('context', '')}"
-        f"\n\nReferences: {context_details.get('references', '')}"
+        f"\n\nExtracted PDF notes: {context_details.get('pdf_context', '')}"
         f"\n\nTopic focus: {context_details.get('topic', '')}"
     )
-    response = client.responses.create(model=run.model_info or "gpt-4.1-nano", input=prompt)
+    response = client.responses.create(
+        model=run.model_info or "gpt-4.1-nano",
+        input=prompt,
+        tools=[{"type": "web_search"}],
+        response_format={"type": "json_schema", "json_schema": RESEARCH_RESPONSE_SCHEMA},
+    )
     response_dict = (
         response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
     )
@@ -452,7 +524,7 @@ def staff_select_concept(request):
     run.status = "running"
     run.can_resume_from_step = False
     run.save(update_fields=["current_step", "status", "can_resume_from_step"])
-    _apply_usage_cost(run, getattr(response, "usage", None))
+    _apply_usage_cost(run, getattr(response, "usage", None) or response_dict.get("usage"))
 
     draft_form = ArticleDraftReviewForm(
         initial={
@@ -537,7 +609,7 @@ def staff_finalize_article(request):
             "ended_at": timezone.now(),
         },
     )
-    _apply_usage_cost(run, getattr(response, "usage", None))
+    _apply_usage_cost(run, getattr(response, "usage", None) or response_dict.get("usage"))
 
     article_defaults = {
         "title": payload.get("title") or draft_title,

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -383,6 +383,12 @@ class DashboardView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
         return [
             QuickAction(
+                label="Article Studio",
+                url=str(reverse_lazy("articles:staff_dashboard")),
+                description="Launch the staff-only article ideation and publishing flow.",
+                icon="newspaper",
+            ),
+            QuickAction(
                 label="Resend onboarding email",
                 url=str(reverse_lazy("onboarding-retry")),
                 description="Send a fresh activation email to nudge new users.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ python-dotenv  # to manage env vars locally
 requests
 stripe
 whitenoise
+pypdf
 django-q2
 celery
 cloudinary


### PR DESCRIPTION
## Summary
- allow staff to attach PDF research that is extracted and folded into article concept prompts while upgrading research calls to use the web_search tool and a strict schema
- refresh the staff article UI with accordion panels, HTMX indicators, and automatic collapsing plus skip auto-selecting completed runs; expose the workflow from the navigation and dashboard quick actions
- cover the new PDF flow with tests and add a lightweight PDF helper with an optional pypdf dependency

## Testing
- python manage.py test articles.tests.test_staff_dashboard --settings=specials.settings

------
https://chatgpt.com/codex/tasks/task_e_68dc0796f7ec83328ad75bd4e7e5e031