### PR TITLE
Improve leads dashboard workflow

### DIFF
--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -28,13 +28,42 @@
     </p>
   </header>
 
+  <section class="grid gap-3 md:grid-cols-4">
+    <div class="rounded-2xl border border-slate-200 bg-white/70 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Runs ready</p>
+      <p class="mt-1 text-2xl font-semibold text-slate-900">{{ dashboard_metrics.ready_runs }}</p>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white/70 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Runs in progress</p>
+      <p class="mt-1 text-2xl font-semibold text-slate-900">{{ dashboard_metrics.pending_runs }}</p>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white/70 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Total leads captured</p>
+      <p class="mt-1 text-2xl font-semibold text-slate-900">{{ dashboard_metrics.total_leads }}</p>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white/70 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Total runs</p>
+      <p class="mt-1 text-2xl font-semibold text-slate-900">{{ dashboard_metrics.total_runs }}</p>
+    </div>
+  </section>
+
   <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-white/50 p-6">
     <form method="post" action="{% url 'lead-run-start' %}" class="space-y-4">
       {% csrf_token %}
-      <div class="grid md:grid-cols-3 gap-4">
+      <div class="grid gap-4 md:grid-cols-4">
         <label class="flex flex-col text-sm font-medium text-slate-700">
           Target city
-          <input type="text" name="city" placeholder="Austin" class="mt-1 rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-400" />
+          <select name="city_choice" class="mt-1 rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-400">
+            <option value="">Select a city</option>
+            {% for city in city_choices %}
+              <option value="{{ city }}">{{ city }}</option>
+            {% endfor %}
+            <option value="__custom__">Other (type below)</option>
+          </select>
+        </label>
+        <label class="flex flex-col text-sm font-medium text-slate-700">
+          Custom city (optional)
+          <input type="text" name="custom_city" placeholder="Boise, ID" class="mt-1 rounded-lg border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-400" />
         </label>
         <label class="flex flex-col text-sm font-medium text-slate-700">
           Leads per run
@@ -47,7 +76,7 @@
         </div>
       </div>
       <p class="text-xs text-slate-500">
-        Each run fetches a fresh batch of prospects, builds tailored landing pages, and keeps their engagement signals at your fingertips.
+        Pick a city to research or enter your own, then set the number of prospects you want to review.
       </p>
     </form>
   </section>
@@ -62,7 +91,13 @@
               <span class="lead-run-indicator" aria-hidden="true"></span>
               <div>
                 <p class="text-sm font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</p>
-                <p class="text-xs text-slate-600">Waiting for Outscraper to return lead data…</p>
+                <p class="text-xs text-slate-600">
+                  {% if run.status == LeadRunStatus.READY %}
+                    Outscraper finished but no leads were returned for this run.
+                  {% else %}
+                    Waiting for Outscraper to return lead data…
+                  {% endif %}
+                </p>
               </div>
             </div>
             <span class="text-xs font-medium text-purple-700">{{ run.get_status_display }}</span>
@@ -76,17 +111,39 @@
     {% for card in run_cards %}
       {% with run=card.run metrics=card.metrics leads=card.leads %}
       <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-white/60 p-6 space-y-6">
-        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-          <div>
-            <h2 class="text-2xl font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</h2>
+        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-2xl font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</h2>
+              {% if run.status == LeadRunStatus.READY and leads %}
+                <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Leads ready</span>
+              {% endif %}
+            </div>
             <p class="text-sm text-slate-500">Started {{ run.created_at|date:"M j, Y • H:i" }}</p>
           </div>
-          <div class="flex flex-wrap items-center gap-3">
-            <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-sm font-medium text-purple-700">{{ run.get_status_display }}</span>
-            <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ run.progress_percentage }}% ready</span>
-            <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ metrics.total }} leads</span>
+          <div class="flex flex-col items-start gap-3 md:items-end">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-sm font-medium text-purple-700">{{ run.get_status_display }}</span>
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ run.progress_percentage }}% ready</span>
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ metrics.total }} leads</span>
+            </div>
+            <form method="post" action="{% url 'lead-run-delete' run.id %}" class="inline">
+              {% csrf_token %}
+              <button type="submit" onclick="return confirm('Delete this run and remove its leads?');" class="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 hover:text-red-600">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+                  <path d="M6.5 3.5A1.5 1.5 0 018 2h4a1.5 1.5 0 011.5 1.5V4h3a.5.5 0 010 1h-.59l-.77 10.218A2 2 0 0113.14 17H6.86a2 2 0 01-1.99-1.782L4.1 5H3.5a.5.5 0 110-1h3zM9 7a.5.5 0 00-1 0v6a.5.5 0 001 0V7zm3 0a.5.5 0 10-1 0v6a.5.5 0 001 0V7zM8 3.5a.5.5 0 00-.5.5v.5h5V4a.5.5 0 00-.5-.5H8z" />
+                </svg>
+                Delete run
+              </button>
+            </form>
           </div>
         </div>
