### PR TITLE
Add polling workflow to article research flow

### DIFF
--- a/app/templates/layouts/app.html
+++ b/app/templates/layouts/app.html
@@ -10,8 +10,23 @@
 {% block extra_head %}
   <script>
     document.addEventListener("DOMContentLoaded", function () {
+      function getCsrfToken() {
+        const name = "csrftoken=";
+        const cookies = document.cookie ? document.cookie.split(";") : [];
+        for (const cookie of cookies) {
+          const trimmed = cookie.trim();
+          if (trimmed.startsWith(name)) {
+            return decodeURIComponent(trimmed.slice(name.length));
+          }
+        }
+        return null;
+      }
+
       document.body.addEventListener("htmx:configRequest", (event) => {
-        event.detail.headers["X-CSRFToken"] = "{{ csrf_token }}";
+        const token = getCsrfToken();
+        if (token) {
+          event.detail.headers["X-CSRFToken"] = token;
+        }
       });
     });
   </script>
@@ -127,6 +142,47 @@
       });
 
       window.addEventListener("resize", closeMenu);
+    });
+  </script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const overlay = document.getElementById("global-overlay");
+      const message = document.getElementById("overlay-message");
+      if (!overlay || !message) {
+        return;
+      }
+
+      let activeRequests = 0;
+
+      function showOverlay(text) {
+        message.textContent = text || "Working…";
+        overlay.classList.remove("hidden");
+      }
+
+      function hideOverlay() {
+        if (activeRequests === 0) {
+          overlay.classList.add("hidden");
+        }
+      }
+
+      document.body.addEventListener("htmx:beforeRequest", function (event) {
+        activeRequests += 1;
+        const elt = event.detail.elt;
+        const text = (elt && (elt.dataset.loadingMessage || elt.getAttribute("aria-label"))) || "Working…";
+        showOverlay(text);
+      });
+
+      function requestFinished() {
+        activeRequests = Math.max(activeRequests - 1, 0);
+        hideOverlay();
+      }
+
+      document.body.addEventListener("htmx:afterRequest", requestFinished);
+
+      document.body.addEventListener("htmx:responseError", function () {
+        message.textContent = "Something went wrong";
+        setTimeout(requestFinished, 1500);
+      });
     });
   </script>
   <script>

--- a/appertivo/leads/urls.py
+++ b/appertivo/leads/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("leads/", views.lead_dashboard, name="lead-dashboard"),
     path("leads/runs/start/", views.start_lead_run, name="lead-run-start"),
     path("leads/runs/<int:run_id>/", views.update_run_selection, name="lead-run-selection"),
-    path("leads/outscraper-webhook/" views.outscraper_webhook, name="outscraper_webhook"),
+    path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
     path("demo/<slug:slug>/", views.lead_landing, name="lead-landing"),
     path("demo/<slug:slug>/track/", views.track_open, name="lead-track"),
 ]

--- a/articles/schemas.py
+++ b/articles/schemas.py
@@ -1,0 +1,50 @@
+RESEARCH_RESPONSE_SCHEMA = {
+    "name": "article_research",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "summary": {"type": "string"},
+            "citations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "title": {"type": "string"},
+                        "url": {"type": "string"},
+                        "snippet": {"type": "string"},
+                        "source": {"type": "string"},
+                    },
+                    "required": ["title", "url"],
+                },
+            },
+            "draft": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "title": {"type": "string"},
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "heading": {"type": "string"},
+                                "paragraphs": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "body": {"type": "string"},
+                            },
+                            "required": ["heading"],
+                        },
+                    },
+                    "text": {"type": "string"},
+                },
+            },
+        },
+        "required": ["summary", "citations", "draft"],
+    },
+}

--- a/articles/tasks.py
+++ b/articles/tasks.py
@@ -14,6 +14,8 @@ from .openai_helpers import (
     parse_structured_payload,
 )
 from .pipeline import build_next_input, finalize_run, next_step_name, schedule_step
+from .schemas import RESEARCH_RESPONSE_SCHEMA
+from .utils import apply_usage_cost, ensure_dict, ensure_list, sections_to_markdown
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +89,90 @@ def run_step(step_id: int, *, client: Optional[Any] = None) -> None:
             finalize_run(run)
     except Exception as exc:  # pragma: no cover - network failure handling
         logger.exception("Step %s failed: %s", step.name, exc)
