### PR TITLE
Remove favorite star badge from recent concept thumbnails

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -156,9 +156,6 @@
                             <i class="fa-solid fa-palette text-base" aria-hidden="true"></i>
                           </div>
                         {% endif %}
-                        <span class="absolute right-1 top-1 inline-flex items-center justify-center rounded-full bg-white/90 px-1.5 py-0.5 text-[10px] font-semibold text-[#FF5C00] shadow">
-                          <i class="fa-solid fa-star" aria-hidden="true"></i>
-                        </span>
                       </div>
                     {% endif %}
                     <div class="flex-1 space-y-1">


### PR DESCRIPTION
## Summary
- remove the star badge overlay from favorited concept thumbnails in the dashboard recent concepts section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd558574688332a3a72937939e6087