+
+        {% if run.status == LeadRunStatus.READY and leads %}
+          <p class="rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3 text-sm text-emerald-700">
+            This run is ready to work. Shortlist the restaurants to focus outreach and log who you contact.
+          </p>
+        {% endif %}
 
         <dl class="grid md:grid-cols-4 gap-3 text-sm">
           <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">

--- a/appertivo/leads/tests/test_dashboard.py
+++ b/appertivo/leads/tests/test_dashboard.py
@@ -54,15 +54,31 @@ class LeadDashboardTests(TestCase):
 
         response = self.client.post(
             reverse("lead-run-start"),
-            {"city": "Seattle", "limit": "8"},
+            {"city_choice": "Seattle, WA", "limit": "8"},
         )
         self.assertRedirects(response, reverse("lead-dashboard"))
 
         run = LeadRun.objects.get()
-        self.assertEqual(run.city, "Seattle")
+        self.assertEqual(run.city, "Seattle, WA")
         self.assertEqual(run.expected_leads, 8)
         self.assertEqual(run.status, LeadRun.Status.FETCHING)
-        mock_pipeline.assert_called_once_with(run.id, city="Seattle", limit=8)
+        mock_pipeline.assert_called_once_with(run.id, city="Seattle, WA", limit=8)
+
+    @patch("appertivo.leads.views.build_lead_run_pipeline")
+    def test_start_lead_run_accepts_custom_city(self, mock_pipeline) -> None:
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("lead-run-start"),
+            {"city_choice": "__custom__", "custom_city": "Boise, ID"},
+        )
+        self.assertRedirects(response, reverse("lead-dashboard"))
+
+        run = LeadRun.objects.get()
+        self.assertEqual(run.city, "Boise, ID")
+        self.assertEqual(run.expected_leads, 10)
+        self.assertEqual(run.status, LeadRun.Status.FETCHING)
+        mock_pipeline.assert_called_once_with(run.id, city="Boise, ID", limit=10)
 
     @patch("appertivo.leads.views.send_personalized_email.delay")
     def test_update_run_selection_shortlists_and_sends_email(self, mock_delay) -> None:
@@ -101,3 +117,14 @@ class LeadDashboardTests(TestCase):
         self.assertEqual(run.status, LeadRun.Status.COMPLETED)
         self.assertFalse(lead.shortlisted)
         self.assertEqual(run.selected_leads, 0)
+
+    def test_delete_run_removes_run_and_leads(self) -> None:
+        run = LeadRun.objects.create(status=LeadRun.Status.READY)
+        Lead.objects.create(name="Sunrise Cafe", city="Dallas", run=run)
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse("lead-run-delete", args=[run.id]))
+        self.assertRedirects(response, reverse("lead-dashboard"))
+
+        self.assertFalse(LeadRun.objects.filter(pk=run.id).exists())
+        self.assertEqual(Lead.objects.count(), 0)

--- a/appertivo/leads/urls.py
+++ b/appertivo/leads/urls.py
@@ -9,8 +9,8 @@ urlpatterns = [
     path("leads/", views.lead_dashboard, name="lead-dashboard"),
     path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
     path("leads/runs/start/", views.start_lead_run, name="lead-run-start"),
+    path("leads/runs/<int:run_id>/delete/", views.delete_run, name="lead-run-delete"),
     path("leads/runs/<int:run_id>/", views.update_run_selection, name="lead-run-selection"),
-    path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
     path("demo/<slug:slug>/", views.lead_landing, name="lead-landing"),
     path("demo/<slug:slug>/track/", views.track_open, name="lead-track"),
 ]