+        step.status = "failed"
+        step.error_message = str(exc)
+        step.ended_at = timezone.now()
+        step.save(update_fields=["status", "error_message", "ended_at"])
+        run.mark_failed(str(exc), step=step)
+
+
+def generate_research_draft(step_id: int, *, client: Optional[Any] = None) -> None:
+    step = RunStep.objects.select_related("run").get(id=step_id)
+    run = step.run
+    if run.status == "canceled":
+        logger.info("Run %s canceled before research", run.pk)
+        return
+
+    step.status = "running"
+    step.error_message = ""
+    step.save(update_fields=["status", "error_message"])
+
+    run.status = "running"
+    run.current_step = "draft"
+    run.can_resume_from_step = False
+    run.save(update_fields=["status", "current_step", "can_resume_from_step"])
+
+    payload = ensure_dict(step.input_payload)
+    selected_idea = ensure_dict(payload.get("selected"))
+    idea_index = payload.get("idea_index", 0)
+    context_details = ensure_dict(payload.get("context"))
+
+    client = client or get_openai_client()
+    prompt = (
+        "You are a research assistant with access to live web search. "
+        "Given an article concept and research context, compile supporting citations "
+        "and draft a structured outline with section headings and bullet paragraphs. "
+        "Return structured JSON with keys: summary, citations (list with title, url, and snippet), draft (with title, sections)."
+        f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
+        f"\n\nContext notes: {context_details.get('context', '')}"
+        f"\n\nExtracted PDF notes: {context_details.get('pdf_context', '')}"
+        f"\n\nTopic focus: {context_details.get('topic', '')}"
+    )
+
+    try:
+        response = client.responses.create(
+            model=run.model_info or "gpt-4.1-nano",
+            input=prompt,
+            tools=[{"type": "web_search"}],
+            response_format={"type": "json_schema", "json_schema": RESEARCH_RESPONSE_SCHEMA},
+        )
+        response_dict = (
+            response.model_dump()
+            if hasattr(response, "model_dump")
+            else getattr(response, "to_dict", lambda: {})()
+        )
+        parsed_payload = parse_structured_payload(extract_output_text(response))
+        citations = ensure_list(parsed_payload.get("citations"))
+        draft_data = ensure_dict(parsed_payload.get("draft"))
+        draft_markdown = (
+            parsed_payload.get("draft_markdown")
+            or draft_data.get("markdown")
+            or ""
+        )
+        if not draft_markdown:
+            sections = draft_data.get("sections")
+            if sections:
+                draft_markdown = sections_to_markdown(sections)
+            elif draft_data.get("text"):
+                draft_markdown = str(draft_data.get("text"))
+
+        step.status = "ok"
+        step.output_payload = {
+            "summary": parsed_payload.get("summary", ""),
+            "citations": citations,
+            "draft": draft_data,
+            "draft_markdown": draft_markdown,
+            "idea_index": idea_index,
+            "title": draft_data.get("title", selected_idea.get("title", "")),
+        }
+        step.raw_response = response_dict
+        step.ended_at = timezone.now()
+        step.save(update_fields=["status", "output_payload", "raw_response", "ended_at"])
+
+        usage = getattr(response, "usage", None) or response_dict.get("usage")
+        apply_usage_cost(run, usage)
+    except Exception as exc:  # pragma: no cover - network failure handling
+        logger.exception("Draft research step failed: %s", exc)
         step.status = "failed"
         step.error_message = str(exc)
         step.ended_at = timezone.now()

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -46,6 +46,7 @@
           hx-indicator="#research-loading"
           hx-on::after-request="if (event.detail.successful) { document.getElementById('research-accordion').setAttribute('open', 'open'); }"
           class="mt-4"
+          data-loading-message="Researching concept…"
         >
           {% csrf_token %}
           <input type="hidden" name="run_id" value="{{ active_run.id }}">

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -1,4 +1,10 @@
-{% if draft_form %}
+{% if draft_status == "failed" %}
+  <div class="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+    <p class="font-semibold">Research attempt failed.</p>
+    <p class="mt-2">{{ draft_error|default:"We couldn't finish gathering research." }}</p>
+    <p class="mt-2 text-xs text-red-600/80">Select the concept again or adjust the context to retry.</p>
+  </div>
+{% elif draft_form %}
   <div class="flex flex-col gap-4">
     <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
@@ -36,6 +42,7 @@
       hx-swap="innerHTML"
       hx-indicator="#finalize-loading"
       class="space-y-4"
+      data-loading-message="Polishing the draft…"
     >
       {% csrf_token %}
       {{ draft_form.run_id }}
@@ -69,6 +76,24 @@
         Polishing…
       </span>
     </form>
+  </div>
+{% elif run and draft_pending %}
+  <div
+    class="flex flex-col gap-3 rounded-2xl border border-indigo-200 bg-indigo-50 p-4"
+    hx-get="{% url 'articles:staff_draft_status' run.id %}"
+    hx-trigger="load, every 6s"
+    hx-target="#draft-workflow"
+    hx-swap="outerHTML"
+    data-loading-message="Gathering research…"
+  >
+    <div class="flex items-center gap-2 text-sm font-semibold text-indigo-700">
+      <i class="fa-solid fa-magnifying-glass-chart" aria-hidden="true"></i>
+      Research in progress
+    </div>
+    <p class="text-sm text-indigo-900">We’re gathering citations and an outline. Feel free to navigate away—this panel will refresh automatically.</p>
+    {% if selected_idea and selected_idea.title %}
+      <p class="text-xs text-indigo-800">Concept: <span class="font-semibold">{{ selected_idea.title }}</span></p>
+    {% endif %}
   </div>
 {% else %}
   <div class="flex flex-col items-start gap-2">

--- a/articles/templates/articles/_run_list.html
+++ b/articles/templates/articles/_run_list.html
@@ -11,6 +11,21 @@
             <div class="flex items-center gap-2 text-xs">
               <span class="rounded-full px-2.5 py-1 font-semibold {% if run.status == 'completed' %}bg-emerald-100 text-emerald-700{% elif run.status == 'failed' %}bg-red-100 text-red-700{% else %}bg-amber-100 text-amber-700{% endif %}">{{ run.get_status_display }}</span>
               <span class="rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-600">${{ cost|default:0|floatformat:2 }}</span>
+              <form
+                method="post"
+                hx-post="{% url 'articles:staff_delete_run' run.id %}"
+                hx-target="#runs-panel"
+                hx-swap="innerHTML"
+                hx-confirm="Delete this run and its drafts?"
+                data-loading-message="Deleting run…"
+                class="inline"
+              >
+                {% csrf_token %}
+                <button type="submit" class="inline-flex items-center justify-center rounded-full border border-red-100 bg-white px-2 py-1 text-[11px] font-semibold text-red-600 transition hover:bg-red-50">
+                  <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
+                  <span class="ml-1 hidden sm:inline">Delete</span>
+                </button>
+              </form>
             </div>
           </div>
           {% if run.current_step %}

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -14,26 +14,40 @@
 
 {% block page_content %}
   <div class="px-4 py-6 space-y-6">
