### PR TITLE
Add HTMX-refreshable lead dashboard panel

### DIFF
--- a/appertivo/leads/templates/leads/_dashboard_panel.html
+++ b/appertivo/leads/templates/leads/_dashboard_panel.html
@@ -1,0 +1,188 @@
+<div data-dashboard-polling="{% if pending_runs %}on{% else %}off{% endif %}" hidden></div>
+
+{% if pending_runs %}
+  <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-purple-200 p-6 space-y-4">
+    <h2 class="text-lg font-semibold text-slate-900">Runs in progress</h2>
+    <ul class="space-y-3">
+      {% for run in pending_runs %}
+        <li class="flex items-center justify-between gap-4 rounded-xl border border-purple-100 bg-purple-50/40 px-4 py-3">
+          <div class="flex items-center gap-3">
+            <span class="lead-run-indicator" aria-hidden="true"></span>
+            <div>
+              <p class="text-sm font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</p>
+              <p class="text-xs text-slate-600">
+                {% if run.status == LeadRunStatus.READY %}
+                  Outscraper finished but no leads were returned for this run.
+                {% else %}
+                  Waiting for Outscraper to return lead data…
+                {% endif %}
+              </p>
+            </div>
+          </div>
+          <span class="text-xs font-medium text-purple-700">{{ run.get_status_display }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}
+
+{% if run_cards %}
+  {% for card in run_cards %}
+    {% with run=card.run metrics=card.metrics leads=card.leads %}
+      <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-white/60 p-6 space-y-6">
+        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-2xl font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</h2>
+              {% if run.status == LeadRunStatus.READY and leads %}
+                <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Leads ready</span>
+              {% endif %}
+            </div>
+            <p class="text-sm text-slate-500">Started {{ run.created_at|date:"M j, Y • H:i" }}</p>
+          </div>
+          <div class="flex flex-col items-start gap-3 md:items-end">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-sm font-medium text-purple-700">{{ run.get_status_display }}</span>
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ run.progress_percentage }}% ready</span>
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ metrics.total }} leads</span>
+            </div>
+            <form method="post" action="{% url 'lead-run-delete' run.id %}" class="inline">
+              {% csrf_token %}
+              <button type="submit" onclick="return confirm('Delete this run and remove its leads?');" class="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 hover:text-red-600">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+                  <path d="M6.5 3.5A1.5 1.5 0 018 2h4a1.5 1.5 0 011.5 1.5V4h3a.5.5 0 010 1h-.59l-.77 10.218A2 2 0 0113.14 17H6.86a2 2 0 01-1.99-1.782L4.1 5H3.5a.5.5 0 110-1h3zM9 7a.5.5 0 00-1 0v6a.5.5 0 001 0V7zm3 0a.5.5 0 10-1 0v6a.5.5 0 001 0V7zM8 3.5a.5.5 0 00-.5.5v.5h5V4a.5.5 0 00-.5-.5H8z" />
+                </svg>
+                Delete run
+              </button>
+            </form>
+          </div>
+        </div>
+
+        {% if run.status == LeadRunStatus.READY and leads %}
+          <p class="rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3 text-sm text-emerald-700">
+            This run is ready to work. Shortlist the restaurants to focus outreach and log who you contact.
+          </p>
+        {% endif %}
+
+        <dl class="grid md:grid-cols-4 gap-3 text-sm">
+          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
+            <dt class="text-slate-500">Shortlisted</dt>
+            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.shortlisted }}</dd>
+          </div>
+          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
+            <dt class="text-slate-500">Emails sent</dt>
+            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.emailed }}</dd>
+          </div>
+          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
+            <dt class="text-slate-500">Opens tracked</dt>
+            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.opened }}</dd>
+          </div>
+          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
+            <dt class="text-slate-500">Conversions</dt>
+            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.converted }}</dd>
+          </div>
+        </dl>
+
+        <form method="post" action="{% url 'lead-run-selection' run.id %}" class="space-y-4">
+          {% csrf_token %}
+          <div class="overflow-hidden rounded-xl border border-slate-200">
+            <table class="min-w-full divide-y divide-slate-200">
+              <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th class="px-4 py-3">Shortlist</th>
+                  <th class="px-4 py-3">Restaurant</th>
+                  <th class="px-4 py-3">Email</th>
+                  <th class="px-4 py-3">Status</th>
+                  <th class="px-4 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100 bg-white">
+                {% for entry in leads %}
+                  {% with lead=entry.instance %}
+                    <tr class="{% if lead.shortlisted %}bg-purple-50/70{% endif %}">
+                      <td class="px-4 py-3 align-top">
+                        <input type="checkbox" name="selected_leads" value="{{ lead.id }}" {% if lead.shortlisted %}checked{% endif %} class="h-4 w-4 rounded border-slate-300 text-purple-600 focus:ring-purple-500" />
+                      </td>
+                      <td class="px-4 py-3 align-top">
+                        <div class="font-medium text-slate-900">{{ lead.name }}</div>
+                        <div class="text-xs text-slate-500 flex items-center gap-1">
+                          <span>{{ lead.city|default:"Unknown city" }}</span>
+                          <span>·</span>
+                          <span>{{ lead.json_data.query|default_if_none:"Restaurant prospect" }}</span>
+                        </div>
+                      </td>
+                      <td class="px-4 py-3 align-top">
+                        {% if lead.email %}
+                          <span class="text-sm text-slate-700">{{ lead.email }}</span>
+                        {% else %}
+                          <span class="text-xs font-medium text-amber-600 bg-amber-100 rounded-full px-2 py-1">Missing email</span>
+                        {% endif %}
+                      </td>
+                      <td class="px-4 py-3 align-top">
+                        <div class="flex flex-wrap gap-2 text-xs font-medium">
+                          {% if lead.shortlisted %}
+                            <span class="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-1 text-purple-700">Shortlisted</span>
+                          {% endif %}
+                          {% if lead.emailed %}
+                            <span class="inline-flex items-center rounded-full bg-sky-100 px-2.5 py-1 text-sky-700">Emailed</span>
+                          {% endif %}
+                          {% if lead.opened %}
+                            <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-emerald-700">Opened</span>
+                          {% endif %}
+                          {% if lead.converted %}
+                            <span class="inline-flex items-center rounded-full bg-emerald-200 px-2.5 py-1 text-emerald-800">Converted</span>
+                          {% endif %}
+                          {% if not lead.shortlisted and not lead.emailed and not lead.opened and not lead.converted %}
+                            <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-slate-600">New</span>
+                          {% endif %}
+                        </div>
+                      </td>
+                      <td class="px-4 py-3 align-top">
+                        <div class="flex flex-col items-end gap-2 text-sm">
+                          {% with landing_url=entry.landing_url %}
+                            <a href="{{ landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center gap-1 text-purple-600 hover:text-purple-700">
+                              Preview landing
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+                                <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                                <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                              </svg>
+                            </a>
+                          {% endwith %}
+                          <button type="submit" name="send_email" value="{{ lead.id }}"
+                            class="inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm transition-colors {% if entry.can_send %}bg-purple-600 text-white hover:bg-purple-700{% else %}bg-slate-200 text-slate-500 cursor-not-allowed{% endif %}"
+                            {% if not entry.can_send %}disabled aria-disabled="true"{% endif %}>
+                            Send email
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  {% endwith %}
+                {% empty %}
+                  <tr>
+                    <td colspan="5" class="px-4 py-6 text-center text-sm text-slate-500">No leads yet for this run.</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+
+          <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-950 focus:outline-none focus:ring-2 focus:ring-slate-400">
+              Save shortlist
+            </button>
+            {% if run.status != LeadRunStatus.COMPLETED %}
+              <button type="submit" name="mark_complete" value="1" class="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
+                Mark run complete
+              </button>
+            {% endif %}
+          </div>
+        </form>
+      </section>
+    {% endwith %}
+  {% endfor %}
+{% elif not pending_runs %}
+  <div class="rounded-2xl border border-dashed border-purple-300 bg-white/60 p-10 text-center">
+    <h2 class="text-xl font-semibold text-slate-900">No lead runs yet</h2>
+    <p class="mt-2 text-sm text-slate-600">Kick things off by starting your first run above. We'll fetch a fresh batch of restaurants and craft personalized demos for you.</p>
+  </div>
+{% endif %}

