### PR TITLE
Handle Outscraper pending responses

### DIFF
--- a/appertivo/leads/tasks.py
+++ b/appertivo/leads/tasks.py
@@ -37,11 +37,20 @@ def extract_lead_entries(payload: object) -> list[dict]:
     """Return a flat list of lead dictionaries from an Outscraper payload."""
 
     if isinstance(payload, dict):
-        candidates = payload.get("data") or payload.get("results")
+        candidates = (
+            payload.get("data")
+            or payload.get("Data")
+            or payload.get("results")
+            or payload.get("Results")
+        )
         if isinstance(candidates, list):
             if candidates and isinstance(candidates[0], list):
                 return [entry for entry in candidates[0] if isinstance(entry, dict)]
             return [entry for entry in candidates if isinstance(entry, dict)]
+        if isinstance(candidates, dict):
+            nested = candidates.get("data") or candidates.get("results")
+            if isinstance(nested, list):
+                return [entry for entry in nested if isinstance(entry, dict)]
     elif isinstance(payload, list):
         return [entry for entry in payload if isinstance(entry, dict)]
     return []
@@ -70,11 +79,18 @@ def resolve_outscraper_payload(payload: object, headers: Mapping[str, str] | Non
     if not job_id:
         return payload
 
-    job_url = f"https://api.app.outscraper.com/requests/{job_id}"
+    job_url = f"https://api.outscraper.cloud/requests/{job_id}"
     try:
         response = requests.get(job_url, headers=request_headers or None, timeout=60)
         response.raise_for_status()
-        return response.json()
+        job_payload = response.json()
+        if (
+            isinstance(job_payload, dict)
+            and "Data" in job_payload
+            and "data" not in job_payload
+        ):
+            job_payload["data"] = job_payload["Data"]
+        return job_payload
     except requests.RequestException as exc:  # pragma: no cover - network failure
         logger.exception("Failed to fetch Outscraper job %s: %s", job_id, exc)
         return payload
@@ -207,6 +223,11 @@ def fetch_leads(
     payload = resolve_outscraper_payload(response.json(), headers)
     entries = extract_lead_entries(payload)
     if not entries:
+        if isinstance(payload, dict):
+            status = str(payload.get("status") or payload.get("Status") or "").lower()
+            if status and status != "success":
+                logger.info("Outscraper job %s not ready: %s", payload.get("id"), status)
+                return []
         logger.warning("Unexpected Outscraper payload: %s", payload)
         return []
 

--- a/appertivo/leads/tests/test_tasks.py
+++ b/appertivo/leads/tests/test_tasks.py
@@ -20,25 +20,27 @@ class FetchLeadsTaskTests(TestCase):
     """Verify the fetch_leads task integrates with Outscraper correctly."""
 
     @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
     @patch("appertivo.leads.tasks.requests.get")
     def test_fetch_leads_uses_async_job_and_webhook(self, mock_get: Mock) -> None:
         run = LeadRun.objects.create(expected_leads=5)
 
         first_response = Mock()
         first_response.raise_for_status = Mock()
-        first_response.json.return_value = {"id": "job-123"}
+        first_response.json.return_value = {"id": "job-123", "status": "Pending"}
 
         second_response = Mock()
         second_response.raise_for_status = Mock()
         second_response.json.return_value = {
-            "data": [
+            "Status": "Success",
+            "Data": [
                 {
                     "name": "Sunset Bistro",
                     "email": "owner@example.com",
                     "phone": "555-0100",
                     "city": "Austin, TX",
                 }
-            ]
+            ],
         }
 
         mock_get.side_effect = [first_response, second_response]
@@ -46,12 +48,18 @@ class FetchLeadsTaskTests(TestCase):
         lead_ids = fetch_leads(run_id=run.id, city="Austin, TX", limit=3)
 
         self.assertEqual(len(lead_ids), 1)
-        self.assertEqual(mock_get.call_args_list[0].args[0], "https://api.app.outscraper.com/maps/search-v3")
+        self.assertEqual(
+            mock_get.call_args_list[0].args[0],
+            "https://api.outscraper.cloud/google-maps-search",
+        )
         params = mock_get.call_args_list[0].kwargs["params"]
         self.assertEqual(params["async"], "true")
         self.assertEqual(params["webhook"], "https://appertivo.com/leads/outscraper-webhook/")
         self.assertEqual(params["enrichment"], json.dumps(["domains_service"]))
-        self.assertEqual(mock_get.call_args_list[1].args[0], "https://api.app.outscraper.com/requests/job-123")
+        self.assertEqual(
+            mock_get.call_args_list[1].args[0],
+            "https://api.outscraper.cloud/requests/job-123",
+        )
 
         lead = Lead.objects.get(pk=lead_ids[0])
         self.assertEqual(lead.email, "owner@example.com")
@@ -60,11 +68,32 @@ class FetchLeadsTaskTests(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, LeadRun.Status.PREPARING)
 
+    @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
+    @patch("appertivo.leads.tasks.logger")
+    @patch("appertivo.leads.tasks.requests.get")
+    def test_fetch_leads_logs_pending_jobs(self, mock_get: Mock, mock_logger: Mock) -> None:
+        pending_response = Mock()
+        pending_response.raise_for_status = Mock()
+        pending_response.json.return_value = {
+            "id": "job-456",
+            "status": "Pending",
+            "description": "Results are expired, or the task is not yet finished",
+        }
+
+        mock_get.return_value = pending_response
+
+        lead_ids = fetch_leads(city="Seattle, WA", limit=2)
+
+        self.assertEqual(lead_ids, [])
+        mock_logger.info.assert_any_call("Outscraper job %s not ready: %s", "job-456", "pending")
+
 
 class OutscraperWebhookViewTests(TestCase):
     """Ensure the Outscraper webhook endpoint updates leads."""
 
     @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
     def test_webhook_updates_existing_lead_payload(self) -> None:
         lead = Lead.objects.create(name="Old Name", email="owner@example.com")
 


### PR DESCRIPTION
## Summary
- normalize Outscraper payload handling to follow the cloud API and treat pending jobs as non-fatal
- extend lead extraction to understand the capitalized Data key returned when jobs finish
- update lead task tests to cover the new API responses and pending-job logging

## Testing
- python manage.py test appertivo.leads.tests.test_tasks.FetchLeadsTaskTests

------
https://chatgpt.com/codex/tasks/task_e_68dc1c4fc94c833289125f025ebc77bf