### PR TITLE
Configure asset previews to use Cloudinary when available

### DIFF
--- a/appertivo/assets/tasks.py
+++ b/appertivo/assets/tasks.py
@@ -9,12 +9,28 @@ from typing import Iterable
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
+from django.utils.functional import empty
 
 from app.llm import replicate_client
 
 from .models import AssetPreviewJob
 
 logger = logging.getLogger(__name__)
+
+
+def _storage_backend_name() -> str:
+    """Return a descriptive name for the active default storage backend."""
+
+    storage_obj = getattr(default_storage, "_wrapped", empty)
+    if storage_obj is empty:  # pragma: no cover - defensive lazy storage setup
+        default_storage._setup()  # type: ignore[attr-defined]
+        storage_obj = getattr(default_storage, "_wrapped", None)
+
+    if not storage_obj:
+        return "configured storage"
+
+    storage_class = storage_obj.__class__
+    return f"{storage_class.__module__}.{storage_class.__name__}"
 
 
 def _collect_preview_candidates(output: object) -> Iterable[bytes | str]:
@@ -58,7 +74,20 @@ def _store_preview_bytes(data: bytes) -> tuple[str | None, str | None]:
     try:
         storage_path = default_storage.save(filename, ContentFile(data))
     except Exception as exc:  # pragma: no cover - storage guard
-        logger.warning("Failed to store preview bytes: %s", exc, exc_info=True)
+        storage_label = _storage_backend_name()
+        if "cloudinary" in storage_label.lower():
+            logger.warning(
+                "Failed to store preview bytes via Cloudinary storage: %s",
+                exc,
+                exc_info=True,
+            )
+        else:
+            logger.warning(
+                "Failed to store preview bytes via %s: %s",
+                storage_label,
+                exc,
+                exc_info=True,
+            )
         return None, None
 
     try:

--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import shutil
-import tempfile
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -11,9 +10,10 @@ from unittest.mock import Mock, patch
 import django
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
-from django.test import TestCase, override_settings
+from django.core.files.storage import Storage, default_storage
+from django.test import TestCase
 from django.urls import reverse
+from django.utils.deconstruct import deconstructible
 
 django.setup()
 
@@ -21,15 +21,97 @@ from appertivo.assets import tasks
 from appertivo.assets.models import AssetModel, AssetPreviewJob, GeneratedAsset
 
 
+@deconstructible
+class _BaseMemoryStorage(Storage):
+    """A minimal in-memory storage backend for tests."""
+
+    drop_extension: bool = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._files: dict[str, bytes] = {}
+        self._aliases: dict[str, str] = {}
+
+    def _normalize(self, name: str) -> str:
+        return str(name).replace("\\", "/")
+
+    def _canonical_name(self, name: str) -> str:
+        normalized = self._normalize(name)
+        return self._aliases.get(normalized, normalized)
+
+    def _save(self, name: str, content) -> str:
+        normalized = self._normalize(name)
+        if hasattr(content, "chunks"):
+            data = b"".join(bytes(chunk) for chunk in content.chunks())
+        else:
+            raw = content.read()
+            if isinstance(raw, str):
+                data = raw.encode()
+            elif isinstance(raw, (bytes, bytearray)):
+                data = bytes(raw)
+            else:
+                data = bytes(raw or b"")
+
+        base, _ = os.path.splitext(normalized)
+        canonical = base if self.drop_extension else normalized
+        self._files[canonical] = data
+        if canonical != normalized:
+            self._aliases[normalized] = canonical
+        return canonical
+
+    def _open(self, name: str, mode: str = "rb"):
+        canonical = self._canonical_name(name)
+        if canonical not in self._files:
+            base, _ = os.path.splitext(canonical)
+            canonical = base
+        if canonical not in self._files:
+            raise FileNotFoundError(name)
+        return ContentFile(self._files[canonical], name=canonical)
+
+    def exists(self, name: str) -> bool:  # noqa: D401 - short helper
+        canonical = self._canonical_name(name)
+        if canonical in self._files:
+            return True
+        base, _ = os.path.splitext(canonical)
+        return base in self._files
+
+    def delete(self, name: str) -> None:
+        canonical = self._canonical_name(name)
+        self._files.pop(canonical, None)
+        aliases_to_remove = [alias for alias, target in self._aliases.items() if target == canonical]
+        for alias in aliases_to_remove:
+            self._aliases.pop(alias, None)
+        base, _ = os.path.splitext(canonical)
+        self._files.pop(base, None)
+
+    def url(self, name: str) -> str:
+        canonical = self._canonical_name(name).lstrip("/")
+        return f"https://storage.test/{canonical}"
+
+    def clear(self) -> None:
+        """Reset stored files between tests."""
+
+        self._files.clear()
+        self._aliases.clear()
+
+
+class CloudMemoryStorage(_BaseMemoryStorage):
+    """Storage that mimics Cloudinary public IDs by omitting file extensions."""
+
+    drop_extension = True
+
+
 class AssetDashboardTests(TestCase):
     """Exercise staff-only workflows for the asset studio."""
 
     def setUp(self) -> None:
