### PR TITLE
Add staff-only navigation links for internal tools

### DIFF
--- a/app/templates/layouts/app.html
+++ b/app/templates/layouts/app.html
@@ -79,7 +79,9 @@
         <a href="{% url 'favorites' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Favorites</a>
         <a href="{% url 'menus' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Menus</a>
         {% if request.user.is_staff %}
-          <a href="{% url 'articles:staff_dashboard' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Article Studio</a>
+          <a href="{% url 'lead-dashboard' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Leads</a>
+          <a href="{% url 'articles:staff_dashboard' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Staff Articles</a>
+          <a href="{% url 'dashboard:overview' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Internal Dashboard</a>
         {% endif %}
 
         <a href="{% url 'settings' %}" class="rounded-lg px-3 py-2 transition hover:bg-slate-100">Settings</a>

--- a/tests/test_staff_navigation_links.py
+++ b/tests/test_staff_navigation_links.py
@@ -1,0 +1,51 @@
+"""Tests for staff-only dashboard navigation links."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app import models
+
+
+class StaffNavigationLinkTests(TestCase):
+    """Ensure internal navigation links only appear for staff users."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.account = models.Account.objects.create(name="Test Account")
+        self.restaurant = models.Restaurant.objects.create(
+            account=self.account,
+            name="Test Bistro",
+            location_text="New York",
+        )
+        self.staff_user = user_model.objects.create_user(
+            username="staffer",
+            email="staff@example.com",
+            password="password123",
+            is_staff=True,
+        )
+        self.member_user = user_model.objects.create_user(
+            username="member",
+            email="member@example.com",
+            password="password123",
+        )
+        models.Membership.objects.create(account=self.account, user=self.staff_user)
+        models.Membership.objects.create(account=self.account, user=self.member_user)
+
+    def test_staff_user_sees_internal_links(self) -> None:
+        """Staff users should see the leads, articles, and dashboard links."""
+
+        self.client.force_login(self.staff_user)
+        response = self.client.get(reverse("menus"))
+        self.assertContains(response, f'href="{reverse("lead-dashboard")}"')
+        self.assertContains(response, f'href="{reverse("articles:staff_dashboard")}"')
+        self.assertContains(response, f'href="{reverse("dashboard:overview")}"')
+
+    def test_member_does_not_see_internal_links(self) -> None:
+        """Non-staff members should not see staff-only navigation links."""
+
+        self.client.force_login(self.member_user)
+        response = self.client.get(reverse("menus"))
+        self.assertNotContains(response, f'href="{reverse("lead-dashboard")}"')
+        self.assertNotContains(response, f'href="{reverse("articles:staff_dashboard")}"')
+        self.assertNotContains(response, f'href="{reverse("dashboard:overview")}"')


### PR DESCRIPTION
## Summary
- add staff-only navigation entries for the leads dashboard, staff articles, and the internal dashboard
- cover the new navigation with tests to confirm visibility for staff users only

## Testing
- python manage.py test tests.test_staff_navigation_links

------
https://chatgpt.com/codex/tasks/task_e_68dc434e3290833281ff1ec40a0ed4a1