--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -81,191 +81,40 @@
     </form>
   </section>
 
-  {% if pending_runs %}
-    <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-purple-200 p-6 space-y-4">
-      <h2 class="text-lg font-semibold text-slate-900">Runs in progress</h2>
-      <ul class="space-y-3">
-        {% for run in pending_runs %}
-          <li class="flex items-center justify-between gap-4 rounded-xl border border-purple-100 bg-purple-50/40 px-4 py-3">
-            <div class="flex items-center gap-3">
-              <span class="lead-run-indicator" aria-hidden="true"></span>
-              <div>
-                <p class="text-sm font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</p>
-                <p class="text-xs text-slate-600">
-                  {% if run.status == LeadRunStatus.READY %}
-                    Outscraper finished but no leads were returned for this run.
-                  {% else %}
-                    Waiting for Outscraper to return lead data…
-                  {% endif %}
-                </p>
-              </div>
-            </div>
-            <span class="text-xs font-medium text-purple-700">{{ run.get_status_display }}</span>
-          </li>
-        {% endfor %}
-      </ul>
-    </section>
-  {% endif %}
-
-  {% if run_cards %}
-    {% for card in run_cards %}
-      {% with run=card.run metrics=card.metrics leads=card.leads %}
-      <section class="bg-white/80 backdrop-blur rounded-2xl shadow-sm border border-white/60 p-6 space-y-6">
-        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div class="space-y-2">
-            <div class="flex flex-wrap items-center gap-2">
-              <h2 class="text-2xl font-semibold text-slate-900">Run {{ run.pk }} · {{ run.city|default:"Any city" }}</h2>
-              {% if run.status == LeadRunStatus.READY and leads %}
-                <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Leads ready</span>
-              {% endif %}
-            </div>
-            <p class="text-sm text-slate-500">Started {{ run.created_at|date:"M j, Y • H:i" }}</p>
-          </div>
-          <div class="flex flex-col items-start gap-3 md:items-end">
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-sm font-medium text-purple-700">{{ run.get_status_display }}</span>
-              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ run.progress_percentage }}% ready</span>
-              <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ metrics.total }} leads</span>
-            </div>
-            <form method="post" action="{% url 'lead-run-delete' run.id %}" class="inline">
-              {% csrf_token %}
-              <button type="submit" onclick="return confirm('Delete this run and remove its leads?');" class="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 hover:text-red-600">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-                  <path d="M6.5 3.5A1.5 1.5 0 018 2h4a1.5 1.5 0 011.5 1.5V4h3a.5.5 0 010 1h-.59l-.77 10.218A2 2 0 0113.14 17H6.86a2 2 0 01-1.99-1.782L4.1 5H3.5a.5.5 0 110-1h3zM9 7a.5.5 0 00-1 0v6a.5.5 0 001 0V7zm3 0a.5.5 0 10-1 0v6a.5.5 0 001 0V7zM8 3.5a.5.5 0 00-.5.5v.5h5V4a.5.5 0 00-.5-.5H8z" />
-                </svg>
-                Delete run
-              </button>
-            </form>
-          </div>
-        </div>
-
-        {% if run.status == LeadRunStatus.READY and leads %}
-          <p class="rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3 text-sm text-emerald-700">
-            This run is ready to work. Shortlist the restaurants to focus outreach and log who you contact.
-          </p>
-        {% endif %}
-
-        <dl class="grid md:grid-cols-4 gap-3 text-sm">
-          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
-            <dt class="text-slate-500">Shortlisted</dt>
-            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.shortlisted }}</dd>
-          </div>
-          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
-            <dt class="text-slate-500">Emails sent</dt>
-            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.emailed }}</dd>
-          </div>
-          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
-            <dt class="text-slate-500">Opens tracked</dt>
-            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.opened }}</dd>
-          </div>
-          <div class="rounded-lg border border-slate-200 bg-white px-4 py-3">
-            <dt class="text-slate-500">Conversions</dt>
-            <dd class="mt-1 text-lg font-semibold text-slate-900">{{ metrics.converted }}</dd>
-          </div>
-        </dl>
-
-        <form method="post" action="{% url 'lead-run-selection' run.id %}" class="space-y-4">
-          {% csrf_token %}
-          <div class="overflow-hidden rounded-xl border border-slate-200">
-            <table class="min-w-full divide-y divide-slate-200">
-              <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
-                <tr>
-                  <th class="px-4 py-3">Shortlist</th>
-                  <th class="px-4 py-3">Restaurant</th>
-                  <th class="px-4 py-3">Email</th>
-                  <th class="px-4 py-3">Status</th>
-                  <th class="px-4 py-3 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-slate-100 bg-white">
-                {% for entry in leads %}
-                  {% with lead=entry.instance %}
-                  <tr class="{% if lead.shortlisted %}bg-purple-50/70{% endif %}">
-                    <td class="px-4 py-3 align-top">
-                      <input type="checkbox" name="selected_leads" value="{{ lead.id }}" {% if lead.shortlisted %}checked{% endif %} class="h-4 w-4 rounded border-slate-300 text-purple-600 focus:ring-purple-500" />
-                    </td>
-                    <td class="px-4 py-3 align-top">
-                      <div class="font-medium text-slate-900">{{ lead.name }}</div>
-                      <div class="text-xs text-slate-500 flex items-center gap-1">
-                        <span>{{ lead.city|default:"Unknown city" }}</span>
-                        <span>·</span>
-                        <span>{{ lead.json_data.query|default_if_none:"Restaurant prospect" }}</span>
-                      </div>
-                    </td>
-                    <td class="px-4 py-3 align-top">
-                      {% if lead.email %}
-                        <span class="text-sm text-slate-700">{{ lead.email }}</span>
-                      {% else %}
-                        <span class="text-xs font-medium text-amber-600 bg-amber-100 rounded-full px-2 py-1">Missing email</span>
-                      {% endif %}
-                    </td>
-                    <td class="px-4 py-3 align-top">
-                      <div class="flex flex-wrap gap-2 text-xs font-medium">
-                        {% if lead.shortlisted %}
-                          <span class="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-1 text-purple-700">Shortlisted</span>
-                        {% endif %}
-                        {% if lead.emailed %}
-                          <span class="inline-flex items-center rounded-full bg-sky-100 px-2.5 py-1 text-sky-700">Emailed</span>
-                        {% endif %}
-                        {% if lead.opened %}
-                          <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-emerald-700">Opened</span>
-                        {% endif %}
-                        {% if lead.converted %}
-                          <span class="inline-flex items-center rounded-full bg-emerald-200 px-2.5 py-1 text-emerald-800">Converted</span>
-                        {% endif %}
-                        {% if not lead.shortlisted and not lead.emailed and not lead.opened and not lead.converted %}
-                          <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-slate-600">New</span>
-                        {% endif %}
-                      </div>
-                    </td>
-                    <td class="px-4 py-3 align-top">
-                      <div class="flex flex-col items-end gap-2 text-sm">
-                        {% with landing_url=entry.landing_url %}
-                          <a href="{{ landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center gap-1 text-purple-600 hover:text-purple-700">
-                            Preview landing
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
-                              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
-                              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
-                            </svg>
-                          </a>
-                        {% endwith %}
-                        <button type="submit" name="send_email" value="{{ lead.id }}"
-                          class="inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm transition-colors {% if entry.can_send %}bg-purple-600 text-white hover:bg-purple-700{% else %}bg-slate-200 text-slate-500 cursor-not-allowed{% endif %}"
-                          {% if not entry.can_send %}disabled aria-disabled="true"{% endif %}>
-                          Send email
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                  {% endwith %}
-                {% empty %}
-                  <tr>
-                    <td colspan="5" class="px-4 py-6 text-center text-sm text-slate-500">No leads yet for this run.</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-
-          <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-            <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-950 focus:outline-none focus:ring-2 focus:ring-slate-400">
-              Save shortlist
-            </button>
-            {% if run.status != LeadRunStatus.COMPLETED %}
-              <button type="submit" name="mark_complete" value="1" class="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
-                Mark run complete
-              </button>
-            {% endif %}
-          </div>
-        </form>
-      </section>
-      {% endwith %}
-    {% endfor %}
-  {% elif not pending_runs %}
-    <div class="rounded-2xl border border-dashed border-purple-300 bg-white/60 p-10 text-center">
-      <h2 class="text-xl font-semibold text-slate-900">No lead runs yet</h2>
-      <p class="mt-2 text-sm text-slate-600">Kick things off by starting your first run above. We'll fetch a fresh batch of restaurants and craft personalized demos for you.</p>
-    </div>
-  {% endif %}
+  <div
+    id="lead-dashboard-panel"
+    class="space-y-6"
+    hx-get="{% url 'lead-dashboard-panel' %}"
+    hx-trigger="load, every 5s"
+    hx-swap="innerHTML"
+  >
+    {% include "leads/_dashboard_panel.html" %}
+  </div>
 </div>