-    <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 class="text-lg font-semibold text-[#14080E]">Workflow overview</h2>
-      <p class="mt-1 text-sm text-slate-500 max-w-3xl">
-        This dashboard guides staff-only article production. Start with research context, validate the AI draft, then approve the final SEO-optimized article.
-      </p>
-      <ol class="mt-4 grid gap-4 md:grid-cols-3">
-        <li class="rounded-2xl border border-[#E8D5FF] bg-[#F7F2FF] p-4">
-          <p class="text-xs font-semibold uppercase text-[#7B1FA2]">Step 1</p>
-          <h3 class="mt-2 text-base font-semibold text-[#2E005D]">Generate article concepts</h3>
-          <p class="mt-2 text-sm text-slate-600">Paste context from research papers or notes, then let AI propose five article directions.</p>
+    <section class="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div class="max-w-3xl space-y-1">
+          <h2 class="text-lg font-semibold text-[#14080E]">Workflow overview</h2>
+          <p class="text-sm text-slate-500">
+            Move from research context to ready-to-publish articles. Each step can pause safely so you can return when long-running jobs finish.
+          </p>
+        </div>
+        <div class="hidden md:flex items-center gap-2 rounded-full bg-[#F5F1FF] px-3 py-1 text-xs font-semibold text-[#5C008B]">
+          <i class="fa-solid fa-clock" aria-hidden="true"></i>
+          Auto-saves every stage
+        </div>
+      </div>
+      <ol class="mt-4 grid gap-3 md:grid-cols-3">
+        <li class="flex items-start gap-3 rounded-2xl border border-[#E8D5FF] bg-[#FBF8FF] p-3">
+          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#7B1FA2] text-xs font-semibold text-white">1</span>
+          <div class="space-y-1">
+            <h3 class="text-sm font-semibold text-[#2E005D]">Generate concepts</h3>
+            <p class="text-xs text-slate-600">Share context or upload research for tailored article directions.</p>
+          </div>
         </li>
-        <li class="rounded-2xl border border-[#FFE3CC] bg-[#FFF7F0] p-4">
-          <p class="text-xs font-semibold uppercase text-[#FF5C00]">Step 2</p>
-          <h3 class="mt-2 text-base font-semibold text-[#B54D00]">Research &amp; draft</h3>
-          <p class="mt-2 text-sm text-slate-600">Pick the best concept to generate a sourced outline and editable draft. Make inline edits before continuing.</p>
+        <li class="flex items-start gap-3 rounded-2xl border border-[#FFE3CC] bg-[#FFF8F2] p-3">
+          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#FF5C00] text-xs font-semibold text-white">2</span>
+          <div class="space-y-1">
+            <h3 class="text-sm font-semibold text-[#B54D00]">Research &amp; draft</h3>
+            <p class="text-xs text-slate-600">Polling keeps progress updated while citations and drafts are prepared.</p>
+          </div>
         </li>
-        <li class="rounded-2xl border border-[#C7F0D8] bg-[#F0FFF6] p-4">
-          <p class="text-xs font-semibold uppercase text-[#2F855A]">Step 3</p>
-          <h3 class="mt-2 text-base font-semibold text-[#1E6A45]">Finalize &amp; publish</h3>
-          <p class="mt-2 text-sm text-slate-600">Approve the polished article with SEO metadata and publish when ready. Costs are tracked from Nano 4.1 usage.</p>
+        <li class="flex items-start gap-3 rounded-2xl border border-[#C7F0D8] bg-[#F4FFF9] p-3">
+          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#2F855A] text-xs font-semibold text-white">3</span>
+          <div class="space-y-1">
+            <h3 class="text-sm font-semibold text-[#1E6A45]">Finalize &amp; publish</h3>
+            <p class="text-xs text-slate-600">Polish copy, approve SEO, and publish straight to the library.</p>
+          </div>
         </li>
       </ol>
     </section>
@@ -67,6 +81,7 @@
               hx-indicator="#concepts-loading"
               hx-on::after-request="if (event.detail.successful) { document.getElementById('concepts-accordion').removeAttribute('open'); }"
               class="space-y-4"
+              data-loading-message="Generating article concepts…"
             >
               {% csrf_token %}
               <div class="grid gap-4 md:grid-cols-2">
@@ -104,6 +119,7 @@
                 <button
                   type="submit"
                   class="inline-flex items-center justify-center gap-2 rounded-full bg-[#5C008B] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#460069]"
+                  data-loading-message="Generating article concepts…"
                 >
                   <i class="fa-solid fa-sparkles" aria-hidden="true"></i>
                   Generate concepts
@@ -150,10 +166,11 @@
           <div
             id="runs-panel"
             hx-get="{% url 'articles:staff_runs_fragment' %}"
-            hx-trigger="load, articles:refresh-runs from:body"
+            hx-trigger="load, every 20s, articles:refresh-runs from:body"
             hx-target="this"
             hx-swap="innerHTML"
             class="mt-4"
+            data-loading-message="Refreshing run history…"
           >
             {% include "articles/_run_list.html" with runs_with_meta=runs_with_meta only %}
           </div>
@@ -161,4 +178,12 @@
       </aside>
     </div>
   </div>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document.body.addEventListener("articles:refresh-dashboard", function () {
+        window.location.reload();
+      });
+    });
+  </script>
 {% endblock %}

