### PR TITLE
Add OG image generation and refresh article presentation

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -152,6 +152,9 @@ def _generate_replicate_asset(
     *,
     folder: str,
     output_quality: int,
+    width: int = 500,
+    height: int = 500,
+    crop: str = "fill",
 ) -> str:
     """Generate an image via Replicate, upload to Cloudinary, and return the URL."""
 
@@ -195,9 +198,9 @@ def _generate_replicate_asset(
                 resource_type="image",
             )
             optimized_url = cloudinary.CloudinaryImage(upload_result["public_id"]).build_url(
-                width=500,
-                height=500,
-                crop="fill",
+                width=width,
+                height=height,
+                crop=crop,
                 quality="auto",
                 fetch_format="auto",
             )
@@ -233,6 +236,23 @@ def generate_concept_sketch_from_prompt(prompt: str, default_url: str, *, user=N
         default_url,
         folder="appertivo/sketches",
         output_quality=60,
+    )
+
+
+DEFAULT_ARTICLE_OG_IMAGE_URL = "https://placehold.co/1200x630?text=Appertivo+Article"
+
+
+def generate_article_og_image(prompt: str, default_url: str | None = None) -> str:
+    """Generate a landscape OG image for an article."""
+
+    return _generate_replicate_asset(
+        prompt,
+        default_url or DEFAULT_ARTICLE_OG_IMAGE_URL,
+        folder="appertivo/articles",
+        output_quality=90,
+        width=1200,
+        height=630,
+        crop="fill",
     )
 
 

--- a/articles/models.py
+++ b/articles/models.py
@@ -116,11 +116,27 @@ class Article(models.Model):
     def save(self, *args: Any, **kwargs: Any) -> None:
         if not self.slug:
             self.slug = slugify(self.title)[:250]
-        if self.status == "published" and not self.published_at:
-            self.published_at = timezone.now()
-        if self.status == "draft" and self.published_at:
+
+        previous_status = None
+        if self.pk:
+            previous_status = (
+                type(self)
+                .objects.filter(pk=self.pk)
+                .values_list("status", flat=True)
+                .first()
+            )
+
+        status_changed_to_published = False
+        if self.status == "published":
+            if not self.published_at:
+                self.published_at = timezone.now()
+            if previous_status != "published":
+                status_changed_to_published = True
+        elif self.status == "draft" and self.published_at:
             # Drafts should not retain a published timestamp to avoid routing confusion.
             self.published_at = None
+
+        self._generate_og_on_save = status_changed_to_published
         super().save(*args, **kwargs)
 
     def get_absolute_url(self) -> str:

--- a/articles/signals.py
+++ b/articles/signals.py
@@ -1,1 +1,56 @@
-"""Placeholder for future signal handlers."""
+"""Signal handlers for the articles app."""
+
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from app.llm import DEFAULT_ARTICLE_OG_IMAGE_URL, generate_article_og_image
+
+from .models import Article
+
+logger = logging.getLogger(__name__)
+
+
+def _build_og_prompt(article: Article) -> str:
+    summary = article.summary or article.seo_description or ""
+    summary_fragment = summary[:400]
+    prompt = (
+        "Editorial food photography for an article aimed at independent restaurant operators. "
+        "No text overlay, cinematic lighting, atmospheric background. "
+        f"Article title: {article.title}. "
+    )
+    if summary_fragment:
+        prompt += f"Key idea: {summary_fragment}"
+    return prompt
+
+
+@receiver(post_save, sender=Article)
+def generate_article_og_image_on_publish(
+    sender,
+    instance: Article,
+    created: bool,
+    update_fields,
+    **kwargs,
+) -> None:
+    should_generate = getattr(instance, "_generate_og_on_save", False)
+    if not should_generate:
+        return
+
+    default_url = getattr(settings, "DEFAULT_ARTICLE_OG_IMAGE_URL", DEFAULT_ARTICLE_OG_IMAGE_URL)
+    prompt = _build_og_prompt(instance)
+
+    try:
+        image_url = generate_article_og_image(prompt, default_url)
+    except Exception:  # pragma: no cover - defensive guard for external failures
+        logger.exception("Article %s OG image generation failed", instance.pk)
+        return
+
+    if not image_url:
+        return
+
+    Article.objects.filter(pk=instance.pk).update(og_image_url=image_url)
+    instance._generate_og_on_save = False

--- a/articles/tasks.py
+++ b/articles/tasks.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 from django.utils import timezone
 