+
+<script>
+  (function () {
+    const panelContainer = document.getElementById("lead-dashboard-panel");
+    if (!panelContainer) {
+      return;
+    }
+
+    function updatePollingTrigger() {
+      const marker = panelContainer.querySelector("[data-dashboard-polling]");
+      if (!marker) {
+        return;
+      }
+      const shouldPoll = marker.dataset.dashboardPolling === "on";
+      panelContainer.setAttribute("hx-trigger", shouldPoll ? "load, every 5s" : "load");
+    }
+
+    updatePollingTrigger();
+
+    document.body.addEventListener("htmx:afterSwap", function (event) {
+      if (event.target === panelContainer) {
+        updatePollingTrigger();
+      }
+    });
+  })();
+</script>
 {% endblock %}

--- a/appertivo/leads/urls.py
+++ b/appertivo/leads/urls.py
@@ -7,6 +7,7 @@ from . import views
 
 urlpatterns = [
     path("leads/", views.lead_dashboard, name="lead-dashboard"),
+    path("leads/dashboard-panel/", views.lead_dashboard_panel, name="lead-dashboard-panel"),
     path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
     path("leads/runs/start/", views.start_lead_run, name="lead-run-start"),
     path("leads/runs/<int:run_id>/delete/", views.delete_run, name="lead-run-delete"),

--- a/appertivo/leads/views.py
+++ b/appertivo/leads/views.py
@@ -131,9 +131,8 @@ def track_open(request: HttpRequest, slug: str) -> HttpResponse:
     return redirect("lead-landing", slug=lead.slug)
 
 
-@login_required
-def lead_dashboard(request: HttpRequest) -> HttpResponse:
-    """Render a dashboard for managing Outscraper lead runs."""
+def _build_dashboard_panel_context(request: HttpRequest) -> dict[str, object]:
+    """Return the reusable context required to render the dashboard panel."""
 
     runs_qs = LeadRun.objects.prefetch_related("leads").order_by("-created_at")
     runs = list(runs_qs)
@@ -170,12 +169,10 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
             lead_entries.append({"instance": lead, "landing_url": landing_url, "can_send": can_send})
         run_cards.append({"run": run, "metrics": metrics, "leads": lead_entries})
 
-    context = {
+    return {
         "run_cards": run_cards,
         "pending_runs": pending_runs,
         "LeadRunStatus": LeadRun.Status,
-        "default_limit": 10,
-        "city_choices": TOP_CULINARY_CITIES,
         "dashboard_metrics": {
             "total_runs": len(runs),
             "ready_runs": ready_runs,
@@ -183,7 +180,26 @@ def lead_dashboard(request: HttpRequest) -> HttpResponse:
             "total_leads": total_leads,
         },
     }
+
+
+@login_required
+def lead_dashboard(request: HttpRequest) -> HttpResponse:
+    """Render a dashboard for managing Outscraper lead runs."""
+
+    context = {
+        **_build_dashboard_panel_context(request),
+        "default_limit": 10,
+        "city_choices": TOP_CULINARY_CITIES,
+    }
     return render(request, "leads/dashboard.html", context)
+
+
+@login_required
+def lead_dashboard_panel(request: HttpRequest) -> HttpResponse:
+    """Render the fragment that lists pending runs and run cards."""
+
+    context = _build_dashboard_panel_context(request)
+    return render(request, "leads/_dashboard_panel.html", context)
 
 
 @login_required

--- a/tests/test_lead_dashboard_panel.py
+++ b/tests/test_lead_dashboard_panel.py
@@ -1,0 +1,38 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from appertivo.leads.models import Lead, LeadRun
+
+
+class LeadDashboardPanelViewTests(TestCase):
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="lead-panel@example.com",
+            email="lead-panel@example.com",
+            password="password123",
+        )
+
+    def test_panel_fragment_renders_new_leads(self) -> None:
+        run = LeadRun.objects.create(
+            city="Austin, TX",
+            status=LeadRun.Status.READY,
+            expected_leads=1,
+        )
+        Lead.objects.create(
+            run=run,
+            name="Panel Bistro",
+            email="hello@panel.test",
+            city="Austin, TX",
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("lead-dashboard-panel"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "leads/_dashboard_panel.html")
+        html = response.content.decode()
+        self.assertIn("Panel Bistro", html)
+        self.assertIn(f"Run {run.pk}", html)
+        self.assertIn('data-dashboard-polling="off"', html)


### PR DESCRIPTION
## Summary
- extract the lead dashboard panel into a reusable partial template
- add an HTMX fragment view with polling guard to refresh pending run data
- cover the new fragment with a template test to ensure leads appear without reloading

## Testing
- python manage.py test tests.test_lead_dashboard_panel


------
https://chatgpt.com/codex/tasks/task_e_68dc6ceb52f88332816403fc96e7ea41