--- a/articles/tests/test_staff_dashboard.py
+++ b/articles/tests/test_staff_dashboard.py
@@ -71,7 +71,16 @@ class StaffDashboardTests(TestCase):
         self.assertGreater(run.cost_cents, 0)
         self.assertEqual(ideas_step.input_payload.get("pdf_context"), "")
 
-    @patch("articles.views.get_openai_client")
+    def test_generate_concepts_requires_context_or_pdf(self):
+        response = self.client.post(
+            reverse("articles:staff_generate_concepts"),
+            {"topic": "Inventory tactics", "context": ""},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Add brief context", response.content.decode())
+
+    @patch("articles.tasks.get_openai_client")
     def test_select_concept_creates_draft_step(self, mock_client_factory):
         run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="ideas")
         RunStep.objects.create(
@@ -116,6 +125,36 @@ class StaffDashboardTests(TestCase):
         self.assertEqual(draft_step.output_payload["summary"], "Outline summary")
         self.assertGreater(run.cost_cents, 0)
 
+    @patch("articles.views.async_task")
+    def test_select_concept_returns_polling_when_pending(self, mock_async_task):
+        mock_async_task.side_effect = lambda *_, **__: None
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="ideas")
+        RunStep.objects.create(
+            run=run,
+            name="ideas",
+            status="ok",
+            input_payload={"topic": "Inventory", "context": "Inventory", "pdf_context": "Research"},
+            output_payload={
+                "ideas": [
+                    {"title": "Idea One", "subtitle": "Subtitle"},
+                ],
+                "notes": "Notes",
+            },
+        )
+
+        response = self.client.post(
+            reverse("articles:staff_select_concept"),
+            {"run_id": run.id, "idea_index": 0},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Research in progress", content)
+        draft_step = RunStep.objects.get(run=run, name="draft")
+        self.assertEqual(draft_step.status, "queued")
+        self.assertEqual(draft_step.output_payload, {})
+
     @patch("articles.views.extract_pdf_text", return_value="PDF insights")
     @patch("articles.views.get_openai_client")
     def test_generate_concepts_uses_pdf_upload(self, mock_client_factory, mock_extract):
@@ -137,7 +176,7 @@ class StaffDashboardTests(TestCase):
             reverse("articles:staff_generate_concepts"),
             {
                 "topic": "Inventory tactics",
-                "context": "Recent interviews about food waste.",
+                "context": "",
                 "pdf_upload": pdf_file,
             },
             HTTP_HX_REQUEST="true",
@@ -148,6 +187,29 @@ class StaffDashboardTests(TestCase):
         run = ArticleRun.objects.get()
         ideas_step = RunStep.objects.get(run=run, name="ideas")
         self.assertEqual(ideas_step.input_payload.get("pdf_context"), "PDF insights")
+
+    def test_staff_draft_status_returns_partial(self):
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="draft")
+        RunStep.objects.create(
+            run=run,
+            name="draft",
+            status="ok",
+            input_payload={"selected": {"title": "Idea One"}, "idea_index": 0},
+            output_payload={
+                "summary": "Outline summary",
+                "citations": [{"title": "Source", "url": "https://example.com"}],
+                "draft_markdown": "## Intro\nBody",
+                "idea_index": 0,
+            },
+        )
+
+        response = self.client.get(
+            reverse("articles:staff_draft_status", kwargs={"run_id": run.id}),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Research summary", response.content.decode())
 
     @patch("articles.views.get_openai_client")
     def test_finalize_article_creates_article(self, mock_client_factory):
@@ -220,6 +282,18 @@ class StaffDashboardTests(TestCase):
         self.assertEqual(response.status_code, 200)
         article.refresh_from_db()
         self.assertEqual(article.status, "published")
+
+    def test_delete_run_removes_run(self):
+        run = ArticleRun.objects.create(created_by=self.staff_user, status="running")
+        Article.objects.create(title="Draft", slug="draft", body_markdown="Body", run=run)
+
+        response = self.client.post(
+            reverse("articles:staff_delete_run", kwargs={"run_id": run.id}),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(ArticleRun.objects.filter(id=run.id).exists())
 
     def test_runs_fragment_renders(self):
         ArticleRun.objects.create(created_by=self.staff_user)

--- a/articles/urls.py
+++ b/articles/urls.py
@@ -8,8 +8,10 @@ urlpatterns = [
     path("staff/articles/", views.staff_dashboard, name="staff_dashboard"),
     path("staff/articles/generate/", views.staff_generate_concepts, name="staff_generate_concepts"),
     path("staff/articles/concept/", views.staff_select_concept, name="staff_select_concept"),
+    path("staff/articles/runs/<int:run_id>/status/", views.staff_draft_status, name="staff_draft_status"),
     path("staff/articles/finalize/", views.staff_finalize_article, name="staff_finalize_article"),
     path("staff/articles/publish/", views.staff_publish_article, name="staff_publish_article"),
+    path("staff/articles/runs/<int:run_id>/delete/", views.staff_delete_run, name="staff_delete_run"),
     path("staff/articles/runs/", views.staff_runs_fragment, name="staff_runs_fragment"),
     path("articles/", views.article_index, name="article_index"),
     path(

--- a/articles/utils.py
+++ b/articles/utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+
+from typing import Any, Dict, List
+
+from .openai_helpers import calculate_nano_cost_cents
+
+
+def ensure_dict(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            data = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(data, dict):
+            return data
+    return {}
+
+
+def ensure_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        try:
+            data = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, list):
+            return data
+    return []
+
+
+def sections_to_markdown(sections: Any) -> str:
+    if not isinstance(sections, list):
+        return ""
+    lines: List[str] = []
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        heading = section.get("heading") or section.get("h2")
+        if heading:
+            lines.append(f"## {heading}".strip())
+        paragraphs = section.get("paragraphs")
+        if isinstance(paragraphs, list):
+            for paragraph in paragraphs:
+                if paragraph:
+                    lines.append(str(paragraph).strip())
+        elif section.get("body"):
+            lines.append(str(section["body"]).strip())
+        lines.append("")
+    return "\n".join(line for line in lines if line is not None).strip()
+
+
+def apply_usage_cost(run, usage: Any) -> None:
+    cost_cents = calculate_nano_cost_cents(usage)
+    if cost_cents:
+        run.cost_cents += cost_cents
+        run.save(update_fields=["cost_cents"])

--- a/articles/views.py
+++ b/articles/views.py
@@ -10,67 +10,13 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
+from django_q.tasks import async_task
 
 from .models import Article, ArticleRun, RunStep
-from .openai_helpers import (
-    calculate_nano_cost_cents,
-    extract_output_text,
-    get_openai_client,
-    parse_structured_payload,
-)
+from .openai_helpers import extract_output_text, get_openai_client, parse_structured_payload
 from .pdf_utils import extract_pdf_text
-
-
-RESEARCH_RESPONSE_SCHEMA = {
-    "name": "article_research",
-    "strict": True,
-    "schema": {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "summary": {"type": "string"},
-            "citations": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "properties": {
-                        "title": {"type": "string"},
-                        "url": {"type": "string"},
-                        "snippet": {"type": "string"},
-                        "source": {"type": "string"},
-                    },
-                    "required": ["title", "url"],
-                },
-            },
-            "draft": {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    "title": {"type": "string"},
-                    "sections": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "heading": {"type": "string"},
-                                "paragraphs": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                },
-                                "body": {"type": "string"},
-                            },
-                            "required": ["heading"],
-                        },
-                    },
-                    "text": {"type": "string"},
-                },
-            },
-        },
-        "required": ["summary", "citations", "draft"],
-    },
-}
+from .schemas import RESEARCH_RESPONSE_SCHEMA
+from .utils import apply_usage_cost, ensure_dict, ensure_list, sections_to_markdown
 
 
 class ArticleConceptForm(forms.Form):
