### PR TITLE
Handle file-like Replicate outputs

### DIFF
--- a/appertivo/assets/tasks.py
+++ b/appertivo/assets/tasks.py
@@ -23,6 +23,13 @@ def _collect_preview_candidates(output: object) -> Iterable[bytes | str]:
     if output is None:
         return []
 
+    if hasattr(output, "read"):
+        try:
+            return [bytes(output.read())]
+        except Exception:  # pragma: no cover - defensive guard
+            logger.warning("Failed to read file-like Replicate output", exc_info=True)
+            return []
+
     if isinstance(output, (bytes, bytearray)):
         return [bytes(output)]
 

--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -212,6 +212,27 @@ class AssetDashboardTests(TestCase):
         default_storage.delete(job.storage_path)
 
     @patch("appertivo.assets.tasks.replicate_client")
+    def test_run_preview_job_handles_file_output(self, mock_replicate: Mock) -> None:
+        """File-like outputs from Replicate are read and stored."""
+
+        class DummyFile:
+            def __init__(self, data: bytes) -> None:
+                self._data = data
+
+            def read(self) -> bytes:
+                return self._data
+
+        mock_replicate.run.return_value = DummyFile(b"file-bytes")
+        job = AssetPreviewJob.objects.create(model=self.model, prompt="File please")
+        tasks.run_preview_job(job.pk)
+        job.refresh_from_db()
+        self.assertEqual(job.status, AssetPreviewJob.Status.SUCCESS)
+        self.assertTrue(job.preview_url)
+        self.assertTrue(job.storage_path)
+        self.assertTrue(default_storage.exists(job.storage_path))
+        default_storage.delete(job.storage_path)
+
+    @patch("appertivo.assets.tasks.replicate_client")
     def test_run_preview_job_handles_errors(self, mock_replicate: Mock) -> None:
         """Unexpected errors mark the job as failed with a message."""
 


### PR DESCRIPTION
## Summary
- add support for file-like Replicate responses when collecting preview candidates
- add a regression test ensuring file-based outputs are saved successfully

## Testing
- python manage.py test appertivo.assets.tests.test_dashboard.AssetDashboardTests.test_run_preview_job_handles_file_output

------
https://chatgpt.com/codex/tasks/task_e_68de9d1501848332b2843b801fe6d1a1