### PR TITLE
Add pending state to lead dashboard runs

### DIFF
--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -1,6 +1,24 @@
 {% extends "base.html" %}
 {% block title %}Lead Dashboard · Appertivo{% endblock %}
 
+{% block extra_head %}
+  {{ block.super }}
+  <style>
+    @keyframes lead-run-blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.2; }
+    }
+
+    .lead-run-indicator {
+      width: 0.75rem;
+      height: 0.75rem;
+      border-radius: 9999px;
+      background-color: #7c3aed;
+      animation: lead-run-blink 1s ease-in-out infinite;
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
 <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
   <header class="space-y-3">
@@ -33,6 +51,26 @@
       </p>
     </form>
   </section>
+
+  {% if pending_runs %}
+    <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-purple-200 p-6 space-y-4">
+      <h2 class="text-lg font-semibold text-slate-900">Runs in progress</h2>
+      <ul class="space-y-3">
+        {% for run in pending_runs %}
+          <li class="flex items-center justify-between gap-4 rounded-xl border border-purple-100 bg-purple-50/40 px-4 py-3">
+            <div class="flex items-center gap-3">
+              <span class="lead-run-indicator" aria-hidden="true"></span>
+              <div>
+                <p class="text-sm font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</p>
+                <p class="text-xs text-slate-600">Waiting for Outscraper to return lead data…</p>
+              </div>
+            </div>
+            <span class="text-xs font-medium text-purple-700">{{ run.get_status_display }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
 
   {% if run_cards %}
     {% for card in run_cards %}
@@ -166,7 +204,7 @@
       </section>
       {% endwith %}
     {% endfor %}
-  {% else %}
+  {% elif not pending_runs %}
     <div class="rounded-2xl border border-dashed border-purple-300 bg-white/60 p-10 text-center">
       <h2 class="text-xl font-semibold text-slate-900">No lead runs yet</h2>
       <p class="mt-2 text-sm text-slate-600">Kick things off by starting your first run above. We'll fetch a fresh batch of restaurants and craft personalized demos for you.</p>

--- a/appertivo/leads/tests/test_dashboard.py
+++ b/appertivo/leads/tests/test_dashboard.py
@@ -36,6 +36,18 @@ class LeadDashboardTests(TestCase):
         self.assertContains(response, f"Run {run.pk}")
         self.assertContains(response, "Morning Sun")
 
+    def test_pending_run_shows_in_progress_indicator(self) -> None:
+        run = LeadRun.objects.create(city="Boston", status=LeadRun.Status.FETCHING)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("lead-dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Runs in progress")
+        self.assertContains(response, f"Run {run.pk}")
+        self.assertContains(response, "Waiting for Outscraper")
+        self.assertNotContains(response, "Shortlist</th>")
+        self.assertNotContains(response, "No lead runs yet")
+
     @patch("appertivo.leads.views.build_lead_run_pipeline")
     def test_start_lead_run_triggers_pipeline(self, mock_pipeline) -> None:
         self.client.force_login(self.user)

--- a/appertivo/leads/views.py
+++ b/appertivo/leads/views.py
@@ -79,9 +79,14 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
     """Render a dashboard for managing Outscraper lead runs."""
 
     runs = LeadRun.objects.prefetch_related("leads").order_by("-created_at")
+    pending_runs: list[LeadRun] = []
     run_cards: list[dict[str, object]] = []
     for run in runs:
         leads = list(run.leads.all())
+        if not leads:
+            pending_runs.append(run)
+            continue
+
         leads = sorted(leads, key=lambda lead: lead.created_at, reverse=True)
         leads.sort(key=lambda lead: not lead.shortlisted)
         metrics = {
@@ -104,6 +109,7 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
 
     context = {
         "run_cards": run_cards,
+        "pending_runs": pending_runs,
         "LeadRunStatus": LeadRun.Status,
         "default_limit": 10,
     }


### PR DESCRIPTION
## Summary
- hide lead run cards until Outscraper returns lead data
- show an in-progress banner with a blinking indicator for pending runs
- add coverage to ensure the dashboard renders the pending state

## Testing
- python manage.py test appertivo.leads.tests.test_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dc2487053c833293b3864bca34d92c