-        media_root = Path(tempfile.mkdtemp(prefix="appertivo-test-media-"))
-        self.addCleanup(lambda: shutil.rmtree(media_root, ignore_errors=True))
-        override = override_settings(MEDIA_ROOT=media_root)
-        override.enable()
-        self.addCleanup(override.disable)
+        super().setUp()
+        original_storage = getattr(default_storage, "_wrapped", None)
+        self.addCleanup(lambda: setattr(default_storage, "_wrapped", original_storage))
+
+        storage_backend = CloudMemoryStorage()
+        default_storage._wrapped = storage_backend
+        self.storage = storage_backend
 
         user_model = get_user_model()
         self.staff_user = user_model.objects.create_user(
@@ -167,6 +249,7 @@ class AssetDashboardTests(TestCase):
 
         self.client.force_login(self.staff_user)
         stored_path = default_storage.save("previews/test-bytes.png", ContentFile(b"bytes"))
+        self.assertFalse(Path(stored_path).suffix)
         response = self.client.post(
             reverse("assets:dashboard"),
             {
@@ -208,6 +291,7 @@ class AssetDashboardTests(TestCase):
         self.assertEqual(job.status, AssetPreviewJob.Status.SUCCESS)
         self.assertTrue(job.preview_url)
         self.assertTrue(job.storage_path)
+        self.assertFalse(Path(job.storage_path).suffix)
         self.assertTrue(default_storage.exists(job.storage_path))
         default_storage.delete(job.storage_path)
 

--- a/appertivo/assets/views.py
+++ b/appertivo/assets/views.py
@@ -6,6 +6,7 @@ import logging
 import mimetypes
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 from django.contrib import messages
@@ -48,19 +49,42 @@ def _save_preview(
     extension = ".png"
 
     if storage_path:
-        try:
-            with default_storage.open(storage_path, "rb") as stored_file:
-                file_bytes = stored_file.read()
-        except FileNotFoundError:
+        preview_extension = ""
+        if preview_url:
+            preview_extension = Path(urlparse(preview_url).path).suffix
+
+        candidates: list[str] = [storage_path]
+        if not Path(storage_path).suffix:
+            if preview_extension:
+                candidate = f"{storage_path}{preview_extension}"
+                if candidate not in candidates:
+                    candidates.append(candidate)
+            fallback_candidate = f"{storage_path}.png"
+            if fallback_candidate not in candidates:
+                candidates.append(fallback_candidate)
+
+        read_path = storage_path
+        for candidate in candidates:
+            try:
+                with default_storage.open(candidate, "rb") as stored_file:
+                    file_bytes = stored_file.read()
+                read_path = candidate
+                break
+            except FileNotFoundError:
+                continue
+            except OSError as exc:  # pragma: no cover - storage guard
+                logger.warning("Failed to read stored preview %s: %s", candidate, exc)
+                return None, "Could not read the preview image from storage."
+        else:
             logger.warning("Stored preview missing at %s", storage_path)
             return None, "Preview file is no longer available. Please generate it again."
-        except OSError as exc:  # pragma: no cover - storage guard
-            logger.warning("Failed to read stored preview %s: %s", storage_path, exc)
-            return None, "Could not read the preview image from storage."
 
-        suffix = Path(storage_path).suffix
+        storage_path = read_path
+        suffix = Path(read_path).suffix
         if suffix:
             extension = suffix
+        elif preview_extension:
+            extension = preview_extension
     else:
         try:
             response = requests.get(preview_url, timeout=20)

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -10,10 +10,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from datetime import timedelta
 from decimal import Decimal
 from pathlib import Path
-import os
+
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -25,6 +26,15 @@ APP_LOG_FILE = BASE_DIR / "logs" / "app-log.json"
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI")
+
+CLOUDINARY_URL = os.getenv("CLOUDINARY_URL")
+CLOUDINARY_CLOUD_NAME = os.getenv("CLOUDINARY_CLOUD_NAME")
+CLOUDINARY_API_KEY = os.getenv("CLOUDINARY_API_KEY")
+CLOUDINARY_API_SECRET = os.getenv("CLOUDINARY_API_SECRET")
+USE_CLOUDINARY_STORAGE = bool(
+    CLOUDINARY_URL
+    or (CLOUDINARY_CLOUD_NAME and CLOUDINARY_API_KEY and CLOUDINARY_API_SECRET)
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
@@ -65,6 +75,9 @@ INSTALLED_APPS = [
     'django_q',
     'dashboard.apps.DashboardConfig',
 ]
+
+if USE_CLOUDINARY_STORAGE and 'cloudinary_storage' not in INSTALLED_APPS:
+    INSTALLED_APPS.append('cloudinary_storage')
 
 # Map Django message levels to Bootstrap alert classes
 MESSAGE_TAGS = {
@@ -214,8 +227,27 @@ STATICFILES_DIRS = [BASE_DIR / 'static']
 STATIC_ROOT = BASE_DIR / 'staticfiles'  # For collectstatic
 
 # MEDIA FILES
-MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_URL = '/media/'
+
+if USE_CLOUDINARY_STORAGE:
+    cloudinary_storage_config = {
+        key: value
+        for key, value in {
+            "CLOUD_NAME": CLOUDINARY_CLOUD_NAME,
+            "API_KEY": CLOUDINARY_API_KEY,
+            "API_SECRET": CLOUDINARY_API_SECRET,
+        }.items()
+        if value
+    }
+    if cloudinary_storage_config:
+        CLOUDINARY_STORAGE = cloudinary_storage_config
+    DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
+    media_url_override = os.getenv("CLOUDINARY_MEDIA_URL")
+    if media_url_override:
+        MEDIA_URL = media_url_override
+    elif CLOUDINARY_CLOUD_NAME:
+        MEDIA_URL = f"https://res.cloudinary.com/{CLOUDINARY_CLOUD_NAME}/"
 
 # DEFAULT PRIMARY KEY
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
@@ -323,7 +355,7 @@ LLM_PRICING = {
 
 CRONJOBS = [("0 * * * *", "app.cron.unpublish_expired_specials")]
 
-for _app in ['django_extensions', 'corsheaders', 'anymail', 'cloudinary', 'django_crontab']:
+for _app in ['django_extensions', 'corsheaders', 'anymail', 'cloudinary', 'cloudinary_storage', 'django_crontab']:
     try:
         __import__(_app)
     except ModuleNotFoundError:


### PR DESCRIPTION
## Summary
- detect Cloudinary credentials in settings and switch default media storage to Cloudinary when configured
- adjust asset preview storage logic and view handling to work with Cloudinary public IDs while keeping existing fallbacks
- add an in-memory Cloudinary-like storage backend to the asset dashboard tests to cover preview generation and saving end to end

## Testing
- python manage.py test appertivo.assets.tests.test_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dea1b14660833299e4bfbb9cbbe130