### PR TITLE
Redesign mobile layout for leads list

### DIFF
--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -82,61 +82,52 @@
       <h2 class="text-lg font-semibold text-slate-900">Review &amp; manage leads</h2>
       <p class="text-sm text-slate-500">Use the checkboxes to run batch approvals or manage bounce status.</p>
     </div>
-    <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white/70 shadow-sm">
-      <table class="min-w-full divide-y divide-slate-200 text-sm">
-        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
-          <tr>
-            <th class="px-4 py-3">
-              <span class="sr-only">Select</span>
-            </th>
-            <th class="px-4 py-3">Lead</th>
-            <th class="px-4 py-3">Contact</th>
-            <th class="px-4 py-3">Status</th>
-            <th class="px-4 py-3 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-slate-100 bg-white/70">
-          {% for lead in leads %}
-            <tr class="align-top">
-              <td class="px-4 py-4">
-                <input form="bulk-action-form" type="checkbox" name="lead_ids" value="{{ lead.id }}" class="h-4 w-4 rounded border-slate-300 text-purple-600 focus:ring-purple-500" />
-              </td>
-              <td class="px-4 py-4">
-                <div class="font-semibold text-slate-900">{{ lead.name }}</div>
-                <div class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</div>
-                {% if lead.landing_url %}
-                  <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="mt-1 inline-flex items-center text-xs font-medium text-purple-600 hover:text-purple-700">Open landing page</a>
-                {% endif %}
-                <details class="mt-2 text-xs text-slate-600">
-                  <summary class="cursor-pointer text-purple-600 hover:text-purple-700">View details</summary>
-                  <div class="mt-2 space-y-1">
-                    <div><span class="font-medium">Run:</span> {{ lead.run|default:"—" }}</div>
-                    <div><span class="font-medium">Created:</span> {{ lead.created_at|date:"M j, Y H:i" }}</div>
-                    {% if lead.landing_url %}
-                      <div><span class="font-medium">Landing page:</span> <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="text-purple-600 hover:text-purple-700">View landing</a></div>
-                    {% endif %}
-                    {% if lead.json_data %}
-                      <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="mt-1 inline-flex items-center rounded border border-slate-200 px-2 py-1 font-medium text-purple-600 hover:border-purple-400 hover:text-purple-700">View JSON data</button>
-                    {% endif %}
+    {% if leads %}
+      <div class="space-y-3">
+        {% for lead in leads %}
+          <article class="rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 shadow-sm">
+            <div class="flex flex-col gap-4 md:grid md:grid-cols-12 md:items-start md:gap-6">
+              <div class="flex items-start gap-3 md:col-span-5">
+                <input form="bulk-action-form" type="checkbox" name="lead_ids" value="{{ lead.id }}" class="mt-1 h-4 w-4 shrink-0 rounded border-slate-300 text-purple-600 focus:ring-purple-500" />
+                <div class="space-y-2">
+                  <div>
+                    <div class="text-base font-semibold text-slate-900">{{ lead.name }}</div>
+                    <div class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</div>
                   </div>
-                </details>
-                {% if lead.json_data %}
-                  <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
-                    <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
-                      <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-                        <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
-                        <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
-                      </div>
-                      <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
-                        <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
-                      </div>
+                  {% if lead.landing_url %}
+                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex w-full items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-purple-600 hover:border-purple-400 hover:text-purple-700 md:w-auto md:justify-start">Open landing page</a>
+                  {% endif %}
+                  <details class="text-xs text-slate-600">
+                    <summary class="cursor-pointer text-purple-600 hover:text-purple-700">View details</summary>
+                    <div class="mt-2 space-y-1">
+                      <div><span class="font-medium">Run:</span> {{ lead.run|default:"—" }}</div>
+                      <div><span class="font-medium">Created:</span> {{ lead.created_at|date:"M j, Y H:i" }}</div>
+                      {% if lead.landing_url %}
+                        <div><span class="font-medium">Landing page:</span> <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="text-purple-600 hover:text-purple-700">View landing</a></div>
+                      {% endif %}
+                      {% if lead.json_data %}
+                        <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="mt-1 inline-flex w-full items-center justify-center rounded border border-slate-200 px-2 py-1 font-medium text-purple-600 hover:border-purple-400 hover:text-purple-700 md:w-auto md:justify-start">View JSON data</button>
+                      {% endif %}
+                    </div>
+                  </details>
+                </div>
+              </div>
+              {% if lead.json_data %}
+                <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
+                  <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
+                    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+                      <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
+                      <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
+                    </div>
+                    <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
+                      <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
                     </div>
                   </div>
