### PR TITLE
Refine staff article workflow UX and footer links

### DIFF
--- a/app/templates/layouts/marketing.html
+++ b/app/templates/layouts/marketing.html
@@ -91,7 +91,7 @@
         </ul>
       </div>
       <div class="space-y-3">
-        <h3 class="text-sm font-semibold uppercase tracking-widest text-white/60">Future Articles</h3>
+        <h3 class="text-sm font-semibold uppercase tracking-widest text-white/60">Recent Articles</h3>
         {% with articles=footer_articles|default:None %}
           {% if articles %}
             <ul class="space-y-2 text-sm">

--- a/app/views.py
+++ b/app/views.py
@@ -449,7 +449,7 @@ def home_view(request):
         "demo_dish_favorite": demo_dish_favorite,
         "demo_restaurant": demo_restaurant,
         "demo_user_id": DEMO_USER_ID,
-        "footer_articles": _footer_articles(),
+        "footer_articles": _footer_articles(limit=3),
     }
 
     return render(request, "home.html", context)

--- a/articles/tasks.py
+++ b/articles/tasks.py
@@ -145,7 +145,6 @@ def generate_research_draft(step_id: int, *, client: Optional[Any] = None) -> No
         f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
         f"\n\nContext notes: {context_details.get('context', '')}"
         f"\n\nExtracted PDF notes: {context_details.get('pdf_context', '')}"
-        f"\n\nTopic focus: {context_details.get('topic', '')}"
     )
 
     try:

--- a/articles/templates/articles/_concept_results.html
+++ b/articles/templates/articles/_concept_results.html
@@ -18,9 +18,12 @@
       <p class="mt-1 whitespace-pre-wrap">{{ ideas_payload.notes }}</p>
     </div>
   {% endif %}
-  <div class="grid gap-4 md:grid-cols-2">
+  <div class="grid gap-4 md:grid-cols-2" data-concepts-list>
     {% for idea in ideas %}
-      <div class="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+      <div
+        data-concept-card
+        class="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm transition-all duration-300"
+      >
         <div class="space-y-2">
           <p class="text-xs uppercase font-semibold text-[#7B1FA2]">Idea {{ forloop.counter }}</p>
           <h4 class="text-lg font-semibold text-[#14080E]">{{ idea.title }}</h4>

--- a/articles/templates/articles/_draft_workflow.html
+++ b/articles/templates/articles/_draft_workflow.html
@@ -21,26 +21,13 @@
         <p class="mt-2 whitespace-pre-wrap">{{ draft_summary }}</p>
       </div>
     {% endif %}
-    {% if citations %}
-      <div class="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
-        <p class="text-sm font-semibold text-emerald-700">Citations gathered</p>
-        <ul class="mt-2 space-y-1 text-xs text-emerald-800">
-          {% for citation in citations %}
-            <li>
-              {% if citation.title %}<span class="font-semibold">{{ citation.title }}.</span>{% endif %}
-              {% if citation.url %}<a href="{{ citation.url }}" target="_blank" rel="noopener" class="underline">{{ citation.url }}</a>{% endif %}
-              {% if citation.note %}<span class="ml-1">({{ citation.note }})</span>{% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
     <form
       method="post"
       hx-post="{% url 'articles:staff_finalize_article' %}"
       hx-target="#final-article-panel"
       hx-swap="innerHTML"
       hx-indicator="#finalize-loading"
+      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
       class="space-y-4"
       data-loading-message="Polishing the draft…"
       data-disable-global-overlay
@@ -62,6 +49,14 @@
           <span class="text-xs text-red-600">{{ error }}</span>
         {% endfor %}
       </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
+        {{ draft_form.editor_notes.label }}
+        {{ draft_form.editor_notes }}
+        <span class="text-xs font-normal text-slate-500">Optional: add clarifications or tone guidance for the final polish.</span>
+        {% for error in draft_form.editor_notes.errors %}
+          <span class="text-xs text-red-600">{{ error }}</span>
+        {% endfor %}
+      </label>
       <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-xs text-slate-500">Continuing sends the edited draft to gpt-4.1-nano for professional polish and SEO metadata.</p>
         <button
@@ -79,6 +74,27 @@
         Polishing…
       </span>
     </form>
+    {% if citations %}
+      <div class="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-sm font-semibold text-emerald-700">Research citations</p>
+          <span class="text-xs font-medium text-emerald-600">{{ citations|length }} source{% if citations|length != 1 %}s{% endif %}</span>
+        </div>
+        <div class="mt-3 max-h-56 space-y-2 overflow-y-auto pr-1 text-xs text-emerald-900">
+          {% for citation in citations %}
+            <div class="rounded-xl border border-emerald-200 bg-white/70 p-2">
+              {% if citation.title %}<p class="font-semibold text-emerald-800">{{ citation.title }}</p>{% endif %}
+              {% if citation.url %}
+                <a href="{{ citation.url }}" target="_blank" rel="noopener" class="break-all text-emerald-700 underline">{{ citation.url }}</a>
+              {% endif %}
+              {% if citation.note %}
+                <p class="mt-1 text-emerald-700">{{ citation.note }}</p>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
   </div>
 {% elif run and draft_pending %}
   <div

--- a/articles/templates/articles/staff_dashboard.html
+++ b/articles/templates/articles/staff_dashboard.html
@@ -13,25 +13,55 @@
 {% endblock %}
 
 {% block page_content %}
+  <style>
+    #concepts-accordion {
+      transition-property: max-height, opacity;
+    }
+
+    #concepts-accordion .concepts-body {
+      max-height: 2000px;
+      transition: max-height 0.6s ease, opacity 0.6s ease;
+    }
+
+    #concepts-accordion.is-submitting .concepts-body {
+      max-height: 200px;
+      opacity: 0.5;
+    }
+
+    [data-concept-card] {
+      transition: opacity 0.4s ease, transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+    }
+
+    [data-concept-card].concept-card--inactive {
+      opacity: 0.35;
+      transform: translateY(6px);
+      filter: grayscale(0.2);
+    }
+
+    [data-concept-card].concept-card--active {
+      border-color: rgba(94, 0, 139, 0.35);
+      box-shadow: 0 18px 35px -20px rgba(94, 0, 139, 0.4);
+    }
+  </style>
   <div class="px-4 py-6 space-y-6">
     <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
       <section class="space-y-6">
         <details
           id="concepts-accordion"
