### PR TITLE
Improve staff research workflow responsiveness

### DIFF
--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -35,6 +35,7 @@
           hx-target="#draft-workflow"
           hx-swap="innerHTML"
           hx-indicator="#research-loading"
+          hx-on::before-request="document.getElementById('concepts-accordion')?.removeAttribute('open'); console.info('Queuing research for concept {{ forloop.counter }}');"
           hx-on::after-request="if (event.detail.successful) { document.getElementById('research-accordion').setAttribute('open', 'open'); }"
           class="mt-4"
           data-loading-message="Researching concept…"

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -81,13 +81,16 @@
   <div
     class="flex flex-col gap-3 rounded-2xl border border-indigo-200 bg-indigo-50 p-4"
     hx-get="{% url 'articles:staff_draft_status' run.id %}"
-    hx-trigger="load, every 6s"
+    hx-trigger="load, every 6s, articles:watch-draft from:body"
     hx-target="#draft-workflow"
     hx-swap="outerHTML"
     data-loading-message="Gathering research…"
   >
-    <div class="flex items-center gap-2 text-sm font-semibold text-indigo-700">
-      <i class="fa-solid fa-magnifying-glass-chart" aria-hidden="true"></i>
+    <div class="flex items-center gap-3 text-sm font-semibold text-indigo-700">
+      <span class="relative flex h-3 w-3">
+        <span class="absolute inline-flex h-full w-full rounded-full bg-indigo-300 opacity-75 animate-ping"></span>
+        <span class="relative inline-flex h-3 w-3 rounded-full bg-indigo-600"></span>
+      </span>
       Research in progress
     </div>
     <p class="text-sm text-indigo-900">We’re gathering citations and an outline. Feel free to navigate away—this panel will refresh automatically.</p>

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -14,44 +14,6 @@
 
 {% block page_content %}
   <div class="px-4 py-6 space-y-6">
