### PR TITLE
Improve logging handler resilience and configurability

### DIFF
--- a/dashboard/tests/test_logging_handlers.py
+++ b/dashboard/tests/test_logging_handlers.py
@@ -1,0 +1,82 @@
+"""Tests covering the custom logging handlers."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from specials.logging_handlers import DailyJsonFileHandler
+
+
+class DailyJsonFileHandlerTests(SimpleTestCase):
+    """Validate the custom JSON logging handler behaviour."""
+
+    def test_handler_writes_to_env_override(self) -> None:
+        """Environment overrides should determine the log output path."""
+
+        with TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "nested" / "app-log.json"
+            with mock.patch.dict(os.environ, {"APP_LOG_FILE": str(log_path)}, clear=False):
+                handler = DailyJsonFileHandler(os.environ["APP_LOG_FILE"])
+                record = logging.LogRecord(
+                    name="appertivo.tests",  # pragma: no branch - deterministic name for record logger
+                    level=logging.INFO,
+                    pathname=__file__,
+                    lineno=0,
+                    msg="json handler env override",
+                    args=(),
+                    exc_info=None,
+                )
+
+                handler.emit(record)
+
+            self.assertTrue(log_path.exists())
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            payload = json.loads(lines[0])
+            self.assertEqual(payload["message"], "json handler env override")
+
+    def test_handler_degrades_when_path_unwritable(self) -> None:
+        """The handler should fall back to console logging when it cannot write."""
+
+        logger = logging.getLogger("appertivo.tests.logging")
+        original_handlers = list(logger.handlers)
+        original_level = logger.level
+        original_propagate = logger.propagate
+        fallback_stream = io.StringIO()
+        fallback_handler = logging.StreamHandler(fallback_stream)
+
+        logger.handlers = []
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.addHandler(fallback_handler)
+
+        with TemporaryDirectory() as tmp_dir:
+            blocked = Path(tmp_dir) / "blocked"
+            blocked.write_text("not a directory", encoding="utf-8")
+            handler = DailyJsonFileHandler(str(blocked / "app-log.json"))
+            logger.addHandler(handler)
+
+            try:
+                logger.info("first degraded message")
+                logger.info("second degraded message")
+            finally:
+                logger.removeHandler(handler)
+                handler.close()
+
+        logger.handlers = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+        output_lines = [line for line in fallback_stream.getvalue().splitlines() if line]
+        warning_lines = [line for line in output_lines if "Unable to write app logs" in line]
+        self.assertEqual(len(warning_lines), 1)
+        self.assertIn("first degraded message", output_lines)
+        self.assertIn("second degraded message", output_lines)

--- a/specials/logging_handlers.py
+++ b/specials/logging_handlers.py
@@ -9,31 +9,103 @@ from pathlib import Path
 from typing import Any
 
 
+def _first_non_matching_handler(
+    *,
+    record: logging.LogRecord,
+    current: logging.Handler,
+) -> logging.Handler | None:
+    """Return the first handler on the originating or root logger that isn't the current one."""
+
+    logger = logging.getLogger(record.name)
+    for handler in logger.handlers:
+        if handler is not current:
+            return handler
+
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if handler is not current:
+            return handler
+
+    return None
+
+
 class DailyJsonFileHandler(logging.Handler):
     """Write structured log records to a JSON lines file, resetting each day."""
 
     def __init__(self, filename: str) -> None:
         super().__init__()
         self.log_path = Path(filename)
-        self.log_path.parent.mkdir(parents=True, exist_ok=True)
         self._current_date = None
+        self._fallback_handler: logging.Handler | None = None
+        self._warning_logged = False
+        self._use_fallback = False
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - exercised via integration
         """Write the log record as JSON, rotating when the UTC date changes."""
 
         try:
-            now = datetime.now(timezone.utc)
-            if self._current_date != now.date():
-                self._current_date = now.date()
-                self.log_path.write_text("", encoding="utf-8")
+            if self._use_fallback:
+                self._emit_via_fallback(record)
+                return
 
-            payload: dict[str, Any] = {
-                "timestamp": now.isoformat().replace("+00:00", "Z"),
-                "level": record.levelname,
-                "name": record.name,
-                "message": record.getMessage(),
-            }
-            with self.log_path.open("a", encoding="utf-8") as stream:
-                stream.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            self._write_record(record)
+        except OSError as error:  # pragma: no cover - exercised via tests
+            self._handle_unwritable(record, error)
         except Exception:  # pragma: no cover - defensive guard
             self.handleError(record)
+
+    def _write_record(self, record: logging.LogRecord) -> None:
+        """Write a single record to disk, rotating the file daily."""
+
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        now = datetime.now(timezone.utc)
+        if self._current_date != now.date():
+            self.log_path.write_text("", encoding="utf-8")
+            self._current_date = now.date()
+
+        payload: dict[str, Any] = {
+            "timestamp": now.isoformat().replace("+00:00", "Z"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        with self.log_path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    def _emit_via_fallback(self, record: logging.LogRecord) -> None:
+        fallback = self._fallback_handler
+        if fallback is None:
+            fallback = _first_non_matching_handler(record=record, current=self)
+            self._fallback_handler = fallback
+
+        if fallback is not None:
+            fallback.handle(record)
+        else:  # pragma: no cover - defensive guard
+            self.handleError(record)
+
+    def _handle_unwritable(self, record: logging.LogRecord, error: OSError) -> None:
+        """Switch to a console fallback when writing fails."""
+
+        self._fallback_handler = _first_non_matching_handler(record=record, current=self)
+        if self._fallback_handler is None:
+            self.handleError(record)
+            return
+
+        if not self._warning_logged:
+            warning_record = logging.LogRecord(
+                name=__name__,
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=0,
+                msg=(
+                    "Unable to write app logs to %s (%s). Falling back to console output."
+                ),
+                args=(str(self.log_path), error),
+                exc_info=None,
+            )
+            self._fallback_handler.handle(warning_record)
+            self._warning_logged = True
+
+        self._use_fallback = True
+        self._emit_via_fallback(record)

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -21,7 +21,9 @@ from django.contrib.messages import constants as message_constants
 from django.urls import reverse_lazy
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-APP_LOG_FILE = BASE_DIR / "logs" / "app-log.json"
+
+default_log_dir = Path(os.getenv("APP_LOG_DIR", "/tmp/appertivo/logs"))
+APP_LOG_FILE = Path(os.getenv("APP_LOG_FILE", str(default_log_dir / "app-log.json")))
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI")


### PR DESCRIPTION
## Summary
- allow overriding the application log file path via environment variables with a writable default
- make the daily JSON logging handler create directories lazily and fall back to the console when the file is unavailable
- add regression tests covering the handler's write path and failure fallback behaviour

## Testing
- python manage.py test dashboard.tests.test_logging_handlers

------
https://chatgpt.com/codex/tasks/task_e_68dea1b0743083328b5a86912bda2aea