-from .models import PromptTemplate, RunStep
+from .models import Article, PromptTemplate, RunStep
 from .openai_helpers import (
     calculate_nano_cost_cents,
     extract_output_text,
@@ -48,8 +48,27 @@ def run_step(step_id: int, *, client: Optional[Any] = None) -> None:
 
     client = client or get_openai_client()
 
-    prompt_context = json.dumps(step.input_payload, indent=2, sort_keys=True)
-    prompt_text = f"{template.prompt_text.strip()}\n\nContext:\n{prompt_context}"
+    base_payload = step.input_payload if isinstance(step.input_payload, dict) else {}
+    prompt_payload = dict(base_payload)
+    existing_titles: list[str] = []
+    if step.name == "ideas":
+        existing_titles = list(
+            Article.objects.filter(status="published")
+            .exclude(title__isnull=True)
+            .exclude(title__exact="")
+            .values_list("title", flat=True)
+        )
+        if existing_titles:
+            prompt_payload["existing_article_titles"] = existing_titles
+
+    prompt_context = json.dumps(prompt_payload, indent=2, sort_keys=True)
+    prompt_text = template.prompt_text.strip()
+    if existing_titles:
+        title_list = "\n".join(f"- {title}" for title in existing_titles)
+        prompt_text = (
+            f"{prompt_text}\n\nAvoid duplicating these published Appertivo article titles:\n{title_list}"
+        )
+    prompt_text = f"{prompt_text}\n\nContext:\n{prompt_context}"
 
     try:
         response = client.responses.create(

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -12,15 +12,6 @@
 {% endif %}
 
 {% if ideas %}
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-    <div>
-      <h3 class="text-base font-semibold text-[#14080E]">Concepts ready for review</h3>
-      <p class="text-sm text-slate-500">Pick the best direction to launch research and a first draft. Need to tweak context? Reopen the panel above and regenerate.</p>
-    </div>
-    {% if active_run %}
-      <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">Run #{{ active_run.id }}</span>
-    {% endif %}
-  </div>
   {% if ideas_payload.notes %}
     <div class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
       <p class="font-semibold">Model notes</p>

--- a/articles/templates/articles/detail.html
+++ b/articles/templates/articles/detail.html
@@ -5,49 +5,77 @@
 
 {% block extra_head %}
   <meta name="description" content="{{ article.seo_description|default:article.summary }}">
+  <meta name="author" content="Ian Larsen">
   <link rel="canonical" href="{{ request.build_absolute_uri }}">
   <meta property="og:title" content="{{ article.seo_title|default:article.title }}">
   <meta property="og:description" content="{{ article.seo_description|default:article.summary }}">
   {% if article.og_image_url %}
     <meta property="og:image" content="{{ article.og_image_url }}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
   {% endif %}
 {% endblock %}
 
 {% block header %}
-  <header class="py-12 text-center">
-    <p class="text-sm uppercase tracking-widest text-indigo-600">Appertivo Articles</p>
-    <h1 class="text-4xl font-bold text-gray-900 mt-2">{{ article.title }}</h1>
-    {% if article.published_at %}
-      <p class="mt-2 text-gray-500">Published {{ article.published_at|date:"F j, Y" }}</p>
-    {% endif %}
+  <header class="relative overflow-hidden bg-gradient-to-br from-[#2E005D] via-[#5C008B] to-[#FF5C00]">
+    <div class="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35),_transparent_70%)]"></div>
+    <div class="relative mx-auto max-w-5xl px-6 py-16 text-center text-white">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">Appertivo Articles</p>
+      <h1 class="mt-4 text-4xl font-semibold leading-tight sm:text-5xl">{{ article.title }}</h1>
+      {% if article.summary %}
+        <p class="mx-auto mt-4 max-w-2xl text-base text-white/80">{{ article.summary }}</p>
+      {% endif %}
+      {% if article.published_at %}
+        <p class="mt-6 text-sm font-medium text-white/70">Published {{ article.published_at|date:"F j, Y" }}</p>
+      {% endif %}
+      <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <div class="flex items-center gap-3 rounded-full bg-white/10 px-5 py-3 backdrop-blur">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-white/20 text-lg font-semibold text-white">IL</div>
+          <div class="text-left">
+            <p class="text-sm font-semibold text-white">Ian Larsen</p>
+            <p class="text-xs text-white/80">Ex-Chef &amp; Owner, Appertivo</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </header>
 {% endblock %}
 
 {% block content %}
-  <article class="max-w-3xl mx-auto px-4 pb-16">
-    <div class="prose prose-lg max-w-none">
-      {{ article.body_markdown|article_markdown }}
+  <section class="relative -mt-16 bg-slate-50 pb-16">
+    <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+      <article class="rounded-3xl bg-white p-6 shadow-2xl sm:p-10">
+        <div class="prose prose-lg max-w-none text-slate-800">
+          {{ article.body_markdown|article_markdown }}
+        </div>
+        {% with sources=article.sources %}
+          {% if sources %}
+            <details class="mt-12 rounded-2xl border border-slate-200 bg-slate-50/60 p-5 text-slate-700" data-testid="citations">
+              <summary class="cursor-pointer list-none text-base font-semibold text-[#5C008B]">
+                View citations ({{ sources|length }})
+              </summary>
+              <ul class="mt-4 space-y-3 text-sm">
+                {% for source in sources %}
+                  <li class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+                    <div class="font-medium text-slate-900">
+                      {% if source.url %}
+                        <a href="{{ source.url }}" class="text-[#FF5C00] hover:text-[#d94a00] hover:underline" rel="noopener" target="_blank">
+                          {{ source.title|default:source.url }}
+                        </a>
+                      {% else %}
+                        {{ source.title|default:"Reference" }}
+                      {% endif %}
+                    </div>
+                    {% if source.reason %}
+                      <p class="mt-1 text-xs text-slate-500">{{ source.reason }}</p>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+        {% endwith %}
+      </article>
     </div>
-    {% with sources=article.sources %}
-      {% if sources %}
-        <section class="mt-12">
-          <h2 class="text-xl font-semibold text-gray-900">Sources</h2>
-          <ul class="mt-4 space-y-2 list-disc list-inside text-gray-700">
-            {% for source in sources %}
-              <li>
-                {% if source.url %}
-                  <a href="{{ source.url }}" class="text-indigo-600 hover:underline" rel="noopener" target="_blank">{{ source.title|default:source.url }}</a>
-                {% else %}
-                  {{ source.title|default:"Reference" }}
-                {% endif %}
-                {% if source.reason %}
-                  <span class="text-gray-500">— {{ source.reason }}</span>
-                {% endif %}
-              </li>
-            {% endfor %}
-          </ul>
-        </section>
-      {% endif %}
-    {% endwith %}
-  </article>
+  </section>
 {% endblock %}

--- a/articles/tests/test_signals.py
+++ b/articles/tests/test_signals.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from articles.models import Article
+
+
+class ArticleSignalTests(TestCase):
+    def test_publish_generates_og_image_once(self):
+        with patch("articles.signals.generate_article_og_image") as mock_generate:
+            Article.objects.create(
+                title="Draft Article",
+                slug="draft-article",
+                body_markdown="Body",
+                summary="Summary",
+            )
+            mock_generate.assert_not_called()
+
+        article = Article.objects.get(slug="draft-article")
+        with patch(
+            "articles.signals.generate_article_og_image",
+            return_value="https://example.com/generated-og.jpg",
+        ) as mock_generate:
+            article.status = "published"
+            article.save()
+            mock_generate.assert_called_once()
+
+        article.refresh_from_db()
+        self.assertEqual(article.og_image_url, "https://example.com/generated-og.jpg")

--- a/articles/tests/test_staff_dashboard.py
+++ b/articles/tests/test_staff_dashboard.py
@@ -62,7 +62,7 @@ class StaffDashboardTests(TestCase):
             HTTP_HX_REQUEST="true",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Concepts ready for review")
+        self.assertContains(response, "Model notes")
         run = ArticleRun.objects.get()
         self.assertEqual(run.created_by, self.staff_user)
         self.assertEqual(run.current_step, "ideas")
@@ -81,7 +81,8 @@ class StaffDashboardTests(TestCase):
         self.assertIn("Add brief context", response.content.decode())
 
     @patch("articles.tasks.get_openai_client")
-    def test_select_concept_creates_draft_step(self, mock_client_factory):
+    @patch("articles.views.get_openai_client")
+    def test_select_concept_creates_draft_step(self, mock_view_client_factory, mock_task_client_factory):
         run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="ideas")
         RunStep.objects.create(
             run=run,
@@ -111,7 +112,8 @@ class StaffDashboardTests(TestCase):
                 create=lambda **_: self._make_openai_response(draft_payload)
             )
         )