--- a/appertivo/leads/views.py
+++ b/appertivo/leads/views.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -12,8 +13,7 @@ from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from dotenv import load_dotenv
-load_dotenv()
-import os
+
 from .models import Lead, LeadRun
 from .tasks import (
     build_lead_run_pipeline,
@@ -23,7 +23,37 @@ from .tasks import (
     store_lead_entries,
 )
 
+load_dotenv()
+
 logger = logging.getLogger(__name__)
+
+TOP_CULINARY_CITIES: list[str] = [
+    "New York, NY",
+    "Los Angeles, CA",
+    "Chicago, IL",
+    "San Francisco, CA",
+    "Houston, TX",
+    "Austin, TX",
+    "Portland, OR",
+    "Seattle, WA",
+    "New Orleans, LA",
+    "Nashville, TN",
+    "Miami, FL",
+    "Charleston, SC",
+    "Atlanta, GA",
+    "Boston, MA",
+    "Philadelphia, PA",
+    "Denver, CO",
+    "Washington, DC",
+    "Las Vegas, NV",
+    "San Diego, CA",
+    "San Antonio, TX",
+    "Minneapolis, MN",
+    "Phoenix, AZ",
+    "Dallas, TX",
+    "Detroit, MI",
+    "Kansas City, MO",
+]
 
 
 @csrf_exempt
@@ -78,11 +108,17 @@ def track_open(request: HttpRequest, slug: str) -> HttpResponse:
 def lead_dashboard(request: HttpRequest) -> HttpResponse:
     """Render a dashboard for managing Outscraper lead runs."""
 
-    runs = LeadRun.objects.prefetch_related("leads").order_by("-created_at")
+    runs_qs = LeadRun.objects.prefetch_related("leads").order_by("-created_at")
+    runs = list(runs_qs)
     pending_runs: list[LeadRun] = []
     run_cards: list[dict[str, object]] = []
+    ready_runs = 0
+    total_leads = 0
     for run in runs:
         leads = list(run.leads.all())
+        total_leads += len(leads)
+        if run.status == LeadRun.Status.READY and leads:
+            ready_runs += 1
         if not leads:
             pending_runs.append(run)
             continue
@@ -112,6 +148,13 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
         "pending_runs": pending_runs,
         "LeadRunStatus": LeadRun.Status,
         "default_limit": 10,
+        "city_choices": TOP_CULINARY_CITIES,
+        "dashboard_metrics": {
+            "total_runs": len(runs),
+            "ready_runs": ready_runs,
+            "pending_runs": len(pending_runs),
+            "total_leads": total_leads,
+        },
     }
     return render(request, "leads/dashboard.html", context)
 
@@ -121,7 +164,15 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
 def start_lead_run(request: HttpRequest) -> HttpResponse:
     """Create a new lead run and trigger the asynchronous pipeline."""
 
-    raw_city = (request.POST.get("city") or "").strip()
+    selection = (request.POST.get("city_choice") or "").strip()
+    custom_city = (request.POST.get("custom_city") or "").strip()
+    if selection and selection != "__custom__":
+        raw_city = selection
+    elif selection == "__custom__":
+        raw_city = custom_city
+    else:
+        legacy_city = (request.POST.get("city") or "").strip()
+        raw_city = custom_city or legacy_city
     city = raw_city or None
     raw_limit = request.POST.get("limit")
     try:
@@ -136,6 +187,16 @@ def start_lead_run(request: HttpRequest) -> HttpResponse:
         status=LeadRun.Status.FETCHING,
     )
     build_lead_run_pipeline(run.id, city=city, limit=limit)
+    return redirect("lead-dashboard")
+
+
+@login_required
+@require_POST
+def delete_run(request: HttpRequest, run_id: int) -> HttpResponse:
+    """Delete a lead run and its associated leads."""
+
+    run = get_object_or_404(LeadRun, pk=run_id)
+    run.delete()
     return redirect("lead-dashboard")
 
 


### PR DESCRIPTION
## Summary
- add a metrics banner and ready-state cues to the leads dashboard so completed runs are visible immediately
- convert the target city input into a curated dropdown with an optional custom entry and pass choices through the view
- allow deleting lead runs from the dashboard and cover the new flows with dashboard view tests

## Testing
- python manage.py test appertivo.leads.tests.test_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dc3e006b388332bfc2a90f8f8439b0