### PR TITLE
Refine article workflow loading indicators and CSRF handling

### DIFF
--- a/app/templates/layouts/app.html
+++ b/app/templates/layouts/app.html
@@ -165,23 +165,64 @@
         }
       }
 
+      function usesOverlay(elt) {
+        if (!elt) {
+          return true;
+        }
+        if (elt.closest("[data-disable-global-overlay]")) {
+          elt.dataset.usesGlobalOverlay = "false";
+          return false;
+        }
+        elt.dataset.usesGlobalOverlay = "true";
+        return true;
+      }
+
+      function clearOverlayFlag(elt) {
+        if (elt) {
+          delete elt.dataset.usesGlobalOverlay;
+        }
+      }
+
+      function finishRequest(elt) {
+        if (elt && elt.dataset.usesGlobalOverlay === "false") {
+          clearOverlayFlag(elt);
+          return;
+        }
+        activeRequests = Math.max(activeRequests - 1, 0);
+        hideOverlay();
+        clearOverlayFlag(elt);
+      }
+
       document.body.addEventListener("htmx:beforeRequest", function (event) {
+        const detail = event.detail || {};
+        const elt = detail.elt;
+        if (!usesOverlay(elt)) {
+          return;
+        }
         activeRequests += 1;
-        const elt = event.detail.elt;
         const text = (elt && (elt.dataset.loadingMessage || elt.getAttribute("aria-label"))) || "Working…";
         showOverlay(text);
       });
 
-      function requestFinished() {
-        activeRequests = Math.max(activeRequests - 1, 0);
-        hideOverlay();
-      }
+      document.body.addEventListener("htmx:afterRequest", function (event) {
+        const detail = event.detail || {};
+        if (detail.successful === false) {
+          return;
+        }
+        finishRequest(detail.elt);
+      });
 
-      document.body.addEventListener("htmx:afterRequest", requestFinished);
-
-      document.body.addEventListener("htmx:responseError", function () {
+      document.body.addEventListener("htmx:responseError", function (event) {
+        const detail = event.detail || {};
+        const elt = detail.elt;
+        if (elt && elt.dataset.usesGlobalOverlay === "false") {
+          clearOverlayFlag(elt);
+          return;
+        }
         message.textContent = "Something went wrong";
-        setTimeout(requestFinished, 1500);
+        setTimeout(function () {
+          finishRequest(elt);
+        }, 1500);
       });
     });
   </script>

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -39,6 +39,7 @@
           hx-on::after-request="if (event.detail.successful) { document.getElementById('research-accordion').setAttribute('open', 'open'); }"
           class="mt-4"
           data-loading-message="Researching concept…"
+          data-disable-global-overlay
         >
           {% csrf_token %}
           <input type="hidden" name="run_id" value="{{ active_run.id }}">
@@ -46,9 +47,11 @@
           <button
             type="submit"
             class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#FF5C00] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#e05400]"
+            data-loading-button
           >
-            <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-            Research this concept
+            <i class="fa-solid fa-magnifying-glass" aria-hidden="true" data-default-icon></i>
+            <i class="fa-solid fa-circle-notch hidden animate-spin" aria-hidden="true" data-loading-icon></i>
+            <span>Research this concept</span>
           </button>
         </form>
       </div>

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -43,6 +43,7 @@
       hx-indicator="#finalize-loading"
       class="space-y-4"
       data-loading-message="Polishing the draft…"
+      data-disable-global-overlay
     >
       {% csrf_token %}
       {{ draft_form.run_id }}
@@ -66,9 +67,11 @@
         <button
           type="submit"
           class="inline-flex items-center justify-center gap-2 rounded-full bg-[#2E005D] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#220045]"
+          data-loading-button
         >
-          <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
-          Continue to final polish
+          <i class="fa-solid fa-arrow-right" aria-hidden="true" data-default-icon></i>
+          <i class="fa-solid fa-circle-notch hidden animate-spin" aria-hidden="true" data-loading-icon></i>
+          <span>Continue to final polish</span>
         </button>
       </div>
       <span id="finalize-loading" class="htmx-indicator inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
@@ -85,6 +88,7 @@
     hx-target="#draft-workflow"
     hx-swap="outerHTML"
     data-loading-message="Gathering research…"
+    data-disable-global-overlay
   >
     <div class="flex items-center gap-3 text-sm font-semibold text-indigo-700">
       <span class="relative flex h-3 w-3">

--- a/articles/templates/articles/_final_article_panel.html
+++ b/articles/templates/articles/_final_article_panel.html
@@ -54,6 +54,7 @@
           hx-target="#final-article-panel"
           hx-swap="innerHTML"
           class="inline-flex"
+          data-disable-global-overlay
         >
           {% csrf_token %}
           <input type="hidden" name="run_id" value="{{ run.id }}">
@@ -61,9 +62,11 @@
           <button
             type="submit"
             class="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+            data-loading-button
           >
-            <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
-            Approve &amp; publish
+            <i class="fa-solid fa-circle-check" aria-hidden="true" data-default-icon></i>
+            <i class="fa-solid fa-circle-notch hidden animate-spin" aria-hidden="true" data-loading-icon></i>
+            <span>Approve &amp; publish</span>
           </button>
         </form>
       {% else %}

--- a/articles/templates/articles/_run_list.html
+++ b/articles/templates/articles/_run_list.html
@@ -19,10 +19,16 @@
                 hx-confirm="Delete this run and its drafts?"
                 data-loading-message="Deleting run…"
                 class="inline"
