### PR TITLE
Integrate Outscraper webhook into leads pipeline

### DIFF
--- a/appertivo/leads/tasks.py
+++ b/appertivo/leads/tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Mapping, Sequence
 
 import requests
 from celery import shared_task
@@ -20,6 +20,101 @@ except ImportError:  # pragma: no cover - optional dependency for local dev
 
 from .models import Concept, DishIdea, Lead, LeadRun
 from .utils import pick_city
+
+
+DEFAULT_WEBHOOK_URL = "https://appertivo.com/leads/outscraper-webhook/"
+
+
+def get_outscraper_webhook_url() -> str:
+    """Return the configured Outscraper webhook URL for lead imports."""
+
+    return getattr(settings, "LEADS_OUTSCRAPER_WEBHOOK_URL", DEFAULT_WEBHOOK_URL)
+
+
+def extract_lead_entries(payload: object) -> list[dict]:
+    """Return a flat list of lead dictionaries from an Outscraper payload."""
+
+    if isinstance(payload, dict):
+        candidates = payload.get("data") or payload.get("results")
+        if isinstance(candidates, list):
+            if candidates and isinstance(candidates[0], list):
+                return [entry for entry in candidates[0] if isinstance(entry, dict)]
+            return [entry for entry in candidates if isinstance(entry, dict)]
+    elif isinstance(payload, list):
+        return [entry for entry in payload if isinstance(entry, dict)]
+    return []
+
+
+def resolve_outscraper_payload(payload: object, headers: Mapping[str, str] | None = None) -> object:
+    """Fetch Outscraper job results when the initial payload only includes metadata."""
+
+    if not isinstance(payload, dict):
+        return payload
+
+    if extract_lead_entries(payload):
+        return payload
+
+    results_url = payload.get("results_location")
+    request_headers = dict(headers or {})
+    if results_url:
+        try:
+            response = requests.get(results_url, headers=request_headers or None, timeout=60)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            logger.exception("Failed to download Outscraper results: %s", exc)
+
+    job_id = str(payload.get("id") or payload.get("job_id") or payload.get("task_id") or "").strip()
+    if not job_id:
+        return payload
+
+    job_url = f"https://api.app.outscraper.com/requests/{job_id}"
+    try:
+        response = requests.get(job_url, headers=request_headers or None, timeout=60)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        logger.exception("Failed to fetch Outscraper job %s: %s", job_id, exc)
+        return payload
+
+
+def store_lead_entries(entries: Sequence[Mapping[str, object]], *, city: str | None = None, run: LeadRun | None = None) -> list[int]:
+    """Create or update Lead objects for the supplied Outscraper entries."""
+
+    created_ids: list[int] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        lead_defaults: dict[str, object | None] = {
+            "name": entry.get("name") or entry.get("title") or "Unknown Restaurant",
+            "email": entry.get("email"),
+            "phone": entry.get("phone"),
+            "city": entry.get("city") or city,
+            "json_data": dict(entry),
+        }
+        if run is not None:
+            lead_defaults["run"] = run
+            lead_defaults["shortlisted"] = False
+        identifier = entry.get("email") or entry.get("phone") or entry.get("name")
+        if not identifier:
+            continue
+        email = entry.get("email")
+        if email:
+            lead, created = Lead.objects.update_or_create(
+                email=email,
+                defaults=lead_defaults,
+            )
+        else:
+            lead = Lead.objects.create(**lead_defaults)
+            created = True
+        if created:
+            created_ids.append(lead.id)
+        else:
+            for field, value in lead_defaults.items():
+                setattr(lead, field, value)
+            lead.save()
+            created_ids.append(lead.id)
+    return created_ids
 
 logger = logging.getLogger(__name__)
 