-          class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5"
-          {% if not ideas %}open{% endif %}
+          class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-5 transition-all duration-500 ease-in-out overflow-hidden"
+          open
         >
           <summary class="flex cursor-pointer list-none flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 class="text-lg font-semibold text-[#14080E]">1. Provide context &amp; generate concepts</h2>
-              <p class="text-sm text-slate-500 max-w-xl">Paste research context or upload supporting PDFs to guide ideation.</p>
+              <p class="text-sm text-slate-500 max-w-xl">Share research notes or upload a PDF so the model can ideate within that brief.</p>
             </div>
             <span id="concepts-loading" class="htmx-indicator inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
               <i class="fa-solid fa-circle-notch animate-spin" aria-hidden="true"></i>
               Generating…
             </span>
           </summary>
-          <div class="space-y-4 pt-4">
+          <div class="concepts-body space-y-4 pt-4">
             <form
               id="article-concepts-form"
               method="post"
@@ -41,24 +71,13 @@
               hx-swap="innerHTML"
               hx-encoding="multipart/form-data"
               hx-indicator="#concepts-loading"
-              hx-on::after-request="if (event.detail.successful) { document.getElementById('concepts-accordion').removeAttribute('open'); }"
+              hx-on::before-request="const accordion = document.getElementById('concepts-accordion'); if (accordion) { accordion.classList.add('is-submitting'); accordion.dataset.wasOpen = accordion.open ? 'true' : 'false'; accordion.open = true; }"
+              hx-on::after-request="const accordion = document.getElementById('concepts-accordion'); if (accordion) { accordion.classList.remove('is-submitting'); if (event.detail.successful) { accordion.removeAttribute('open'); } else if (accordion.dataset.wasOpen === 'true') { accordion.setAttribute('open', 'open'); } }"
               class="space-y-4"
               data-loading-message="Generating article concepts…"
               data-disable-global-overlay
             >
               {% csrf_token %}
-              <div class="grid gap-4 md:grid-cols-2">
-                <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
-                  {{ form.topic.label }}
-                  {{ form.topic }}
-                  {% if form.topic.help_text %}
-                    <span class="text-xs font-normal text-slate-500">{{ form.topic.help_text }}</span>
-                  {% endif %}
-                  {% for error in form.topic.errors %}
-                    <span class="text-xs text-red-600">{{ error }}</span>
-                  {% endfor %}
-                </label>
-              </div>
               <div class="grid gap-4">
                 <label class="flex flex-col gap-1 text-sm font-medium text-[#14080E]">
                   {{ form.context.label }}
@@ -183,11 +202,26 @@
           return;
         }
         const button = findLoadingButton(trigger);