@@ -88,8 +34,9 @@ class ArticleConceptForm(forms.Form):
     )
     context = forms.CharField(
         label="Research context",
+        required=False,
         widget=forms.Textarea(attrs={"rows": 6, "class": "rounded-xl border border-slate-200 p-3"}),
-        help_text="Paste summaries, insights, or research notes to ground the concepts.",
+        help_text="Optional unless you upload a PDF — add quick notes to ground the concepts.",
     )
     pdf_upload = forms.FileField(
         label="Attach PDF research",
@@ -101,8 +48,19 @@ class ArticleConceptForm(forms.Form):
                 "class": "rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
             }
         ),
-        help_text="Optional. Upload a PDF to extract text for the research context.",
+        help_text="Optional. Uploading research counts as context if you prefer not to type notes.",
     )
+
+    def clean(self) -> Dict[str, Any]:
+        cleaned_data = super().clean()
+        context_text = (cleaned_data.get("context") or "").strip()
+        pdf = cleaned_data.get("pdf_upload")
+        if not context_text and not pdf:
+            raise forms.ValidationError(
+                "Add brief context notes or attach a research PDF so the model has guidance."
+            )
+        cleaned_data["context"] = context_text
+        return cleaned_data
 
 
 class ArticleConceptChoiceForm(forms.Form):
@@ -128,32 +86,6 @@ class ArticlePublishForm(forms.Form):
     article_id = forms.IntegerField()
 
 
