### PR TITLE
Handle missing Stripe key during onboarding checkout

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -3480,7 +3480,20 @@ def create_checkout_session_view(request):
         return JsonResponse({"error": "No account found"}, status=400)
     
     account = membership.account
-    
+
+    stripe_secret = getattr(settings, "STRIPE_SECRET_KEY", "")
+    if not stripe_secret:
+        logger.warning("Stripe secret key missing; cannot start onboarding checkout.")
+        return JsonResponse(
+            {
+                "error": (
+                    "Payments are temporarily unavailable. "
+                    "Please contact support to complete your onboarding."
+                )
+            },
+            status=503,
+        )
+
     _ensure_stripe_api_key()
     
     success_url = request.build_absolute_uri(reverse("checkout-success"))

--- a/tests/test_appertivo_views.py
+++ b/tests/test_appertivo_views.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from decimal import Decimal
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
@@ -1251,6 +1252,21 @@ class ViewSmokeTests(TestCase):
 
         cancel = self.client.post(reverse("billing-cancel"))
         self.assertEqual(cancel.status_code, 302)
+
+    @patch("app.views.stripe.checkout.Session.create")
+    def test_onboarding_checkout_requires_configured_stripe_key(
+        self, mock_checkout
+    ):
+        with override_settings(STRIPE_SECRET_KEY=""):
+            self.assertEqual(settings.STRIPE_SECRET_KEY, "")
+            response = self.client.post(reverse("create-checkout"))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.json()["error"],
+            "Payments are temporarily unavailable. Please contact support to complete your onboarding.",
+        )
+        mock_checkout.assert_not_called()
 
     def test_job_status_and_notifications(self):
         job = models.Job.objects.create(


### PR DESCRIPTION
## Summary
- return a clear error message when the Stripe secret key is not configured for onboarding checkout
- add a regression test to ensure onboarding checkout is blocked when the Stripe key is missing

## Testing
- python manage.py test tests.test_appertivo_views.ViewSmokeTests.test_onboarding_checkout_requires_configured_stripe_key

------
https://chatgpt.com/codex/tasks/task_e_68dc51a42a508332bce2b107717b3942