-        mock_client_factory.return_value = mock_client
+        mock_view_client_factory.return_value = mock_client
+        mock_task_client_factory.return_value = mock_client
 
         response = self.client.post(
             reverse("articles:staff_select_concept"),
@@ -125,8 +127,9 @@ class StaffDashboardTests(TestCase):
         self.assertEqual(draft_step.output_payload["summary"], "Outline summary")
         self.assertGreater(run.cost_cents, 0)
 
+    @patch("articles.views.get_openai_client")
     @patch("articles.views.async_task")
-    def test_select_concept_returns_polling_when_pending(self, mock_async_task):
+    def test_select_concept_returns_polling_when_pending(self, mock_async_task, mock_client_factory):
         mock_async_task.side_effect = lambda *_, **__: None
         run = ArticleRun.objects.create(created_by=self.staff_user, status="running", current_step="ideas")
         RunStep.objects.create(
@@ -140,6 +143,17 @@ class StaffDashboardTests(TestCase):
                 ],
                 "notes": "Notes",
             },
+        )
+        mock_client_factory.return_value = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=lambda **_: self._make_openai_response(
+                    {
+                        "summary": "",
+                        "citations": [],
+                        "draft": {"sections": []},
+                    }
+                )
+            )
         )
 
         response = self.client.post(

--- a/articles/tests/test_tasks.py
+++ b/articles/tests/test_tasks.py
@@ -4,8 +4,9 @@ from types import SimpleNamespace
 from unittest import mock
 
 from django.test import TestCase
+from django.utils import timezone
 
-from articles.models import ArticleRun, PromptTemplate, RunStep
+from articles.models import Article, ArticleRun, PromptTemplate, RunStep
 from articles.tasks import run_step
 
 
@@ -23,8 +24,10 @@ class DummyClient:
     def __init__(self, payload):
         self.payload = payload
         self.responses = SimpleNamespace(create=self._create)
+        self.last_kwargs = {}
 
     def _create(self, **kwargs):
+        self.last_kwargs = kwargs
         return DummyResponse(self.payload)
 
 
@@ -55,3 +58,26 @@ class RunStepTaskTests(TestCase):
         next_step = self.run.steps.filter(name="scoring").first()
         self.assertIsNotNone(next_step)
         self.assertEqual(next_step.input_payload.get("ideas")[0]["title"], "Idea")
+
+    def test_run_step_includes_existing_titles_in_prompt(self):
+        Article.objects.create(
+            title="Inventory Systems That Save Hours",
+            slug="inventory-systems-save-hours",
+            body_markdown="Body",
+            status="published",
+            published_at=timezone.now(),
+        )
+
+        step = RunStep.objects.create(
+            run=self.run,
+            name="ideas",
+            input_payload={"topic": "staffing"},
+        )
+        client = DummyClient('{"ideas": [{"title": "Idea"}], "notes": "Note"}')
+
+        with mock.patch("articles.tasks.schedule_step"):
+            run_step(step.id, client=client)
+
+        prompt_input = client.last_kwargs.get("input", "")
+        self.assertIn("Avoid duplicating", prompt_input)
+        self.assertIn("Inventory Systems That Save Hours", prompt_input)

--- a/articles/views.py
+++ b/articles/views.py
@@ -381,7 +381,7 @@ def staff_generate_concepts(request):
     context = {
         "ideas": normalized_ideas,
         "active_run": run,
-        "ideas_payload": run_payload,
+        "ideas_payload": {"notes": payload.get("notes", "")},
     }
     response = _render_partial(request, "articles/_concept_results.html", context)
     response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True})
