### PR TITLE
Redesign lead review cards

### DIFF
--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -73,72 +73,18 @@
     </form>
   </section>
 
-  <form id="bulk-action-form" method="post" action="{% url 'lead-actions' %}">
-    {% csrf_token %}
-  </form>
-
   <section class="space-y-4">
-    <div class="flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-900">Review &amp; manage leads</h2>
-      <p class="text-sm text-slate-500">Use the checkboxes to run batch approvals or manage bounce status.</p>
-    </div>
+    <h2 class="text-lg font-semibold text-slate-900">Review &amp; manage leads</h2>
     {% if leads %}
       <div class="space-y-3">
         {% for lead in leads %}
-          <article class="rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 shadow-sm">
-            <div class="flex flex-col gap-4 md:grid md:grid-cols-12 md:items-start md:gap-6">
-              <div class="flex items-start gap-3 md:col-span-5">
-                <input form="bulk-action-form" type="checkbox" name="lead_ids" value="{{ lead.id }}" class="mt-1 h-4 w-4 shrink-0 rounded border-slate-300 text-purple-600 focus:ring-purple-500" />
-                <div class="space-y-2">
-                  <div>
-                    <div class="text-base font-semibold text-slate-900">{{ lead.name }}</div>
-                    <div class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</div>
-                  </div>
-                  {% if lead.landing_url %}
-                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex w-full items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-purple-600 hover:border-purple-400 hover:text-purple-700 md:w-auto md:justify-start">Open landing page</a>
-                  {% endif %}
-                  <details class="text-xs text-slate-600">
-                    <summary class="cursor-pointer text-purple-600 hover:text-purple-700">View details</summary>
-                    <div class="mt-2 space-y-1">
-                      <div><span class="font-medium">Run:</span> {{ lead.run|default:"—" }}</div>
-                      <div><span class="font-medium">Created:</span> {{ lead.created_at|date:"M j, Y H:i" }}</div>
-                      {% if lead.landing_url %}
-                        <div><span class="font-medium">Landing page:</span> <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="text-purple-600 hover:text-purple-700">View landing</a></div>
-                      {% endif %}
-                      {% if lead.json_data %}
-                        <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="mt-1 inline-flex w-full items-center justify-center rounded border border-slate-200 px-2 py-1 font-medium text-purple-600 hover:border-purple-400 hover:text-purple-700 md:w-auto md:justify-start">View JSON data</button>
-                      {% endif %}
-                    </div>
-                  </details>
+          <article class="rounded-2xl border border-slate-200 bg-white/70 p-5 text-sm text-slate-600 shadow-sm">
+            <div class="flex flex-col gap-4">
+              <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div class="text-base font-semibold text-slate-900">{{ lead.name }}</div>
+                  <div class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</div>
                 </div>
-              </div>
-              {% if lead.json_data %}
-                <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
-                  <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
-                    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-                      <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
-                      <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
-                    </div>
-                    <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
-                      <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
-                    </div>
-                  </div>
-                </div>
-              {% endif %}
-              <div class="space-y-2 md:col-span-3">
-                {% if lead.email %}
-                  <div class="flex flex-wrap items-center gap-1 text-slate-700">
-                    <span class="font-medium">Email:</span>
-                    <a href="mailto:{{ lead.email }}" class="text-purple-600 hover:text-purple-700">{{ lead.email }}</a>
-                  </div>
-                {% else %}
-                  <div class="text-slate-500">No email on file</div>
-                {% endif %}
-                {% if lead.phone %}
-                  <div class="text-slate-600"><span class="font-medium">Phone:</span> {{ lead.phone }}</div>
-                {% endif %}
-              </div>
-              <div class="md:col-span-2">
                 <div class="flex flex-wrap gap-2">
                   {% if lead.shortlisted %}
                     <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">Approved</span>
@@ -157,29 +103,72 @@
                   {% endif %}
                 </div>
               </div>
-              <div class="flex flex-col gap-2 md:col-span-2 md:items-end">
-                {% if lead.landing_url %}
-                  <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex w-full items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600 md:w-auto">View landing</a>
-                {% endif %}
-                <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:items-end">
-                  {% csrf_token %}
-                  <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
-                  {% if email_templates %}
-                    <label class="sr-only" for="template-{{ lead.id }}">Email template</label>
-                    <select id="template-{{ lead.id }}" name="template_id" class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">
-                      <option value="">Default template</option>
-                      {% for template in email_templates %}
-                        <option value="{{ template.id }}">{{ template.name }}</option>
-                      {% endfor %}
-                    </select>
+
+              <div class="space-y-3">
+                <div class="space-y-1 text-slate-600">
+                  {% if lead.email %}
+                    <div class="flex flex-wrap items-center gap-1 text-slate-700">
+                      <span class="font-medium">Email:</span>
+                      <a href="mailto:{{ lead.email }}" class="text-purple-600 hover:text-purple-700">{{ lead.email }}</a>
+                    </div>
+                  {% else %}
+                    <div class="text-slate-500">No email on file</div>
                   {% endif %}
