### PR TITLE
Link Outscraper webhook results to lead runs

### DIFF
--- a/appertivo/leads/migrations/0003_leadrun_outscraper_job_id.py
+++ b/appertivo/leads/migrations/0003_leadrun_outscraper_job_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("leads", "0002_leadrun_lead_shortlisted_lead_run"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="leadrun",
+            name="outscraper_job_id",
+            field=models.CharField(blank=True, max_length=100, null=True, unique=True),
+        ),
+    ]

--- a/appertivo/leads/models.py
+++ b/appertivo/leads/models.py
@@ -22,6 +22,7 @@ class LeadRun(models.Model):
         choices=Status.choices,
         default=Status.CREATED,
     )
+    outscraper_job_id = models.CharField(max_length=100, blank=True, null=True, unique=True)
     expected_leads = models.PositiveIntegerField(default=10)
     total_leads = models.PositiveIntegerField(default=0)
     processed_leads = models.PositiveIntegerField(default=0)

--- a/appertivo/leads/tasks.py
+++ b/appertivo/leads/tasks.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover - optional dependency for local dev
     OpenAI = None  # type: ignore
 
 from .models import Concept, DishIdea, Lead, LeadRun
-from .utils import pick_city
+from .utils import extract_outscraper_job_id, pick_city
 
 
 DEFAULT_WEBHOOK_URL = "https://appertivo.com/leads/outscraper-webhook/"
@@ -220,7 +220,12 @@ def fetch_leads(
         logger.exception("Outscraper request failed: %s", exc)
         return []
 
-    payload = resolve_outscraper_payload(response.json(), headers)
+    initial_payload = response.json()
+    payload = resolve_outscraper_payload(initial_payload, headers)
+    job_id = extract_outscraper_job_id(payload) or extract_outscraper_job_id(initial_payload)
+    if run is not None and job_id and run.outscraper_job_id != job_id:
+        run.outscraper_job_id = job_id
+        run.save(update_fields=["outscraper_job_id"])
     entries = extract_lead_entries(payload)
     if not entries:
         if isinstance(payload, dict):
@@ -376,9 +381,10 @@ def dispatch_lead_pipeline(
             run = None
     if run is not None:
         if not lead_ids:
-            run.status = LeadRun.Status.READY
-            run.processed_leads = run.total_leads
-            run.save(update_fields=["status", "processed_leads"])
+            if run.status != LeadRun.Status.FETCHING:
+                run.status = LeadRun.Status.READY
+                run.processed_leads = run.total_leads
+                run.save(update_fields=["status", "processed_leads"])
             return
         run.status = LeadRun.Status.PREPARING
         run.processed_leads = 0

--- a/appertivo/leads/tests/test_tasks.py
+++ b/appertivo/leads/tests/test_tasks.py
@@ -13,7 +13,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "specials.settings")
 django.setup()
 
 from appertivo.leads.models import Lead, LeadRun
-from appertivo.leads.tasks import fetch_leads
+from appertivo.leads.tasks import dispatch_lead_pipeline, fetch_leads
 
 
 class FetchLeadsTaskTests(TestCase):
@@ -67,6 +67,7 @@ class FetchLeadsTaskTests(TestCase):
 
         run.refresh_from_db()
         self.assertEqual(run.status, LeadRun.Status.PREPARING)
+        self.assertEqual(run.outscraper_job_id, "job-123")
 
     @override_settings(OUTSCRAPER_API_KEY="test-key")
     @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
@@ -87,6 +88,19 @@ class FetchLeadsTaskTests(TestCase):
 
         self.assertEqual(lead_ids, [])
         mock_logger.info.assert_any_call("Outscraper job %s not ready: %s", "job-456", "pending")
+
+
+class DispatchLeadPipelineTests(TestCase):
+    """Validate dispatch_lead_pipeline coordination behaviours."""
+
+    def test_dispatch_pipeline_keeps_fetching_run_without_leads(self) -> None:
+        run = LeadRun.objects.create(status=LeadRun.Status.FETCHING, total_leads=0, processed_leads=0)
+
+        dispatch_lead_pipeline(lead_ids=[], run_id=run.id, send_email=False)
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, LeadRun.Status.FETCHING)
+        self.assertEqual(run.processed_leads, 0)
 
 
 class OutscraperWebhookViewTests(TestCase):
@@ -120,3 +134,37 @@ class OutscraperWebhookViewTests(TestCase):
         lead.refresh_from_db()
         self.assertEqual(lead.name, "Updated Name")
         self.assertEqual(lead.json_data["city"], "Miami, FL")