-                {% endif %}
-              </td>
-              <td class="px-4 py-4 space-y-1">
+                </div>
+              {% endif %}
+              <div class="space-y-2 md:col-span-3">
                 {% if lead.email %}
-                  <div class="flex items-center gap-1 text-slate-700">
+                  <div class="flex flex-wrap items-center gap-1 text-slate-700">
                     <span class="font-medium">Email:</span>
                     <a href="mailto:{{ lead.email }}" class="text-purple-600 hover:text-purple-700">{{ lead.email }}</a>
                   </div>
@@ -146,8 +137,8 @@
                 {% if lead.phone %}
                   <div class="text-slate-600"><span class="font-medium">Phone:</span> {{ lead.phone }}</div>
                 {% endif %}
-              </td>
-              <td class="px-4 py-4">
+              </div>
+              <div class="md:col-span-2">
                 <div class="flex flex-wrap gap-2">
                   {% if lead.shortlisted %}
                     <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">Approved</span>
@@ -165,46 +156,38 @@
                     <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600">Awaiting review</span>
                   {% endif %}
                 </div>
-              </td>
-              <td class="px-4 py-4 text-right">
-                <div class="flex flex-col items-end gap-2">
-                  {% if lead.landing_url %}
-                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600">View landing</a>
+              </div>
+              <div class="flex flex-col gap-2 md:col-span-2 md:items-end">
+                {% if lead.landing_url %}
+                  <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex w-full items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600 md:w-auto">View landing</a>
+                {% endif %}
+                <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:items-end">
+                  {% csrf_token %}
+                  <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
+                  {% if email_templates %}
+                    <label class="sr-only" for="template-{{ lead.id }}">Email template</label>
+                    <select id="template-{{ lead.id }}" name="template_id" class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">
+                      <option value="">Default template</option>
+                      {% for template in email_templates %}
+                        <option value="{{ template.id }}">{{ template.name }}</option>
+                      {% endfor %}
+                    </select>
                   {% endif %}
-                  <form method="post" action="{% url 'lead-actions' %}" class="inline-flex items-center gap-2">
-                    {% csrf_token %}
-                    <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
-                    {% if email_templates %}
-                      <label class="sr-only" for="template-{{ lead.id }}">Email template</label>
-                      <select id="template-{{ lead.id }}" name="template_id" class="rounded-lg border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-400">
-                        <option value="">Default template</option>
-                        {% for template in email_templates %}
-                          <option value="{{ template.id }}">{{ template.name }}</option>
-                        {% endfor %}
-                      </select>
-                    {% endif %}
-                    <button type="submit" name="action" value="approve" onclick="return confirm('Approve this lead, generate a landing page, and send the email?');" class="inline-flex items-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">
-                      Approve
-                    </button>
-                  </form>
-                  <form method="post" action="{% url 'lead-actions' %}" class="inline-flex items-center gap-2">
-                    {% csrf_token %}
-                    <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
-                    <button type="submit" name="action" value="delete" onclick="return confirm('Delete this lead?');" class="inline-flex items-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700">
-                      Delete
-                    </button>
-                  </form>
-                </div>
-              </td>
-            </tr>
-          {% empty %}
-            <tr>
-              <td colspan="5" class="px-4 py-12 text-center text-sm text-slate-500">No leads yet. Start a run above to fetch prospects.</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+                  <button type="submit" name="action" value="approve" onclick="return confirm('Approve this lead, generate a landing page, and send the email?');" class="inline-flex w-full items-center justify-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">Approve</button>
+                </form>
+                <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:items-end">
+                  {% csrf_token %}
+                  <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
+                  <button type="submit" name="action" value="delete" onclick="return confirm('Delete this lead?');" class="inline-flex w-full items-center justify-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700 md:w-auto">Delete</button>
+                </form>
+              </div>
+            </div>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="rounded-2xl border border-slate-200 bg-white/70 p-6 text-center text-sm text-slate-500 shadow-sm">No leads yet. Start a run above to fetch prospects.</div>
+    {% endif %}
 
     <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 md:flex-row md:items-center md:justify-between">
       <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- replace the leads dashboard table with a responsive card layout so the action controls stay visible on small screens
- keep contact details, status badges, and JSON modal access within the new layout while improving spacing on mobile
- show a styled empty state card when no leads are available

## Testing
- not run (template change only)


------
https://chatgpt.com/codex/tasks/task_e_68de971bb0548332859ea2361ee967d3