-                  <button type="submit" name="action" value="approve" onclick="return confirm('Approve this lead, generate a landing page, and send the email?');" class="inline-flex w-full items-center justify-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">Approve</button>
-                </form>
-                <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:items-end">
-                  {% csrf_token %}
-                  <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
-                  <button type="submit" name="action" value="delete" onclick="return confirm('Delete this lead?');" class="inline-flex w-full items-center justify-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700 md:w-auto">Delete</button>
-                </form>
+                  {% if lead.phone %}
+                    <div class="text-slate-600"><span class="font-medium">Phone:</span> {{ lead.phone }}</div>
+                  {% endif %}
+                </div>
+
+                <details class="rounded-lg border border-slate-200/80 bg-white/60 px-3 py-2 text-xs text-slate-600">
+                  <summary class="cursor-pointer text-purple-600 hover:text-purple-700">View details</summary>
+                  <div class="mt-2 space-y-2">
+                    {% if lead.json_data %}
+                      <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="inline-flex w-full items-center justify-center rounded border border-slate-200 px-2 py-1 font-medium text-purple-600 hover:border-purple-400 hover:text-purple-700">View JSON data</button>
+                    {% endif %}
+                  </div>
+                </details>
+              </div>
+
+              {% if lead.json_data %}
+                <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
+                  <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
+                    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+                      <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
+                      <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
+                    </div>
+                    <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
+                      <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
+                    </div>
+                  </div>
+                </div>
+              {% endif %}
+
+              <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
+                  {% if lead.landing_url %}
+                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600">View landing</a>
+                  {% endif %}
+                  <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
+                    {% csrf_token %}
+                    <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
+                    {% if email_templates %}
+                      <label class="sr-only" for="template-{{ lead.id }}">Email template</label>
+                      <select id="template-{{ lead.id }}" name="template_id" class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">
+                        <option value="">Default template</option>
+                        {% for template in email_templates %}
+                          <option value="{{ template.id }}">{{ template.name }}</option>
+                        {% endfor %}
+                      </select>
+                    {% endif %}
+                    <button type="submit" name="action" value="approve" onclick="return confirm('Approve this lead, generate a landing page, and send the email?');" class="inline-flex w-full items-center justify-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">Approve</button>
+                  </form>
+                  <form method="post" action="{% url 'lead-actions' %}" class="flex">
+                    {% csrf_token %}
+                    <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
+                    <button type="submit" name="action" value="delete" onclick="return confirm('Delete this lead?');" class="inline-flex items-center justify-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700">Delete</button>
+                  </form>
+                </div>
+                <div class="text-[11px] text-slate-400">Collected {{ lead.created_at|date:"M j, Y H:i" }}</div>
               </div>
             </div>
           </article>
@@ -189,28 +178,6 @@
       <div class="rounded-2xl border border-slate-200 bg-white/70 p-6 text-center text-sm text-slate-500 shadow-sm">No leads yet. Start a run above to fetch prospects.</div>
     {% endif %}
 
-    <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 md:flex-row md:items-center md:justify-between">
-      <div class="flex items-center gap-2">
-        <label for="bulk-template" class="font-medium text-slate-700">Email template</label>
-        <select id="bulk-template" form="bulk-action-form" name="template_id" class="rounded-lg border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400">
-          <option value="">Default template</option>
-          {% for template in email_templates %}
-            <option value="{{ template.id }}">{{ template.name }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="flex flex-wrap gap-2">
-        <button form="bulk-action-form" type="submit" name="action" value="approve" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">
-          Approve selected
-        </button>
-        <button form="bulk-action-form" type="submit" name="action" value="mark_bounced" class="inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 hover:border-red-400 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-300">
-          Mark bounced
-        </button>
-        <button form="bulk-action-form" type="submit" name="action" value="clear_bounce" class="inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 hover:border-emerald-400 hover:text-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-300">
-          Clear bounce
-        </button>
-      </div>
-    </div>
   </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the bulk-selection UI and instructional text from the lead review list
- reorganize each lead card with grouped contact info, compact status chips, and footer metadata
- trim redundant details content so actions rely on the primary buttons

## Testing
- not run (HTML template changes only)


------
https://chatgpt.com/codex/tasks/task_e_68deb7822754833287c444e035715861