+
+    @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
+    @patch("appertivo.leads.views.dispatch_lead_pipeline.delay")
+    def test_webhook_links_results_to_run(self, mock_delay: Mock) -> None:
+        run = LeadRun.objects.create(city="Santa Fe, NM", outscraper_job_id="job-999", status=LeadRun.Status.FETCHING)
+
+        payload = {
+            "id": "job-999",
+            "data": [
+                {
+                    "name": "Coyote Cafe",
+                    "email": "chef@coyotecafe.com",
+                    "city": "Santa Fe, NM",
+                }
+            ],
+        }
+
+        response = self.client.post(
+            reverse("outscraper_webhook"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        lead = Lead.objects.get(email="chef@coyotecafe.com")
+        self.assertEqual(lead.run, run)
+
+        run.refresh_from_db()
+        self.assertEqual(run.total_leads, 1)
+        mock_delay.assert_called_once()
+        args, kwargs = mock_delay.call_args
+        self.assertIn(lead.id, args[0])
+        self.assertEqual(kwargs["run_id"], run.id)

--- a/appertivo/leads/tests/test_utils.py
+++ b/appertivo/leads/tests/test_utils.py
@@ -10,3 +10,13 @@ def test_pick_city_returns_seed_city():
     cities = {utils.pick_city() for _ in range(100)}
     for city in cities:
         assert city in utils.CITIES
+
+
+def test_extract_outscraper_job_id_direct_key() -> None:
+    payload = {"id": "job-123", "status": "Pending"}
+    assert utils.extract_outscraper_job_id(payload) == "job-123"
+
+
+def test_extract_outscraper_job_id_nested_payload() -> None:
+    payload = {"metadata": {"task_id": "abc-789"}, "data": []}
+    assert utils.extract_outscraper_job_id(payload) == "abc-789"

--- a/appertivo/leads/utils.py
+++ b/appertivo/leads/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import random
-from typing import List
+from typing import Iterable, List, Mapping
 
 CITIES: List[str] = [
     "New York, NY",
@@ -37,3 +37,28 @@ def pick_city() -> str:
     """Return a random city from the curated list."""
 
     return random.choice(CITIES)
+
+
+def extract_outscraper_job_id(payload: object) -> str | None:
+    """Return an Outscraper job identifier from nested payload structures."""
+
+    def _search(candidate: object) -> str | None:
+        if isinstance(candidate, Mapping):
+            for key in ("id", "job_id", "task_id", "request_id"):
+                value = candidate.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for key in ("metadata", "Meta", "info", "Info"):
+                nested = candidate.get(key)
+                if nested is not None:
+                    found = _search(nested)
+                    if found:
+                        return found
+        elif isinstance(candidate, Iterable) and not isinstance(candidate, (str, bytes)):
+            for item in candidate:
+                found = _search(item)
+                if found:
+                    return found
+        return None
+
+    return _search(payload)

--- a/appertivo/leads/views.py
+++ b/appertivo/leads/views.py
@@ -17,11 +17,13 @@ from dotenv import load_dotenv
 from .models import Lead, LeadRun
 from .tasks import (
     build_lead_run_pipeline,
+    dispatch_lead_pipeline,
     extract_lead_entries,
     resolve_outscraper_payload,
     send_personalized_email,
     store_lead_entries,
 )
+from .utils import extract_outscraper_job_id
 
 load_dotenv()
 
@@ -70,12 +72,37 @@ def outscraper_webhook(request: HttpRequest) -> JsonResponse:
     headers = {"X-API-KEY": api_key} if api_key else None
     resolved_payload = resolve_outscraper_payload(payload, headers)
     entries = extract_lead_entries(resolved_payload)
+    job_id = extract_outscraper_job_id(payload) or extract_outscraper_job_id(resolved_payload)
+    run = None
+    if job_id:
+        run = LeadRun.objects.filter(outscraper_job_id=job_id).first()
 
     if not entries:
         logger.info("Received Outscraper webhook with no lead entries")
+        if run is not None:
+            run.status = LeadRun.Status.READY
+            run.processed_leads = run.total_leads
+            run.save(update_fields=["status", "processed_leads"])
         return JsonResponse({"status": "ok", "processed": 0})
 
-    lead_ids = store_lead_entries(entries, city=None, run=None)
+    existing_ids: set[int] = set()
+    if run is not None:
+        existing_ids = set(run.leads.values_list("id", flat=True))
+
+    lead_ids = store_lead_entries(entries, city=run.city if run else None, run=run)
+    if run is not None:
+        new_ids = [lead_id for lead_id in lead_ids if lead_id not in existing_ids]
+        run.total_leads = run.leads.count()
+        if run.total_leads and run.total_leads > run.expected_leads:
+            run.expected_leads = run.total_leads
+        run.save(update_fields=["total_leads", "expected_leads"])
+        if new_ids:
+            dispatch_lead_pipeline.delay(new_ids, run_id=run.pk, send_email=False)
+        else:
+            run.status = LeadRun.Status.READY
+            run.processed_leads = run.total_leads
+            run.save(update_fields=["status", "processed_leads"])
+
     logger.info("Processed %s leads from Outscraper webhook", len(lead_ids))
     return JsonResponse({"status": "ok", "processed": len(lead_ids)})
 


### PR DESCRIPTION
## Summary
- persist Outscraper job identifiers on lead runs so webhook callbacks can be matched
- update the webhook handler to attach new leads to the originating run and resume the pipeline
- cover the new helpers and behaviours with unit tests and add a migration for the job id field

## Testing
- python manage.py test appertivo.leads.tests

------
https://chatgpt.com/codex/tasks/task_e_68dc4202361c83328ae53e3ded84e614