-        if (!button) {
-          return;
+        if (button) {
+          toggleButtonState(button, true);
+          trigger.__loadingButton = button;
         }
-        toggleButtonState(button, true);
-        trigger.__loadingButton = button;
+
+        const conceptCard = typeof trigger.closest === "function" ? trigger.closest("[data-concept-card]") : null;
+        if (conceptCard) {
+          const list = conceptCard.parentElement;
+          if (list && list.matches("[data-concepts-list]")) {
+            list.querySelectorAll("[data-concept-card]").forEach(function (card) {
+              card.classList.remove("concept-card--active");
+              if (card !== conceptCard) {
+                card.classList.add("concept-card--inactive");
+              }
+            });
+            conceptCard.classList.remove("concept-card--inactive");
+            conceptCard.classList.add("concept-card--active");
+            list.prepend(conceptCard);
+          }
+        }
       });
 
       function resetButton(event) {
@@ -204,6 +238,17 @@
 
       document.body.addEventListener("htmx:afterRequest", resetButton);
       document.body.addEventListener("htmx:responseError", resetButton);
+      document.body.addEventListener("htmx:afterSwap", function (event) {
+        const target = event.detail && event.detail.target;
+        if (!target || target.id !== "draft-workflow") {
+          return;
+        }
+        document.querySelectorAll("[data-concepts-list]").forEach(function (list) {
+          list.querySelectorAll("[data-concept-card]").forEach(function (card) {
+            card.classList.remove("concept-card--inactive");
+          });
+        });
+      });
     });
   </script>
 