@@ -427,13 +427,13 @@ def staff_select_concept(request):
         response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
     )
     payload = parse_structured_payload(extract_output_text(response))
-    citations = _ensure_list(payload.get("citations"))
-    draft_data = _ensure_dict(payload.get("draft"))
+    citations = ensure_list(payload.get("citations"))
+    draft_data = ensure_dict(payload.get("draft"))
     draft_markdown = payload.get("draft_markdown") or draft_data.get("markdown") or ""
     if not draft_markdown:
         sections = draft_data.get("sections")
         if sections:
-            draft_markdown = _sections_to_markdown(sections)
+            draft_markdown = sections_to_markdown(sections)
         elif draft_data.get("text"):
             draft_markdown = str(draft_data.get("text"))
 

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -143,6 +143,7 @@ TEMPLATES = [
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
+                'django.template.context_processors.csrf',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],


### PR DESCRIPTION
## Summary
- generate Replicate-powered OG images when articles are published and persist the Cloudinary URL for meta tags
- refresh the public article template with a branded hero, author profile, and collapsible citation list
- streamline staff concept results, guard against duplicate titles in prompts, and cover the changes with new tests

## Testing
- python manage.py test articles

------
https://chatgpt.com/codex/tasks/task_e_68dc1ae1f0d48332925052c8c351303a