+                data-disable-global-overlay
               >
                 {% csrf_token %}
-                <button type="submit" class="inline-flex items-center justify-center rounded-full border border-red-100 bg-white px-2 py-1 text-[11px] font-semibold text-red-600 transition hover:bg-red-50">
-                  <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
+                <button
+                  type="submit"
+                  class="inline-flex items-center justify-center rounded-full border border-red-100 bg-white px-2 py-1 text-[11px] font-semibold text-red-600 transition hover:bg-red-50"
+                  data-loading-button
+                >
+                  <i class="fa-solid fa-trash-can" aria-hidden="true" data-default-icon></i>
+                  <i class="fa-solid fa-circle-notch hidden animate-spin" aria-hidden="true" data-loading-icon></i>
                   <span class="ml-1 hidden sm:inline">Delete</span>
                 </button>
               </form>

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -44,6 +44,7 @@
               hx-on::after-request="if (event.detail.successful) { document.getElementById('concepts-accordion').removeAttribute('open'); }"
               class="space-y-4"
               data-loading-message="Generating article concepts…"
+              data-disable-global-overlay
             >
               {% csrf_token %}
               <div class="grid gap-4 md:grid-cols-2">
@@ -82,9 +83,11 @@
                   type="submit"
                   class="inline-flex items-center justify-center gap-2 rounded-full bg-[#5C008B] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#460069]"
                   data-loading-message="Generating article concepts…"
+                  data-loading-button
                 >
-                  <i class="fa-solid fa-sparkles" aria-hidden="true"></i>
-                  Generate concepts
+                  <i class="fa-solid fa-sparkles" aria-hidden="true" data-default-icon></i>
+                  <i class="fa-solid fa-circle-notch hidden animate-spin" aria-hidden="true" data-loading-icon></i>
+                  <span>Generate concepts</span>
                 </button>
               </div>
             </form>
@@ -133,6 +136,7 @@
             hx-swap="innerHTML"
             class="mt-4"
             data-loading-message="Refreshing run history…"
+            data-disable-global-overlay
           >
             {% include "articles/_run_list.html" with runs_with_meta=runs_with_meta only %}
           </div>
@@ -140,6 +144,68 @@
       </aside>
     </div>
   </div>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      function findLoadingButton(elt) {
+        if (!elt) {
+          return null;
+        }
+        if (elt.matches("[data-loading-button]")) {
+          return elt;
+        }
+        return (
+          elt.querySelector("[data-loading-button]") ||
+          (elt.closest("form") ? elt.closest("form").querySelector("[data-loading-button]") : null)
+        );
+      }
+
+      function toggleButtonState(button, isLoading) {
+        if (!button) {
+          return;
+        }
+        button.disabled = isLoading;
+        button.setAttribute("aria-busy", isLoading ? "true" : "false");
+        button.classList.toggle("cursor-wait", isLoading);
+        button.classList.toggle("opacity-70", isLoading);
+
+        const defaultIcon = button.querySelector("[data-default-icon]");
+        const loadingIcon = button.querySelector("[data-loading-icon]");
+        if (defaultIcon && loadingIcon) {
+          defaultIcon.classList.toggle("hidden", isLoading);
+          loadingIcon.classList.toggle("hidden", !isLoading);
+        }
+      }
+
+      document.body.addEventListener("htmx:beforeRequest", function (event) {
+        const trigger = event.detail.elt;
+        if (!trigger) {
+          return;
+        }
+        const button = findLoadingButton(trigger);
+        if (!button) {
+          return;
+        }
+        toggleButtonState(button, true);
+        trigger.__loadingButton = button;
+      });
+
+      function resetButton(event) {
+        const trigger = event.detail.elt;
+        const button = trigger && trigger.__loadingButton;
+        if (!button) {
+          return;
+        }
+        toggleButtonState(button, false);
+        if (trigger) {
+          delete trigger.__loadingButton;
+        }
+      }
+
+      document.body.addEventListener("htmx:afterRequest", resetButton);
+      document.body.addEventListener("htmx:responseError", resetButton);
+    });
+  </script>
 
   <script>
     document.addEventListener("DOMContentLoaded", function () {

--- a/articles/views.py
+++ b/articles/views.py
@@ -8,6 +8,7 @@ from django import forms
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.validators import FileExtensionValidator
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
@@ -282,10 +283,12 @@ def staff_dashboard(request):
         "draft_pending": draft_details["draft_pending"],
         "run_cost": (active_run.cost_cents or 0) / 100 if active_run else 0,
     }
+    get_token(request)
     return render(request, "articles/staff_dashboard.html", context)
 
 
 def _render_partial(request, template: str, context: Dict[str, Any], *, status: int = 200) -> HttpResponse:
+    get_token(request)
     response = render(request, template, context, status=status)
     return response
 


### PR DESCRIPTION
## Summary
- prevent the global HTMX overlay from appearing on elements that opt out and keep the overlay behavior for the rest of the app
- add inline loading spinners and disable the overlay on article workflow forms, including concept, research, finalize, publish, and run deletion actions
- ensure CSRF tokens are generated for the staff dashboard and all HTMX partials

## Testing
- python manage.py test articles

------
https://chatgpt.com/codex/tasks/task_e_68dc2a0d8c8483328bdd5724d0c0bfb8