@@ -91,61 +186,32 @@ def fetch_leads(
 
     params = {
         "query": f"independent restaurants in {city}",
-        "limit": limit,
+        "limit": max(1, limit),
+        "async": "true",
+        "webhook": get_outscraper_webhook_url(),
+        "fields": "query,name,place_id,full_address,latitude,longitude,site,phone,type,description,category,subtypes,about,menu_link,order_links",
+        "enrichment": json.dumps(["domains_service"]),
     }
     headers = {"X-API-KEY": api_key}
     try:
         response = requests.get(
-            "https://api.app.outscraper.com/maps/search-business", params=params, headers=headers, timeout=60
+            "https://api.app.outscraper.com/maps/search-v3",
+            params=params,
+            headers=headers,
+            timeout=60,
         )
         response.raise_for_status()
     except requests.RequestException as exc:  # pragma: no cover - network failure
         logger.exception("Outscraper request failed: %s", exc)
         return []
 
-    payload = response.json()
-    if isinstance(payload, dict) and "data" in payload:
-        results: Sequence[dict] = payload.get("data", [])
-    elif isinstance(payload, list):
-        results = payload
-    else:
+    payload = resolve_outscraper_payload(response.json(), headers)
+    entries = extract_lead_entries(payload)
+    if not entries:
         logger.warning("Unexpected Outscraper payload: %s", payload)
         return []
 
-    created_ids: List[int] = []
-    for entry in results:
-        if not isinstance(entry, dict):
-            continue
-        lead_defaults = {
-            "name": entry.get("name") or entry.get("title") or "Unknown Restaurant",
-            "email": entry.get("email"),
-            "phone": entry.get("phone"),
-            "city": entry.get("city") or city,
-            "json_data": entry,
-        }
-        if run is not None:
-            lead_defaults["run"] = run
-            lead_defaults["shortlisted"] = False
-        identifier = entry.get("email") or entry.get("phone") or entry.get("name")
-        if not identifier:
-            continue
-        email = entry.get("email")
-        if email:
-            lead, created = Lead.objects.update_or_create(
-                email=email,
-                defaults=lead_defaults,
-            )
-        else:
-            lead = Lead.objects.create(**lead_defaults)
-            created = True
-        if created:
-            created_ids.append(lead.id)
-        else:
-            # When updating an existing lead ensure we keep slug and city aligned.
-            for field, value in lead_defaults.items():
-                setattr(lead, field, value)
-            lead.save()
-            created_ids.append(lead.id)
+    created_ids = store_lead_entries(entries, city=city, run=run)
     if run is not None:
         run.total_leads = len(created_ids)
         if created_ids:

--- a/appertivo/leads/tests/test_tasks.py
+++ b/appertivo/leads/tests/test_tasks.py
@@ -1,0 +1,93 @@
+"""Tests for Outscraper integration tasks in the leads app."""
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import django
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "specials.settings")
+django.setup()
+
+from appertivo.leads.models import Lead, LeadRun
+from appertivo.leads.tasks import fetch_leads
+
+
+class FetchLeadsTaskTests(TestCase):
+    """Verify the fetch_leads task integrates with Outscraper correctly."""
+
+    @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch("appertivo.leads.tasks.requests.get")
+    def test_fetch_leads_uses_async_job_and_webhook(self, mock_get: Mock) -> None:
+        run = LeadRun.objects.create(expected_leads=5)
+
+        first_response = Mock()
+        first_response.raise_for_status = Mock()
+        first_response.json.return_value = {"id": "job-123"}
+
+        second_response = Mock()
+        second_response.raise_for_status = Mock()
+        second_response.json.return_value = {
+            "data": [
+                {
+                    "name": "Sunset Bistro",
+                    "email": "owner@example.com",
+                    "phone": "555-0100",
+                    "city": "Austin, TX",
+                }
+            ]
+        }
+
+        mock_get.side_effect = [first_response, second_response]
+
+        lead_ids = fetch_leads(run_id=run.id, city="Austin, TX", limit=3)
+
+        self.assertEqual(len(lead_ids), 1)
+        self.assertEqual(mock_get.call_args_list[0].args[0], "https://api.app.outscraper.com/maps/search-v3")
+        params = mock_get.call_args_list[0].kwargs["params"]
+        self.assertEqual(params["async"], "true")
+        self.assertEqual(params["webhook"], "https://appertivo.com/leads/outscraper-webhook/")
+        self.assertEqual(params["enrichment"], json.dumps(["domains_service"]))
+        self.assertEqual(mock_get.call_args_list[1].args[0], "https://api.app.outscraper.com/requests/job-123")
+
+        lead = Lead.objects.get(pk=lead_ids[0])
+        self.assertEqual(lead.email, "owner@example.com")
+        self.assertEqual(lead.json_data["name"], "Sunset Bistro")
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, LeadRun.Status.PREPARING)
+
+
+class OutscraperWebhookViewTests(TestCase):
+    """Ensure the Outscraper webhook endpoint updates leads."""
+
+    @override_settings(OUTSCRAPER_API_KEY="test-key")
+    def test_webhook_updates_existing_lead_payload(self) -> None:
+        lead = Lead.objects.create(name="Old Name", email="owner@example.com")
+
+        payload = {
+            "data": [
+                {
+                    "name": "Updated Name",
+                    "email": "owner@example.com",
+                    "city": "Miami, FL",
+                    "phone": "555-0100",
+                }
+            ]
+        }
+
+        response = self.client.post(
+            reverse("outscraper_webhook"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["processed"], 1)
+
+        lead.refresh_from_db()
+        self.assertEqual(lead.name, "Updated Name")
+        self.assertEqual(lead.json_data["city"], "Miami, FL")

--- a/appertivo/leads/urls.py
+++ b/appertivo/leads/urls.py
@@ -7,6 +7,7 @@ from . import views
 
 urlpatterns = [
     path("leads/", views.lead_dashboard, name="lead-dashboard"),
+    path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
     path("leads/runs/start/", views.start_lead_run, name="lead-run-start"),
     path("leads/runs/<int:run_id>/", views.update_run_selection, name="lead-run-selection"),
     path("demo/<slug:slug>/", views.lead_landing, name="lead-landing"),

--- a/appertivo/leads/views.py
+++ b/appertivo/leads/views.py
@@ -1,14 +1,51 @@
 """Views for the leads landing experiences."""
 from __future__ import annotations
 
+import json
+import logging
+
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from .models import Lead, LeadRun
-from .tasks import build_lead_run_pipeline, send_personalized_email
+from .tasks import (
+    build_lead_run_pipeline,
+    extract_lead_entries,
+    resolve_outscraper_payload,
+    send_personalized_email,
+    store_lead_entries,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@csrf_exempt
+@require_POST
+def outscraper_webhook(request: HttpRequest) -> JsonResponse:
+    """Persist Outscraper webhook payloads onto matching lead records."""
+
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except json.JSONDecodeError:
+        return JsonResponse({"status": "error", "message": "Invalid JSON"}, status=400)
+
+    api_key = getattr(settings, "OUTSCRAPER_API_KEY", None)
+    headers = {"X-API-KEY": api_key} if api_key else None
+    resolved_payload = resolve_outscraper_payload(payload, headers)
+    entries = extract_lead_entries(resolved_payload)
+
+    if not entries:
+        logger.info("Received Outscraper webhook with no lead entries")
+        return JsonResponse({"status": "ok", "processed": 0})
+
+    lead_ids = store_lead_entries(entries, city=None, run=None)
+    logger.info("Processed %s leads from Outscraper webhook", len(lead_ids))
+    return JsonResponse({"status": "ok", "processed": len(lead_ids)})
 
 
 def lead_landing(request: HttpRequest, slug: str) -> HttpResponse:


### PR DESCRIPTION
## Summary
- update the leads fetch task to request Outscraper results asynchronously using the webhook URL and process the returned job payloads
- expose a webhook endpoint that ingests Outscraper callbacks and stores the received lead data
- add regression tests covering the async fetch flow and webhook persistence

## Testing
- python manage.py test appertivo.leads.tests.test_tasks

------
https://chatgpt.com/codex/tasks/task_e_68dc0e8d9220833291d2fc0ce434f290