-def _ensure_dict(value: Any) -> Dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            data = json.loads(value)
-            if isinstance(data, dict):
-                return data
-        except json.JSONDecodeError:
-            return {}
-    return {}
-
-
-def _ensure_list(value: Any) -> List[Any]:
-    if isinstance(value, list):
-        return value
-    if isinstance(value, str):
-        try:
-            data = json.loads(value)
-            if isinstance(data, list):
-                return data
-        except json.JSONDecodeError:
-            return []
-    return []
-
-
 def _get_run_for_request(request, run_id: int) -> ArticleRun:
     return get_object_or_404(
         ArticleRun.objects.prefetch_related("steps"),
@@ -175,39 +107,75 @@ def _gather_run_context(
             draft_step = step
         elif step.name == "seo":
             final_step = step
-    ideas_payload = _ensure_dict(ideas_step.output_payload if ideas_step else {})
-    draft_payload = _ensure_dict(draft_step.output_payload if draft_step else {})
-    final_payload = _ensure_dict(final_step.output_payload if final_step else {})
-    ideas = _ensure_list(ideas_payload.get("ideas"))
+    ideas_payload = ensure_dict(ideas_step.output_payload if ideas_step else {})
+    draft_payload = ensure_dict(draft_step.output_payload if draft_step else {})
+    final_payload = ensure_dict(final_step.output_payload if final_step else {})
+    ideas = ensure_list(ideas_payload.get("ideas"))
     return ideas, ideas_payload, draft_payload, final_payload
 
 
-def _sections_to_markdown(sections: Any) -> str:
-    if not isinstance(sections, list):
-        return ""
-    lines: List[str] = []
-    for section in sections:
-        if not isinstance(section, dict):
-            continue
-        heading = section.get("heading") or section.get("h2")
-        if heading:
-            lines.append(f"## {heading}".strip())
-        paragraphs = section.get("paragraphs")
-        if isinstance(paragraphs, list):
-            for paragraph in paragraphs:
-                if paragraph:
-                    lines.append(str(paragraph).strip())
-        elif section.get("body"):
-            lines.append(str(section["body"]).strip())
-        lines.append("")
-    return "\n".join(line for line in lines if line is not None).strip()
+def _prepare_draft_details(
+    run: ArticleRun | None,
+    ideas: List[Dict[str, Any]],
+    draft_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    details: Dict[str, Any] = {
+        "draft_form": None,
+        "citations": [],
+        "draft_summary": "",
+        "selected_index": None,
+        "selected_idea": None,
+        "draft_status": None,
+        "draft_error": "",
+        "draft_pending": False,
+    }
+    if not run:
+        return details
 
+    draft_step = run.steps.filter(name="draft").first()
+    details["draft_status"] = draft_step.status if draft_step else None
+    details["draft_error"] = (draft_step.error_message or "") if draft_step else ""
+    details["draft_pending"] = draft_step.status in {"queued", "running"} if draft_step else False
 
-def _apply_usage_cost(run: ArticleRun, usage: Any) -> None:
-    cost_cents = calculate_nano_cost_cents(usage)
-    if cost_cents:
-        run.cost_cents += cost_cents
-        run.save(update_fields=["cost_cents"])
+    citations = ensure_list(draft_payload.get("citations"))
+    draft_summary = draft_payload.get("summary", "")
+    selected_index = draft_payload.get("idea_index")
+    selected_idea = None
+    if selected_index is not None and 0 <= selected_index < len(ideas):
+        selected_idea = ideas[selected_index]
+
+    draft_markdown = draft_payload.get("draft_markdown") or ""
+    draft_data = ensure_dict(draft_payload.get("draft"))
+    if not draft_markdown:
+        sections = draft_data.get("sections")
+        if sections:
+            draft_markdown = sections_to_markdown(sections)
+        elif draft_data.get("text"):
+            draft_markdown = str(draft_data.get("text"))
+
+    draft_title = draft_payload.get("title") or ""
+    if not draft_title and selected_idea:
+        draft_title = selected_idea.get("title", "")
+
+    details.update(
+        {
+            "citations": citations,
+            "draft_summary": draft_summary,
+            "selected_index": selected_index,
+            "selected_idea": selected_idea,
+        }
+    )
+
+    if draft_markdown:
+        details["draft_form"] = ArticleDraftReviewForm(
+            initial={
+                "run_id": run.id,
+                "draft_title": draft_title or "",
+                "draft_body": draft_markdown,
+            }
+        )
+
+    return details
 
 
 def article_index(request):
@@ -283,43 +251,13 @@ def staff_dashboard(request):
     ideas_payload: Dict[str, Any] = {}
     draft_payload: Dict[str, Any] = {}
     final_payload: Dict[str, Any] = {}
-    draft_markdown = ""
-    draft_title = ""
-    selected_index = None
-    citations: List[Dict[str, Any]] = []
     final_article = None
-    draft_summary = ""
-    selected_idea = None
 
     if active_run:
         ideas, ideas_payload, draft_payload, final_payload = _gather_run_context(active_run)
-        selected_index = draft_payload.get("idea_index")
-        citations = _ensure_list(draft_payload.get("citations"))
-        draft_markdown = draft_payload.get("draft_markdown") or ""
-        draft_data = _ensure_dict(draft_payload.get("draft"))
-        if not draft_markdown:
-            sections = draft_data.get("sections")
-            if sections:
-                draft_markdown = _sections_to_markdown(sections)
-            elif draft_data.get("text"):
-                draft_markdown = str(draft_data.get("text"))
-        if selected_index is not None and 0 <= selected_index < len(ideas):
-            draft_title = draft_payload.get("title") or ideas[selected_index].get("title", "")
-            selected_idea = ideas[selected_index]
-        else:
-            draft_title = draft_payload.get("title", "")
-        draft_summary = draft_payload.get("summary", "")
         final_article = articles_by_run.get(active_run.id)
 
-    draft_form = None
-    if active_run and draft_markdown:
-        draft_form = ArticleDraftReviewForm(
-            initial={
-                "run_id": active_run.id,
-                "draft_title": draft_title or "",
-                "draft_body": draft_markdown,
-            }
-        )
+    draft_details = _prepare_draft_details(active_run, ideas, draft_payload)
 
     context = {
         "form": concept_form,
@@ -330,14 +268,17 @@ def staff_dashboard(request):
         "active_run": active_run,
         "ideas": ideas,
         "ideas_payload": ideas_payload,
-        "selected_index": selected_index,
-        "draft_form": draft_form,
+        "selected_index": draft_details["selected_index"],
+        "draft_form": draft_details["draft_form"],
         "draft_payload": draft_payload,
-        "citations": citations,
-        "draft_summary": draft_summary,
+        "citations": draft_details["citations"],
+        "draft_summary": draft_details["draft_summary"],
         "final_payload": final_payload,
         "final_article": final_article,
-        "selected_idea": selected_idea,
+        "selected_idea": draft_details["selected_idea"],
+        "draft_status": draft_details["draft_status"],
+        "draft_error": draft_details["draft_error"],
+        "draft_pending": draft_details["draft_pending"],
         "run_cost": (active_run.cost_cents or 0) / 100 if active_run else 0,
     }
     return render(request, "articles/staff_dashboard.html", context)
@@ -376,7 +317,7 @@ def _create_run_with_ideas(
         raw_response=response_dict,
         ended_at=timezone.now(),
     )
-    _apply_usage_cost(run, usage)
+    apply_usage_cost(run, usage)
     return run
 
 
@@ -413,7 +354,7 @@ def staff_generate_concepts(request):
         response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
     )
     payload = parse_structured_payload(extract_output_text(response))
-    ideas = _ensure_list(payload.get("ideas"))
+    ideas = ensure_list(payload.get("ideas"))
     normalized_ideas: List[Dict[str, Any]] = []
     for idea in ideas:
         if isinstance(idea, dict):
@@ -456,95 +397,114 @@ def staff_select_concept(request):
         return HttpResponseBadRequest("Invalid concept selection")
 
     run = _get_run_for_request(request, form.cleaned_data["run_id"])
-    ideas, ideas_payload, draft_payload, _ = _gather_run_context(run)
+    ideas, _ideas_payload, draft_payload, _ = _gather_run_context(run)
     ideas_step = run.steps.filter(name="ideas").first()
-    context_details = _ensure_dict(ideas_step.input_payload if ideas_step else {})
+    context_details = ensure_dict(ideas_step.input_payload if ideas_step else {})
 
     idea_index = form.cleaned_data["idea_index"]
     if idea_index >= len(ideas):
         return HttpResponseBadRequest("Concept not found for this run")
 
     selected_idea = ideas[idea_index]
-    client = get_openai_client()
-    prompt = (
-        "You are a research assistant with access to live web search. "
-        "Given an article concept and research context, compile supporting citations "
-        "and draft a structured outline with section headings and bullet paragraphs. "
-        "Return structured JSON with keys: summary, citations (list with title, url, and snippet), draft (with title, sections)."
-        f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
-        f"\n\nContext notes: {context_details.get('context', '')}"
-        f"\n\nExtracted PDF notes: {context_details.get('pdf_context', '')}"
-        f"\n\nTopic focus: {context_details.get('topic', '')}"
-    )
-    response = client.responses.create(
-        model=run.model_info or "gpt-4.1-nano",
-        input=prompt,
-        tools=[{"type": "web_search"}],
-        response_format={"type": "json_schema", "json_schema": RESEARCH_RESPONSE_SCHEMA},
-    )
-    response_dict = (
-        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
-    )
-    payload = parse_structured_payload(extract_output_text(response))
-    citations = _ensure_list(payload.get("citations"))
-    draft_data = _ensure_dict(payload.get("draft"))
-    draft_markdown = payload.get("draft_markdown") or draft_data.get("markdown") or ""
-    if not draft_markdown:
-        sections = draft_data.get("sections")
-        if sections:
-            draft_markdown = _sections_to_markdown(sections)
-        elif draft_data.get("text"):
-            draft_markdown = str(draft_data.get("text"))
 
-    RunStep.objects.update_or_create(
+    step_input = {
+        "selected": selected_idea,
+        "idea_index": idea_index,
+        "context": context_details,
+    }
+
+    draft_step, created = RunStep.objects.update_or_create(
         run=run,
         name="draft",
         defaults={
-            "status": "ok",
-            "input_payload": {
-                "selected": selected_idea,
-                "idea_index": idea_index,
-                "context": context_details,
-            },
-            "output_payload": {
-                "summary": payload.get("summary", ""),
-                "citations": citations,
-                "draft": draft_data,
-                "draft_markdown": draft_markdown,
-                "idea_index": idea_index,
-                "title": draft_data.get("title", selected_idea.get("title", "")),
-            },
-            "raw_response": response_dict,
-            "status": "ok",
+            "status": "queued",
+            "input_payload": step_input,
+            "output_payload": {},
+            "raw_response": {},
             "error_message": "",
-            "ended_at": timezone.now(),
+            "ended_at": None,
         },
     )
+    if not created:
+        RunStep.objects.filter(pk=draft_step.pk).update(
+            status="queued",
+            input_payload=step_input,
+            output_payload={},
+            raw_response={},
+            error_message="",
+            ended_at=None,
+        )
+        draft_step.refresh_from_db()
+
     run.current_step = "draft"
     run.status = "running"
     run.can_resume_from_step = False
     run.save(update_fields=["current_step", "status", "can_resume_from_step"])
-    _apply_usage_cost(run, getattr(response, "usage", None) or response_dict.get("usage"))
 
-    draft_form = ArticleDraftReviewForm(
-        initial={
-            "run_id": run.id,
-            "draft_title": draft_data.get("title", selected_idea.get("title", "")),
-            "draft_body": draft_markdown,
-        }
-    )
+    async_task("articles.tasks.generate_research_draft", draft_step.id)
+
+    run.refresh_from_db()
+    draft_step.refresh_from_db()
+    ideas, _ideas_payload, draft_payload, _ = _gather_run_context(run)
+    draft_details = _prepare_draft_details(run, ideas, draft_payload)
+
+    selected_context = draft_details["selected_idea"] or selected_idea
+    selected_index = draft_details["selected_index"]
+    if selected_index is None:
+        selected_index = idea_index
+
     context = {
         "run": run,
-        "selected": selected_idea,
-        "citations": citations,
-        "idea_index": idea_index,
-        "draft_form": draft_form,
-        "draft_summary": payload.get("summary", ""),
-        "selected_idea": selected_idea,
-        "run_cost": (run.cost_cents or 0) / 100,
+        "selected": selected_context,
+        "citations": draft_details["citations"],
+        "idea_index": selected_index,
+        "draft_form": draft_details["draft_form"],
+        "draft_summary": draft_details["draft_summary"],
+        "selected_idea": selected_context,
+        "draft_status": draft_details["draft_status"],
+        "draft_error": draft_details["draft_error"],
+        "draft_pending": draft_details["draft_pending"],
     }
     response = _render_partial(request, "articles/_draft_workflow.html", context)
-    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
+    triggers = {"articles:refresh-runs": True}
+    if draft_details["draft_form"] is None and draft_details["draft_status"] in {"queued", "running"}:
+        triggers["articles:watch-draft"] = {"run_id": run.id}
+    response["HX-Trigger"] = json.dumps(triggers)
+    return response
+
+
+@staff_member_required
+@require_GET
+def staff_draft_status(request, run_id: int):
+    run = _get_run_for_request(request, run_id)
+    ideas, _ideas_payload, draft_payload, _ = _gather_run_context(run)
+    draft_details = _prepare_draft_details(run, ideas, draft_payload)
+    draft_step = run.steps.filter(name="draft").first()
+    selected_context = draft_details["selected_idea"]
+    if not selected_context and draft_step:
+        selected_context = ensure_dict(draft_step.input_payload).get("selected")
+    selected_index = draft_details["selected_index"]
+    if selected_index is None and draft_step:
+        selected_index = ensure_dict(draft_step.input_payload).get("idea_index")
+
+    context = {
+        "run": run,
+        "selected": selected_context,
+        "citations": draft_details["citations"],
+        "idea_index": selected_index,
+        "draft_form": draft_details["draft_form"],
+        "draft_summary": draft_details["draft_summary"],
+        "selected_idea": selected_context,
+        "draft_status": draft_details["draft_status"],
+        "draft_error": draft_details["draft_error"],
+        "draft_pending": draft_details["draft_pending"],
+    }
+    response = _render_partial(request, "articles/_draft_workflow.html", context)
+    triggers: Dict[str, Any] = {}
+    if draft_details["draft_status"] == "ok":
+        triggers["articles:refresh-runs"] = True
+    if triggers:
+        response["HX-Trigger"] = json.dumps(triggers)
     return response
 
 
@@ -565,9 +525,9 @@ def staff_finalize_article(request):
     if not draft_step:
         return HttpResponseBadRequest("Draft step missing for this run")
 
-    draft_payload = _ensure_dict(draft_step.output_payload)
-    draft_input = _ensure_dict(draft_step.input_payload)
-    citations = _ensure_list(draft_payload.get("citations"))
+    draft_payload = ensure_dict(draft_step.output_payload)
+    draft_input = ensure_dict(draft_step.input_payload)
+    citations = ensure_list(draft_payload.get("citations"))
     selected_idea = draft_input.get("selected", {})
     summary = draft_payload.get("summary", "")
 
@@ -590,7 +550,7 @@ def staff_finalize_article(request):
     )
     payload = parse_structured_payload(extract_output_text(response))
     body_markdown = payload.get("body_markdown") or draft_body
-    sources = _ensure_list(payload.get("sources")) or citations
+    sources = ensure_list(payload.get("sources")) or citations
 
     RunStep.objects.update_or_create(
         run=run,
@@ -609,7 +569,7 @@ def staff_finalize_article(request):
             "ended_at": timezone.now(),
         },
     )
-    _apply_usage_cost(run, getattr(response, "usage", None) or response_dict.get("usage"))
+    apply_usage_cost(run, getattr(response, "usage", None) or response_dict.get("usage"))
 
     article_defaults = {
         "title": payload.get("title") or draft_title,
@@ -653,12 +613,12 @@ def staff_publish_article(request):
     run.save(update_fields=["status"])
 
     seo_step = run.steps.filter(name="seo").first()
-    final_payload = _ensure_dict(seo_step.output_payload) if seo_step else {}
+    final_payload = ensure_dict(seo_step.output_payload) if seo_step else {}
     context = {
         "article": article,
         "run": run,
         "final_payload": final_payload,
-        "sources": _ensure_list(article.sources_json),
+        "sources": ensure_list(article.sources_json),
         "run_cost": (run.cost_cents or 0) / 100,
     }
     response = _render_partial(request, "articles/_final_article_panel.html", context)
@@ -694,3 +654,38 @@ def staff_runs_fragment(request):
         "runs_with_meta": runs_with_meta,
     }
     return render(request, "articles/_run_list.html", context)
+
+
+@staff_member_required
+@require_POST
+def staff_delete_run(request, run_id: int):
+    run = _get_run_for_request(request, run_id)
+    Article.objects.filter(run=run).delete()
+    run.delete()
+
+    runs = list(
+        ArticleRun.objects.filter(created_by=request.user)
+        .prefetch_related("steps")
+        .order_by("-created_at")[:10]
+    )
+    articles_by_run = {
+        article.run_id: article for article in Article.objects.filter(run__in=runs)
+    }
+    run_costs = {run_item.id: (run_item.cost_cents or 0) / 100 for run_item in runs}
+    runs_with_meta = [
+        {
+            "run": run_item,
+            "article": articles_by_run.get(run_item.id),
+            "cost": run_costs.get(run_item.id, 0),
+        }
+        for run_item in runs
+    ]
+    context = {
+        "runs": runs,
+        "run_articles": articles_by_run,
+        "run_costs": run_costs,
+        "runs_with_meta": runs_with_meta,
+    }
+    response = render(request, "articles/_run_list.html", context)
+    response["HX-Trigger"] = json.dumps({"articles:refresh-dashboard": True})
+    return response


### PR DESCRIPTION
## Summary
- allow the concept generation form to accept PDF uploads without manual context while validating input
- execute draft research asynchronously with a background task, polling endpoint, and global page indicator updates
- streamline the article studio UI, add run deletion controls, and fix a lead webhook URL typo to keep tests running

## Testing
- python manage.py test articles.tests.test_staff_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dc13a4c2fc83329e9f9785621dab40