-    <section class="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div class="max-w-3xl space-y-1">
-          <h2 class="text-lg font-semibold text-[#14080E]">Workflow overview</h2>
-          <p class="text-sm text-slate-500">
-            Move from research context to ready-to-publish articles. Each step can pause safely so you can return when long-running jobs finish.
-          </p>
-        </div>
-        <div class="hidden md:flex items-center gap-2 rounded-full bg-[#F5F1FF] px-3 py-1 text-xs font-semibold text-[#5C008B]">
-          <i class="fa-solid fa-clock" aria-hidden="true"></i>
-          Auto-saves every stage
-        </div>
-      </div>
-      <ol class="mt-4 grid gap-3 md:grid-cols-3">
-        <li class="flex items-start gap-3 rounded-2xl border border-[#E8D5FF] bg-[#FBF8FF] p-3">
-          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#7B1FA2] text-xs font-semibold text-white">1</span>
-          <div class="space-y-1">
-            <h3 class="text-sm font-semibold text-[#2E005D]">Generate concepts</h3>
-            <p class="text-xs text-slate-600">Share context or upload research for tailored article directions.</p>
-          </div>
-        </li>
-        <li class="flex items-start gap-3 rounded-2xl border border-[#FFE3CC] bg-[#FFF8F2] p-3">
-          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#FF5C00] text-xs font-semibold text-white">2</span>
-          <div class="space-y-1">
-            <h3 class="text-sm font-semibold text-[#B54D00]">Research &amp; draft</h3>
-            <p class="text-xs text-slate-600">Polling keeps progress updated while citations and drafts are prepared.</p>
-          </div>
-        </li>
-        <li class="flex items-start gap-3 rounded-2xl border border-[#C7F0D8] bg-[#F4FFF9] p-3">
-          <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-[#2F855A] text-xs font-semibold text-white">3</span>
-          <div class="space-y-1">
-            <h3 class="text-sm font-semibold text-[#1E6A45]">Finalize &amp; publish</h3>
-            <p class="text-xs text-slate-600">Polish copy, approve SEO, and publish straight to the library.</p>
-          </div>
-        </li>
-      </ol>
-    </section>
-
     <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
       <section class="space-y-6">
         <details
@@ -166,7 +128,7 @@
           <div
             id="runs-panel"
             hx-get="{% url 'articles:staff_runs_fragment' %}"
-            hx-trigger="load, every 20s, articles:refresh-runs from:body"
+            hx-trigger="load, articles:refresh-runs from:body"
             hx-target="this"
             hx-swap="innerHTML"
             class="mt-4"
@@ -181,9 +143,23 @@
 
   <script>
     document.addEventListener("DOMContentLoaded", function () {
-      document.body.addEventListener("articles:refresh-dashboard", function () {
-        window.location.reload();
+      document.body.addEventListener("articles:clear-workflow", function () {
+        const conceptsContainer = document.getElementById("concepts-results");
+        if (conceptsContainer) {
+          conceptsContainer.innerHTML = '<p class="text-sm text-slate-500">Use the form above to generate five article directions tailored to your research context.</p>';
+        }
+        const draftContainer = document.getElementById("draft-workflow");
+        if (draftContainer) {
+          draftContainer.innerHTML = '<div class="flex flex-col items-start gap-2"><h2 class="text-lg font-semibold text-[#14080E]">2. Research &amp; draft review</h2><p class="text-sm text-slate-500">Select an article concept to generate a sourced outline and editable draft.</p></div>';
+        }
+        const finalPanel = document.getElementById("final-article-panel");
+        if (finalPanel) {
+          finalPanel.innerHTML = '';
+        }
+        document.getElementById("concepts-accordion")?.setAttribute("open", "open");
+        document.getElementById("research-accordion")?.removeAttribute("open");
       });
     });
   </script>
+
 {% endblock %}

--- a/articles/views.py
+++ b/articles/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, List, Tuple
 
 from django import forms
@@ -15,8 +16,9 @@ from django_q.tasks import async_task
 from .models import Article, ArticleRun, RunStep
 from .openai_helpers import extract_output_text, get_openai_client, parse_structured_payload
 from .pdf_utils import extract_pdf_text
-from .schemas import RESEARCH_RESPONSE_SCHEMA
 from .utils import apply_usage_cost, ensure_dict, ensure_list, sections_to_markdown
+
+logger = logging.getLogger(__name__)
 
 class ArticleConceptForm(forms.Form):
     topic = forms.CharField(
@@ -406,37 +408,6 @@ def staff_select_concept(request):
 
     selected_idea = ideas[idea_index]
 
-    client = get_openai_client()
-    prompt = (
-        "You are a research assistant with access to live web search. "
-        "Given an article concept and research context, compile supporting citations "
-        "and draft a structured outline with section headings and bullet paragraphs. "
-        "Return structured JSON with keys: summary, citations (list with title, url, and snippet), draft (with title, sections)."
-        f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
-        f"\n\nContext notes: {context_details.get('context', '')}"
-        f"\n\nExtracted PDF notes: {context_details.get('pdf_context', '')}"
-        f"\n\nTopic focus: {context_details.get('topic', '')}"
-    )
-    response = client.responses.create(
-        model="gpt-5",
-        input=prompt,
-        tools=[{"type": "web_search"}],
-        text={"format": RESEARCH_RESPONSE_SCHEMA},
-    )
-    response_dict = (
-        response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
-    )
-    payload = parse_structured_payload(extract_output_text(response))
-    citations = ensure_list(payload.get("citations"))
-    draft_data = ensure_dict(payload.get("draft"))
-    draft_markdown = payload.get("draft_markdown") or draft_data.get("markdown") or ""
-    if not draft_markdown:
-        sections = draft_data.get("sections")
-        if sections:
-            draft_markdown = sections_to_markdown(sections)
-        elif draft_data.get("text"):
-            draft_markdown = str(draft_data.get("text"))
-
     step_input = {
         "selected": selected_idea,
         "idea_index": idea_index,
@@ -472,9 +443,9 @@ def staff_select_concept(request):
     run.save(update_fields=["current_step", "status", "can_resume_from_step"])
 
     async_task("articles.tasks.generate_research_draft", draft_step.id)
+    logger.info("Queued research draft for run %s (idea %s)", run.id, idea_index)
 
-    run.refresh_from_db()
-    draft_step.refresh_from_db()
+    run = ArticleRun.objects.prefetch_related("steps").get(pk=run.pk)
     ideas, _ideas_payload, draft_payload, _ = _gather_run_context(run)
     draft_details = _prepare_draft_details(run, ideas, draft_payload)
 
@@ -717,5 +688,5 @@ def staff_delete_run(request, run_id: int):
         "runs_with_meta": runs_with_meta,
     }
     response = render(request, "articles/_run_list.html", context)
-    response["HX-Trigger"] = json.dumps({"articles:refresh-dashboard": True})
+    response["HX-Trigger"] = json.dumps({"articles:refresh-runs": True, "articles:clear-workflow": True})
     return response


### PR DESCRIPTION
## Summary
- queue article research in the background without blocking the concept selection request and log the queueing
- simplify the staff dashboard by removing the workflow overview, reducing unnecessary run polling, and clearing panels when runs are deleted
- improve research UI feedback by collapsing the concepts section on selection, adding a visible progress indicator, and logging the request in the browser console

## Testing
- pytest articles/tests *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dc263cc00c8332be003141cb0598be