--- a/articles/tests/test_staff_dashboard.py
+++ b/articles/tests/test_staff_dashboard.py
@@ -56,7 +56,6 @@ class StaffDashboardTests(TestCase):
         response = self.client.post(
             reverse("articles:staff_generate_concepts"),
             {
-                "topic": "Inventory tactics",
                 "context": "Recent interviews about food waste.",
             },
             HTTP_HX_REQUEST="true",
@@ -74,7 +73,7 @@ class StaffDashboardTests(TestCase):
     def test_generate_concepts_requires_context_or_pdf(self):
         response = self.client.post(
             reverse("articles:staff_generate_concepts"),
-            {"topic": "Inventory tactics", "context": ""},
+            {"context": ""},
             HTTP_HX_REQUEST="true",
         )
         self.assertEqual(response.status_code, 400)
@@ -88,7 +87,7 @@ class StaffDashboardTests(TestCase):
             run=run,
             name="ideas",
             status="ok",
-            input_payload={"topic": "Inventory", "context": "Inventory", "pdf_context": "Research"},
+            input_payload={"context": "Inventory", "pdf_context": "Research"},
             output_payload={
                 "ideas": [
                     {"title": "Idea One", "subtitle": "Subtitle"},
@@ -136,7 +135,7 @@ class StaffDashboardTests(TestCase):
             run=run,
             name="ideas",
             status="ok",
-            input_payload={"topic": "Inventory", "context": "Inventory", "pdf_context": "Research"},
+            input_payload={"context": "Inventory", "pdf_context": "Research"},
             output_payload={
                 "ideas": [
                     {"title": "Idea One", "subtitle": "Subtitle"},
@@ -189,7 +188,6 @@ class StaffDashboardTests(TestCase):
         response = self.client.post(
             reverse("articles:staff_generate_concepts"),
             {
-                "topic": "Inventory tactics",
                 "context": "",
                 "pdf_upload": pdf_file,
             },

--- a/articles/tests/test_tasks.py
+++ b/articles/tests/test_tasks.py
@@ -45,7 +45,7 @@ class RunStepTaskTests(TestCase):
         step = RunStep.objects.create(
             run=self.run,
             name="ideas",
-            input_payload={"topic": "staffing"},
+            input_payload={"context": "staffing research"},
         )
         client = DummyClient('{"ideas": [{"title": "Idea"}], "notes": "Note"}')
 
@@ -71,7 +71,7 @@ class RunStepTaskTests(TestCase):
         step = RunStep.objects.create(
             run=self.run,
             name="ideas",
-            input_payload={"topic": "staffing"},
+            input_payload={"context": "staffing research"},
         )
         client = DummyClient('{"ideas": [{"title": "Idea"}], "notes": "Note"}')
 

--- a/articles/views.py
+++ b/articles/views.py
@@ -22,23 +22,11 @@ from .utils import apply_usage_cost, ensure_dict, ensure_list, sections_to_markd
 logger = logging.getLogger(__name__)
 
 class ArticleConceptForm(forms.Form):
-    topic = forms.CharField(
-        label="Working focus",
-        required=False,
-        max_length=200,
-        widget=forms.TextInput(
-            attrs={
-                "placeholder": "Example: Sustainability in independent restaurants",
-                "class": "rounded-xl border border-slate-200 px-3 py-2",
-            }
-        ),
-        help_text="Optional working angle for the article concepts.",
-    )
     context = forms.CharField(
         label="Research context",
         required=False,
         widget=forms.Textarea(attrs={"rows": 6, "class": "rounded-xl border border-slate-200 p-3"}),
-        help_text="Optional unless you upload a PDF — add quick notes to ground the concepts.",
+        help_text="Paste research notes or a summary of the uploaded PDF so concepts stay on brief.",
     )
     pdf_upload = forms.FileField(
         label="Attach PDF research",
@@ -80,6 +68,17 @@ class ArticleDraftReviewForm(forms.Form):
     draft_body = forms.CharField(
         label="Editable draft",
         widget=forms.Textarea(attrs={"rows": 16, "class": "font-mono text-sm rounded-xl border border-slate-200 p-3"}),
+    )
+    editor_notes = forms.CharField(
+        label="Editor comments for final polish",
+        required=False,
+        widget=forms.Textarea(
+            attrs={
+                "rows": 4,
+                "class": "rounded-xl border border-slate-200 p-3 text-sm",
+                "placeholder": "Optional notes to shape the polished article…",
+            }
+        ),
     )
 
 
@@ -174,6 +173,7 @@ def _prepare_draft_details(
                 "run_id": run.id,
                 "draft_title": draft_title or "",
                 "draft_body": draft_markdown,
+                "editor_notes": draft_payload.get("editor_notes", ""),
             }
         )
 
@@ -337,7 +337,6 @@ def staff_generate_concepts(request):
             status=400,
         )
 
-    topic = form.cleaned_data.get("topic") or "Independent restaurant operations"
     context_text = form.cleaned_data["context"]
     pdf_upload = form.cleaned_data.get("pdf_upload")
     pdf_text = extract_pdf_text(pdf_upload) if pdf_upload else ""
@@ -352,7 +351,6 @@ def staff_generate_concepts(request):
     )
     if pdf_text:
         prompt += f"Extracted PDF notes:\n{pdf_text}\n\n"
-    prompt += f"Working focus: {topic}"
     response = client.responses.create(model="gpt-4.1-nano", input=prompt)
     response_dict = (
         response.model_dump() if hasattr(response, "model_dump") else getattr(response, "to_dict", lambda: {})()
@@ -370,7 +368,6 @@ def staff_generate_concepts(request):
                 }
             )
     run_payload = {
-        "topic": topic,
         "context": context_text,
         "pdf_context": pdf_text,
     }
@@ -537,6 +534,13 @@ def staff_finalize_article(request):
 
     draft_body = form.cleaned_data["draft_body"]
     draft_title = form.cleaned_data["draft_title"]
+    editor_notes = form.cleaned_data.get("editor_notes", "")
+
+    if editor_notes:
+        draft_payload["editor_notes"] = editor_notes
+    elif "editor_notes" in draft_payload:
+        draft_payload.pop("editor_notes")
+    RunStep.objects.filter(pk=draft_step.pk).update(output_payload=draft_payload)
 
     client = get_openai_client()
     prompt = (
@@ -546,6 +550,7 @@ def staff_finalize_article(request):
         f"\n\nSelected concept: {json.dumps(selected_idea, ensure_ascii=False)}"
         f"\n\nEditor summary: {summary}"
         f"\n\nCitations: {json.dumps(citations, ensure_ascii=False)}"
+        f"\n\nEditor comments: {editor_notes}"
         f"\n\nDraft title: {draft_title}\nDraft body:\n{draft_body}"
     )
     response = client.responses.create(model=run.model_info or "gpt-4.1-nano", input=prompt)
@@ -566,6 +571,7 @@ def staff_finalize_article(request):
                 "title": draft_title,
                 "citations": citations,
                 "selected": selected_idea,
+                "editor_notes": editor_notes,
             },
             "output_payload": payload,
             "raw_response": response_dict,


### PR DESCRIPTION
## Summary
- open the staff concept accordion by default and remove the separate topic input, relying on research context and PDFs
- improve concept selection feedback, add editor comments and scrollable citations to the draft review, and ensure CSRF-safe finalize requests
- surface the three most recent article titles in the marketing footer and update related tests

## Testing
- python manage.py test articles.tests.test_staff_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dc40cb17bc8332a1cee4a16e77669b