### PR TITLE
Refactor asset studio navigation and management

### DIFF
--- a/appertivo/assets/templates/assets/dashboard.html
+++ b/appertivo/assets/templates/assets/dashboard.html
@@ -3,6 +3,12 @@
 
 {% block content %}
 <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+  <nav class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+    <span class="rounded-full bg-purple-100 px-3 py-1 font-semibold text-purple-700">Studio</span>
+    <a href="{% url 'assets:manage-models' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Models</a>
+    <a href="{% url 'assets:manage-prompts' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Prompts</a>
+    <a href="{% url 'assets:gallery' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Gallery</a>
+  </nav>
   <header class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
     <div>
       <p class="text-xs font-semibold uppercase tracking-wide text-purple-600">Internal</p>
@@ -34,164 +40,21 @@
     </div>
   {% endif %}
 
-  <section class="grid gap-6 md:grid-cols-2">
-    <details class="group rounded-2xl border border-slate-200 bg-white/80 p-5" id="add-model-accordion">
-      <summary class="flex cursor-pointer items-center justify-between text-lg font-semibold text-slate-900">
-        <span>Add a model</span>
-        <svg class="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.086l3.71-3.855a.75.75 0 0 1 1.08 1.04l-4.24 4.403a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-        </svg>
-      </summary>
-      <div class="mt-3 space-y-4 border-t border-slate-200 pt-4 text-sm text-slate-600">
-        <p>Store the full model path including version. We list entries alphabetically by description.</p>
-        <form method="post" class="space-y-4">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="create-model" />
-          <div>
-            <label class="text-sm font-medium text-slate-700">Description</label>
-            {{ model_form.description }}
-            {% if model_form.description.errors %}
-              <p class="mt-1 text-xs text-rose-600">{{ model_form.description.errors|join:', ' }}</p>
-            {% endif %}
-          </div>
-          <div>
-            <label class="text-sm font-medium text-slate-700">Identifier</label>
-            {{ model_form.identifier }}
-            {% if model_form.identifier.errors %}
-              <p class="mt-1 text-xs text-rose-600">{{ model_form.identifier.errors|join:', ' }}</p>
-            {% endif %}
-          </div>
-          <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">
-            Save model
-          </button>
-        </form>
-      </div>
-    </details>
-
-    <details class="group rounded-2xl border border-slate-200 bg-white/80 p-5" id="prompt-library-accordion">
-      <summary class="flex cursor-pointer items-center justify-between text-lg font-semibold text-slate-900">
-        <span>Prompt library</span>
-        <svg class="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.086l3.71-3.855a.75.75 0 0 1 1.08 1.04l-4.24 4.403a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-        </svg>
-      </summary>
-      <div class="mt-3 space-y-4 border-t border-slate-200 pt-4 text-sm text-slate-600">
-        <p>Keep reusable prompts handy for future renders.</p>
-        <form method="post" class="space-y-4">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="create-prompt" />
-          <div>
-            <label class="text-sm font-medium text-slate-700">Title</label>
-            {{ prompt_form.title }}
-            {% if prompt_form.title.errors %}
-              <p class="mt-1 text-xs text-rose-600">{{ prompt_form.title.errors|join:', ' }}</p>
-            {% endif %}
-          </div>
-          <div>
-            <label class="text-sm font-medium text-slate-700">Prompt text</label>
-            {{ prompt_form.text }}
-            {% if prompt_form.text.errors %}
-              <p class="mt-1 text-xs text-rose-600">{{ prompt_form.text.errors|join:', ' }}</p>
-            {% endif %}
-          </div>
-          <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">
-            Add prompt
-          </button>
-        </form>
-      </div>
-    </details>
-  </section>
-
-  <section class="grid gap-6 md:grid-cols-2">
-    <div class="rounded-2xl border border-slate-200 bg-white/80 p-5 space-y-4">
+  <section class="grid gap-4 md:grid-cols-2">
+    <a href="{% url 'assets:manage-models' %}" class="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/80 p-5 text-sm text-slate-600 transition hover:border-purple-300 hover:shadow-sm">
       <div>
-        <h2 class="text-lg font-semibold text-slate-900">Saved models</h2>
-        <p class="mt-1 text-sm text-slate-600">Update identifiers or remove entries that are no longer needed.</p>
+        <p class="text-lg font-semibold text-slate-900">Manage models</p>
+        <p class="mt-1">Keep the Replicate identifiers tidy in one place.</p>
       </div>
-      {% if model_forms %}
-        <ul class="space-y-4">
-          {% for model_id, form in model_forms.items %}
-            <li class="rounded-xl border border-slate-200 bg-white/90 p-4 space-y-3">
-              <form method="post" class="space-y-3">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="update-model" />
-                <input type="hidden" name="model_id" value="{{ model_id }}" />
-                <div>
-                  <label class="text-sm font-medium text-slate-700" for="{{ form.description.id_for_label }}">Description</label>
-                  {{ form.description }}
-                  {% if form.description.errors %}
-                    <p class="mt-1 text-xs text-rose-600">{{ form.description.errors|join:', ' }}</p>
-                  {% endif %}
-                </div>
-                <div>
-                  <label class="text-sm font-medium text-slate-700" for="{{ form.identifier.id_for_label }}">Identifier</label>
-                  {{ form.identifier }}
-                  {% if form.identifier.errors %}
-                    <p class="mt-1 text-xs text-rose-600">{{ form.identifier.errors|join:', ' }}</p>
-                  {% endif %}
-                </div>
-                <div class="flex items-center justify-end">
-                  <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save changes</button>
-                </div>
-              </form>
-              <form method="post" class="flex justify-end" onsubmit="return confirm('Delete this model?');">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="delete-model" />
-                <input type="hidden" name="model_id" value="{{ model_id }}" />
-                <button type="submit" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Delete</button>
-              </form>
-            </li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        <p class="text-sm text-slate-600">No models added yet.</p>
-      {% endif %}
-    </div>
-
-    <div class="rounded-2xl border border-slate-200 bg-white/80 p-5 space-y-4">
+      <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-purple-100 text-purple-700">→</span>
+    </a>
+    <a href="{% url 'assets:manage-prompts' %}" class="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/80 p-5 text-sm text-slate-600 transition hover:border-purple-300 hover:shadow-sm">
       <div>
-        <h2 class="text-lg font-semibold text-slate-900">Prompt templates</h2>
-        <p class="mt-1 text-sm text-slate-600">Tweak saved prompt text or remove unused entries.</p>
+        <p class="text-lg font-semibold text-slate-900">Manage prompts</p>
+        <p class="mt-1">Organize reusable copy for faster experiments.</p>
       </div>
-      {% if prompt_forms %}
-        <ul class="space-y-4">
-          {% for prompt_id, form in prompt_forms.items %}
-            <li class="rounded-xl border border-slate-200 bg-white/90 p-4 space-y-3">
-              <form method="post" class="space-y-3">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="update-prompt" />
-                <input type="hidden" name="prompt_id" value="{{ prompt_id }}" />
-                <div>
-                  <label class="text-sm font-medium text-slate-700" for="{{ form.title.id_for_label }}">Title</label>
-                  {{ form.title }}
-                  {% if form.title.errors %}
-                    <p class="mt-1 text-xs text-rose-600">{{ form.title.errors|join:', ' }}</p>
-                  {% endif %}
-                </div>
-                <div>
-                  <label class="text-sm font-medium text-slate-700" for="{{ form.text.id_for_label }}">Prompt text</label>
-                  {{ form.text }}
-                  {% if form.text.errors %}
-                    <p class="mt-1 text-xs text-rose-600">{{ form.text.errors|join:', ' }}</p>
-                  {% endif %}
-                </div>
-                <div class="flex items-center justify-end">
-                  <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save changes</button>
-                </div>
-              </form>
-              <form method="post" class="flex justify-end" onsubmit="return confirm('Delete this prompt?');">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="delete-prompt" />
-                <input type="hidden" name="prompt_id" value="{{ prompt_id }}" />
-                <button type="submit" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Delete</button>
-              </form>
-            </li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        <p class="text-sm text-slate-600">No prompt templates yet.</p>
-      {% endif %}
-    </div>
+      <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-purple-100 text-purple-700">→</span>
+    </a>
   </section>
 
   <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-6">

--- a/appertivo/assets/templates/assets/gallery.html
+++ b/appertivo/assets/templates/assets/gallery.html
@@ -2,7 +2,13 @@
 {% block title %}Asset Gallery · Appertivo{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-6 py-12 space-y-8">
+<div class="max-w-7xl mx-auto px-6 py-12 space-y-8" data-unlocked-folders="{{ unlocked_folder_ids|join:',' }}">
+  <nav class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+    <a href="{% url 'assets:dashboard' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Studio</a>
+    <a href="{% url 'assets:manage-models' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Models</a>
+    <a href="{% url 'assets:manage-prompts' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Prompts</a>
+    <span class="rounded-full bg-purple-100 px-3 py-1 font-semibold text-purple-700">Gallery</span>
+  </nav>
   <header class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
     <div>
       <p class="text-xs font-semibold uppercase tracking-wide text-purple-600">Internal</p>
@@ -26,78 +32,84 @@
     <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
       <div>
         <h2 class="text-lg font-semibold text-slate-900">Folders</h2>
-        <p class="mt-1 text-sm text-slate-600">Group assets for quicker navigation.</p>
+        <p class="mt-1 text-sm text-slate-600">Keep everything organized and locked when needed.</p>
       </div>
-      <form method="post" class="w-full max-w-md space-y-2 md:w-auto">
+      <form method="post" class="flex flex-wrap items-end gap-2 text-sm text-slate-600">
         {% csrf_token %}
         <input type="hidden" name="action" value="create-folder" />
-        <label class="block text-sm font-medium text-slate-700" for="{{ folder_form.name.id_for_label }}">Create folder</label>
-        {{ folder_form.name }}
-        {% if folder_form.name.errors %}
-          <p class="text-xs text-rose-600">{{ folder_form.name.errors|join:', ' }}</p>
-        {% endif %}
-        <div class="grid gap-2 sm:grid-cols-2">
-          <div>
-            <label class="text-sm font-medium text-slate-700" for="{{ folder_form.pin.id_for_label }}">PIN</label>
-            {{ folder_form.pin }}
-            {% if folder_form.pin.errors %}
-              <p class="text-xs text-rose-600">{{ folder_form.pin.errors|join:', ' }}</p>
-            {% endif %}
-          </div>
-          <div class="flex items-end gap-2">
-            {{ folder_form.is_locked }}
-            <label class="text-sm font-medium text-slate-700" for="{{ folder_form.is_locked.id_for_label }}">Lock folder</label>
-          </div>
-        </div>
+        <label class="flex flex-col" for="{{ folder_form.name.id_for_label }}">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Name</span>
+          {{ folder_form.name }}
+        </label>
+        <label class="flex flex-col" for="{{ folder_form.pin.id_for_label }}">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">PIN</span>
+          {{ folder_form.pin }}
+        </label>
+        <label class="flex items-center gap-2" for="{{ folder_form.is_locked.id_for_label }}">
+          {{ folder_form.is_locked }}
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Locked</span>
+        </label>
+        <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">Add</button>
         {% if folder_form.non_field_errors %}
-          <p class="text-xs text-rose-600">{{ folder_form.non_field_errors|join:', ' }}</p>
+          <span class="w-full text-xs text-rose-600">{{ folder_form.non_field_errors|join:', ' }}</span>
         {% endif %}
-        <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">Add folder</button>
       </form>
     </div>
     {% if folders %}
-      <ul class="divide-y divide-slate-200 rounded-lg border border-slate-200 bg-white/70 text-sm text-slate-600">
-        {% for folder, security_form in folder_entries %}
-          <li class="flex flex-col gap-3 px-4 py-3">
-            <div class="flex items-center justify-between gap-3">
-              <span class="font-medium text-slate-800">{{ folder.name }}</span>
-              {% if folder.is_locked %}
-                <span class="inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-600">Locked</span>
-              {% endif %}
-            </div>
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-              <form method="post" class="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-4">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="update-folder-security" />
-                <input type="hidden" name="folder_id" value="{{ folder.id }}" />
-                <div>
-                  <label class="text-xs font-semibold uppercase tracking-wide text-slate-500" for="{{ security_form.pin.id_for_label }}">PIN</label>
-                  {{ security_form.pin }}
-                  {% if security_form.pin.errors %}
-                    <p class="text-xs text-rose-600">{{ security_form.pin.errors|join:', ' }}</p>
-                  {% endif %}
-                </div>
-                <label for="{{ security_form.is_locked.id_for_label }}" class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  {{ security_form.is_locked }}
-                  <span>Locked</span>
-                </label>
-                <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save</button>
-              </form>
-              <form method="post" class="flex items-center gap-2" onsubmit="return confirm('Delete this folder? Assets will remain available.');">
-                {% csrf_token %}
-                <input type="hidden" name="action" value="delete-folder" />
-                <input type="hidden" name="folder_id" value="{{ folder.id }}" />
-                <button type="submit" class="text-sm font-semibold text-rose-600 hover:text-rose-700">Delete</button>
-              </form>
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+          <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="px-3 py-2 text-left">Folder</th>
+              <th class="px-3 py-2 text-left">Security</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-200 bg-white/60">
+            {% for entry in folder_entries %}
+              <tr>
+                <td class="px-3 py-2 font-medium text-slate-800">{{ entry.folder.name }}</td>
+                <td class="px-3 py-2">
+                  <form method="post" class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                    {% csrf_token %}
+                    <input type="hidden" name="action" value="update-folder-security" />
+                    <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
+                    <label class="flex flex-col" for="{{ entry.form.pin.id_for_label }}">
+                      <span class="font-semibold uppercase">PIN</span>
+                      {{ entry.form.pin }}
+                    </label>
+                    <label class="flex items-center gap-2 font-semibold uppercase" for="{{ entry.form.is_locked.id_for_label }}">
+                      {{ entry.form.is_locked }}
+                      <span>Locked</span>
+                    </label>
+                    <button type="submit" class="inline-flex items-center rounded bg-slate-900 px-3 py-1 font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save</button>
+                    {% if entry.form.errors %}
+                      <span class="w-full text-rose-600">{{ entry.form.errors|join:', ' }}</span>
+                    {% endif %}
+                  </form>
+                </td>
+                <td class="px-3 py-2 text-right">
+                  <div class="flex items-center justify-end gap-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {% if entry.folder.is_locked %}
+                      <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-slate-600">🔒 {% if entry.is_unlocked %}Unlocked this session{% else %}Locked{% endif %}</span>
+                    {% endif %}
+                    <form method="post" class="inline" onsubmit="return confirm('Delete this folder? Assets will remain available.');">
+                      {% csrf_token %}
+                      <input type="hidden" name="action" value="delete-folder" />
+                      <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
+                      <button type="submit" class="text-rose-600 hover:text-rose-700">Delete</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     {% else %}
-      <p class="text-sm text-slate-500">No folders created yet. Add one using the form above.</p>
+      <p class="text-sm text-slate-500">No folders created yet. Add one using the quick form above.</p>
     {% endif %}
   </section>
-
   <section class="rounded-2xl border border-slate-200 bg-white/80 p-4">
     <div class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
       <span class="font-semibold text-slate-900">Filter:</span>
@@ -112,12 +124,13 @@
   {% if assets %}
     <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {% for asset in assets %}
-        <article class="flex flex-col rounded-2xl border border-slate-200 bg-white/80 shadow-sm">
+        {% with folder=asset.folder %}
+        <article class="flex flex-col rounded-2xl border border-slate-200 bg-white/80 shadow-sm" data-asset-card data-folder-id="{{ folder.id|default:'' }}" data-locked="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}true{% else %}false{% endif %}" data-original-prompt="{{ asset.prompt|escape }}">
           {% if asset.image %}
-            <div class="relative">
-              <img src="{{ asset.image.url }}" alt="{{ asset.model|default:'Asset' }}" class="h-56 w-full rounded-t-2xl object-cover{% if asset.folder and asset.folder.is_locked %} blur-sm{% endif %}" />
-              {% if asset.folder and asset.folder.is_locked %}
-                <div class="absolute inset-0 flex items-center justify-center rounded-t-2xl bg-slate-900/40 text-sm font-semibold uppercase tracking-wide text-white">Locked</div>
+            <div class="relative" data-locked-trigger tabindex="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}0{% else %}-1{% endif %}" role="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}button{% else %}presentation{% endif %}">
+              <img src="{{ asset.image.url }}" alt="{{ asset.model|default:'Asset' }}" class="h-56 w-full rounded-t-2xl object-cover{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %} blur-2xl{% endif %}" />
+              {% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}
+                <div class="absolute inset-0 flex items-center justify-center rounded-t-2xl bg-slate-900/50 text-sm font-semibold uppercase tracking-wide text-white">Locked • tap to unlock</div>
               {% endif %}
             </div>
           {% else %}
@@ -128,7 +141,7 @@
               <p class="font-semibold text-slate-900">{{ asset.model|default:"Unknown model" }}</p>
               <p class="text-xs uppercase tracking-wide text-slate-500">{{ asset.created_at|date:"M j, Y g:i a" }}</p>
             </div>
-            <p class="flex-1 whitespace-pre-wrap">{% if asset.folder and asset.folder.is_locked %}<span class="italic text-slate-500">Hidden for locked folder</span>{% else %}{{ asset.prompt }}{% endif %}</p>
+            <p class="flex-1 whitespace-pre-wrap" data-prompt-text>{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}<span class="italic text-slate-500">Hidden for locked folder</span>{% else %}{{ asset.prompt }}{% endif %}</p>
             <div class="space-y-3">
               <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
                 <div class="flex flex-wrap items-center gap-2">
@@ -165,6 +178,7 @@
             </div>
           </div>
         </article>
+        {% endwith %}
       {% endfor %}
     </div>
   {% else %}
@@ -172,5 +186,103 @@
       No saved images yet. Generate something new from the <a href="{% url 'assets:dashboard' %}" class="font-semibold text-purple-600 hover:text-purple-700">asset studio</a>.
     </div>
   {% endif %}
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const root = document.querySelector('[data-unlocked-folders]');
+    const unlockedFolders = new Set();
+    if (root) {
+      const initial = (root.getAttribute('data-unlocked-folders') || '').split(',').map((value) => value.trim()).filter(Boolean);
+      initial.forEach((value) => unlockedFolders.add(value));
+    }
+
+    function getCsrfToken() {
+      const tokenInput = document.querySelector('input[name="csrfmiddlewaretoken"]');
+      return tokenInput ? tokenInput.value : '';
+    }
+
+    function decodePrompt(value) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(`<span>${value}</span>`, 'text/html');
+      return doc.body.textContent || '';
+    }
+
+    function markUnlocked(card) {
+      card.dataset.locked = 'false';
+      const image = card.querySelector('img');
+      const overlay = card.querySelector('.absolute');
+      if (image) {
+        image.classList.remove('blur-2xl');
+      }
+      if (overlay) {
+        overlay.remove();
+      }
+      const promptElement = card.querySelector('[data-prompt-text]');
+      if (promptElement) {
+        const stored = decodePrompt(card.getAttribute('data-original-prompt') || '');
+        promptElement.textContent = stored;
+      }
+    }
+
+    function requestUnlock(card, folderId) {
+      if (!folderId) {
+        return;
+      }
+      const pin = window.prompt('Enter the folder PIN to unlock this asset:');
+      if (!pin) {
+        return;
+      }
+      fetch(`{% url 'assets:verify-folder' 0 %}`.replace('/0/', `/${folderId}/`), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({ pin }),
+        credentials: 'same-origin',
+      })
+        .then((response) => {
+          if (!response.ok) {
+            return response.json().then((payload) => {
+              throw payload;
+            });
+          }
+          return response.json();
+        })
+        .then(() => {
+          unlockedFolders.add(String(folderId));
+          markUnlocked(card);
+        })
+        .catch((payload) => {
+          const message = payload && payload.message ? payload.message : 'Incorrect PIN.';
+          window.alert(message);
+        });
+    }
+
+    document.querySelectorAll('[data-asset-card][data-locked="true"]').forEach((card) => {
+      const folderId = card.getAttribute('data-folder-id');
+      if (!folderId) {
+        return;
+      }
+      if (unlockedFolders.has(folderId)) {
+        markUnlocked(card);
+        return;
+      }
+      const trigger = card.querySelector('[data-locked-trigger]');
+      if (!trigger) {
+        return;
+      }
+      const handler = () => requestUnlock(card, folderId);
+      trigger.addEventListener('click', handler);
+      trigger.addEventListener('keypress', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handler();
+        }
+      });
+    });
+  });
+</script>
 </div>
 {% endblock %}

--- a/appertivo/assets/templates/assets/manage_models.html
+++ b/appertivo/assets/templates/assets/manage_models.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block title %}Manage Models · Appertivo{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto px-6 py-12 space-y-8">
+  <nav class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+    <a href="{% url 'assets:dashboard' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Studio</a>
+    <span class="rounded-full bg-purple-100 px-3 py-1 font-semibold text-purple-700">Models</span>
+    <a href="{% url 'assets:manage-prompts' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Prompts</a>
+    <a href="{% url 'assets:gallery' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Gallery</a>
+  </nav>
+
+  <header class="space-y-2">
+    <p class="text-xs font-semibold uppercase tracking-wide text-purple-600">Internal</p>
+    <h1 class="text-3xl font-semibold text-slate-900">Manage models</h1>
+    <p class="text-sm text-slate-600">Register new Replicate identifiers or tidy up existing ones. Changes reflect immediately in the studio dropdown.</p>
+  </header>
+
+  {% if messages %}
+    <div class="space-y-2">
+      {% for message in messages %}
+        <div class="rounded-lg border border-slate-200 bg-white/80 px-4 py-2 text-sm text-slate-700">{{ message }}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
+    <h2 class="text-lg font-semibold text-slate-900">Add a model</h2>
+    <form method="post" class="grid gap-3 text-sm text-slate-600 md:grid-cols-2">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="create-model" />
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Description</span>
+        {{ create_form.description }}
+        {% if create_form.description.errors %}
+          <span class="text-xs text-rose-600">{{ create_form.description.errors|join:', ' }}</span>
+        {% endif %}
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Identifier</span>
+        {{ create_form.identifier }}
+        {% if create_form.identifier.errors %}
+          <span class="text-xs text-rose-600">{{ create_form.identifier.errors|join:', ' }}</span>
+        {% endif %}
+      </label>
+      <div class="md:col-span-2 flex justify-end">
+        <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">Save model</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-slate-900">Saved models</h2>
+      <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ model_entries|length }} total</span>
+    </div>
+    {% if model_entries %}
+      <div class="space-y-4">
+        {% for model, form in model_entries %}
+          <div class="rounded-xl border border-slate-200 bg-white/70 p-4">
+            <form method="post" class="grid gap-3 text-sm text-slate-600 md:grid-cols-[1fr_1fr_auto] md:items-end">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="update-model" />
+              <input type="hidden" name="model_id" value="{{ model.id }}" />
+              <label class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Description</span>
+                {{ form.description }}
+                {% if form.description.errors %}
+                  <span class="text-xs text-rose-600">{{ form.description.errors|join:', ' }}</span>
+                {% endif %}
+              </label>
+              <label class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Identifier</span>
+                {{ form.identifier }}
+                {% if form.identifier.errors %}
+                  <span class="text-xs text-rose-600">{{ form.identifier.errors|join:', ' }}</span>
+                {% endif %}
+              </label>
+              <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
+            </form>
+            <form method="post" class="mt-3 flex justify-end" onsubmit="return confirm('Delete this model?');">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="delete-model" />
+              <input type="hidden" name="model_id" value="{{ model.id }}" />
+              <button type="submit" class="text-xs font-semibold uppercase tracking-wide text-rose-600 hover:text-rose-700">Delete</button>
+            </form>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="text-sm text-slate-600">No models added yet. Use the form above to register one.</p>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/appertivo/assets/templates/assets/manage_prompts.html
+++ b/appertivo/assets/templates/assets/manage_prompts.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Manage Prompts · Appertivo{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto px-6 py-12 space-y-8">
+  <nav class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+    <a href="{% url 'assets:dashboard' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Studio</a>
+    <a href="{% url 'assets:manage-models' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Models</a>
+    <span class="rounded-full bg-purple-100 px-3 py-1 font-semibold text-purple-700">Prompts</span>
+    <a href="{% url 'assets:gallery' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Gallery</a>
+  </nav>
+
+  <header class="space-y-2">
+    <p class="text-xs font-semibold uppercase tracking-wide text-purple-600">Internal</p>
+    <h1 class="text-3xl font-semibold text-slate-900">Prompt library</h1>
+    <p class="text-sm text-slate-600">Save reusable copy for consistent renders and tweak them when inspiration strikes.</p>
+  </header>
+
+  {% if messages %}
+    <div class="space-y-2">
+      {% for message in messages %}
+        <div class="rounded-lg border border-slate-200 bg-white/80 px-4 py-2 text-sm text-slate-700">{{ message }}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
+    <h2 class="text-lg font-semibold text-slate-900">Add a prompt</h2>
+    <form method="post" class="space-y-3 text-sm text-slate-600">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="create-prompt" />
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Title</span>
+        {{ create_form.title }}
+        {% if create_form.title.errors %}
+          <span class="text-xs text-rose-600">{{ create_form.title.errors|join:', ' }}</span>
+        {% endif %}
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Prompt text</span>
+        {{ create_form.text }}
+        {% if create_form.text.errors %}
+          <span class="text-xs text-rose-600">{{ create_form.text.errors|join:', ' }}</span>
+        {% endif %}
+      </label>
+      <div class="flex justify-end">
+        <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">Add prompt</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-slate-900">Saved prompts</h2>
+      <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ prompt_entries|length }} total</span>
+    </div>
+    {% if prompt_entries %}
+      <div class="space-y-4">
+        {% for prompt, form in prompt_entries %}
+          <div class="rounded-xl border border-slate-200 bg-white/70 p-4">
+            <form method="post" class="grid gap-3 text-sm text-slate-600 md:grid-cols-2">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="update-prompt" />
+              <input type="hidden" name="prompt_id" value="{{ prompt.id }}" />
+              <label class="flex flex-col gap-1">
+                <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Title</span>
+                {{ form.title }}
+                {% if form.title.errors %}
+                  <span class="text-xs text-rose-600">{{ form.title.errors|join:', ' }}</span>
+                {% endif %}
+              </label>
+              <label class="flex flex-col gap-1 md:col-span-2">
+                <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Prompt text</span>
+                {{ form.text }}
+                {% if form.text.errors %}
+                  <span class="text-xs text-rose-600">{{ form.text.errors|join:', ' }}</span>
+                {% endif %}
+              </label>
+              <div class="md:col-span-2 flex justify-between text-xs uppercase tracking-wide">
+                <span class="text-slate-400">Created {{ prompt.created_at|date:"M j, Y" }}</span>
+                <div class="flex items-center gap-3">
+                  <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
+                </div>
+              </div>
+            </form>
+            <form method="post" class="mt-3 flex justify-end" onsubmit="return confirm('Delete this prompt?');">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="delete-prompt" />
+              <input type="hidden" name="prompt_id" value="{{ prompt.id }}" />
+              <button type="submit" class="text-xs font-semibold uppercase tracking-wide text-rose-600 hover:text-rose-700">Delete</button>
+            </form>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="text-sm text-slate-600">No prompts saved yet. Add one using the form above.</p>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -140,31 +140,77 @@ class AssetDashboardTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "assets/dashboard.html")
 
-    def test_create_model_and_prompt(self) -> None:
-        """Staff can register models and prompts from the dashboard."""
+    def test_manage_models_crud(self) -> None:
+        """Staff can create, update, and delete models from the management page."""
 
         self.client.force_login(self.staff_user)
-        response = self.client.post(
-            reverse("assets:dashboard"),
+        create_response = self.client.post(
+            reverse("assets:manage-models"),
             {
                 "action": "create-model",
                 "model-description": "High fidelity food",
                 "model-identifier": "owner/food:456",
             },
         )
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(AssetModel.objects.filter(identifier="owner/food:456").exists())
+        self.assertEqual(create_response.status_code, 302)
+        model = AssetModel.objects.get(identifier="owner/food:456")
 
-        response = self.client.post(
-            reverse("assets:dashboard"),
+        update_response = self.client.post(
+            reverse("assets:manage-models"),
+            {
+                "action": "update-model",
+                "model_id": model.pk,
+                f"model-edit-{model.pk}-description": "Updated",
+                f"model-edit-{model.pk}-identifier": "owner/new:789",
+            },
+        )
+        self.assertEqual(update_response.status_code, 302)
+        model.refresh_from_db()
+        self.assertEqual(model.description, "Updated")
+        self.assertEqual(model.identifier, "owner/new:789")
+
+        delete_response = self.client.post(
+            reverse("assets:manage-models"),
+            {"action": "delete-model", "model_id": model.pk},
+        )
+        self.assertEqual(delete_response.status_code, 302)
+        self.assertFalse(AssetModel.objects.filter(pk=model.pk).exists())
+
+    def test_manage_prompts_crud(self) -> None:
+        """Prompt templates are maintained from the dedicated page."""
+
+        self.client.force_login(self.staff_user)
+        create_response = self.client.post(
+            reverse("assets:manage-prompts"),
             {
                 "action": "create-prompt",
                 "prompt-title": "Hero shot",
                 "prompt-text": "Stunning hero image",
             },
         )
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(PromptTemplate.objects.filter(title="Hero shot").exists())
+        self.assertEqual(create_response.status_code, 302)
+        prompt = PromptTemplate.objects.get(title="Hero shot")
+
+        update_response = self.client.post(
+            reverse("assets:manage-prompts"),
+            {
+                "action": "update-prompt",
+                "prompt_id": prompt.pk,
+                f"prompt-edit-{prompt.pk}-title": "Updated title",
+                f"prompt-edit-{prompt.pk}-text": "Updated text",
+            },
+        )
+        self.assertEqual(update_response.status_code, 302)
+        prompt.refresh_from_db()
+        self.assertEqual(prompt.title, "Updated title")
+        self.assertEqual(prompt.text, "Updated text")
+
+        delete_response = self.client.post(
+            reverse("assets:manage-prompts"),
+            {"action": "delete-prompt", "prompt_id": prompt.pk},
+        )
+        self.assertEqual(delete_response.status_code, 302)
+        self.assertFalse(PromptTemplate.objects.filter(pk=prompt.pk).exists())
 
     @patch("appertivo.assets.views.async_task")
     def test_generate_preview_flow(self, mock_async: Mock) -> None:
@@ -193,6 +239,30 @@ class AssetDashboardTests(TestCase):
             job.pk,
             timeout=180,
         )
+
+    @patch("appertivo.assets.views.async_task")
+    def test_generate_preview_appends_additional_text(self, mock_async: Mock) -> None:
+        """Freeform text augments the template instead of replacing it."""
+
+        template = PromptTemplate.objects.create(title="Base", text="Base description")
+        self.client.force_login(self.staff_user)
+        response = self.client.post(
+            reverse("assets:dashboard"),
+            {
+                "action": "generate-asset",
+                "generate-model": str(self.model.pk),
+                "generate-prompt_template": str(template.pk),
+                "generate-prompt_text": "Extra spice",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(response.status_code, 202)
+        job = AssetPreviewJob.objects.get(pk=response.json()["job_id"])
+        self.assertIn("Base description", job.prompt)
+        self.assertIn("Extra spice", job.prompt)
+        self.assertIn("\n\n", job.prompt)
+        mock_async.assert_called_once()
 
     @patch("appertivo.assets.views.async_task")
     def test_generate_preview_requires_prompt(self, mock_async: Mock) -> None:
@@ -364,6 +434,33 @@ class AssetDashboardTests(TestCase):
         self.assertEqual(payload["preview_url"], "https://example.com/asset.png")
         self.assertEqual(payload["storage_path"], "previews/test.png")
 
+    def test_verify_folder_pin_unlocks_session(self) -> None:
+        """Submitting the correct PIN unlocks the folder for the session."""
+
+        folder = AssetFolder.objects.create(name="Private", pin="4321", is_locked=True)
+        self.client.force_login(self.staff_user)
+        url = reverse("assets:verify-folder", args=[folder.pk])
+
+        bad_response = self.client.post(
+            url,
+            data='{"pin": "0000"}',
+            content_type="application/json",
+        )
+        self.assertEqual(bad_response.status_code, 400)
+        self.assertNotIn("asset_unlocked_folders", self.client.session)
+
+        good_response = self.client.post(
+            url,
+            data='{"pin": "4321"}',
+            content_type="application/json",
+        )
+        self.assertEqual(good_response.status_code, 200)
+        self.assertIn(folder.pk, self.client.session.get("asset_unlocked_folders", []))
+
+        gallery = self.client.get(reverse("assets:gallery"))
+        self.assertEqual(gallery.status_code, 200)
+        self.assertIn(folder.pk, gallery.context["unlocked_folder_ids"])
+
     def test_recent_assets_hide_locked_folders(self) -> None:
         """Locked folders do not surface in the recent list."""
 
@@ -380,60 +477,3 @@ class AssetDashboardTests(TestCase):
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].prompt, "Visible")
 
-    def test_update_and_delete_model(self) -> None:
-        """Staff can edit or remove saved models."""
-
-        self.client.force_login(self.staff_user)
-        model = AssetModel.objects.create(description="Old", identifier="owner/old:1")
-
-        update_response = self.client.post(
-            reverse("assets:dashboard"),
-            {
-                "action": "update-model",
-                "model_id": model.pk,
-                f"model-edit-{model.pk}-description": "Updated",
-                f"model-edit-{model.pk}-identifier": "owner/new:2",
-            },
-        )
-
-        self.assertEqual(update_response.status_code, 302)
-        model.refresh_from_db()
-        self.assertEqual(model.description, "Updated")
-        self.assertEqual(model.identifier, "owner/new:2")
-
-        delete_response = self.client.post(
-            reverse("assets:dashboard"),
-            {"action": "delete-model", "model_id": model.pk},
-        )
-
-        self.assertEqual(delete_response.status_code, 302)
-        self.assertFalse(AssetModel.objects.filter(pk=model.pk).exists())
-
-    def test_update_and_delete_prompt(self) -> None:
-        """Staff can edit or remove saved prompt templates."""
-
-        self.client.force_login(self.staff_user)
-        prompt = PromptTemplate.objects.create(title="Original", text="Prompt")
-
-        update_response = self.client.post(
-            reverse("assets:dashboard"),
-            {
-                "action": "update-prompt",
-                "prompt_id": prompt.pk,
-                f"prompt-edit-{prompt.pk}-title": "Changed",
-                f"prompt-edit-{prompt.pk}-text": "Updated text",
-            },
-        )
-
-        self.assertEqual(update_response.status_code, 302)
-        prompt.refresh_from_db()
-        self.assertEqual(prompt.title, "Changed")
-        self.assertEqual(prompt.text, "Updated text")
-
-        delete_response = self.client.post(
-            reverse("assets:dashboard"),
-            {"action": "delete-prompt", "prompt_id": prompt.pk},
-        )
-
-        self.assertEqual(delete_response.status_code, 302)
-        self.assertFalse(PromptTemplate.objects.filter(pk=prompt.pk).exists())

--- a/appertivo/assets/urls.py
+++ b/appertivo/assets/urls.py
@@ -8,7 +8,10 @@ app_name = "assets"
 
 urlpatterns = [
     path("assets/", views.dashboard, name="dashboard"),
+    path("assets/models/", views.manage_models, name="manage-models"),
+    path("assets/prompts/", views.manage_prompts, name="manage-prompts"),
     path("assets/preview-jobs/<int:job_id>/", views.preview_status, name="preview-status"),
     path("assets/previews/discard/", views.discard_preview, name="discard-preview"),
+    path("assets/folders/<int:folder_id>/verify/", views.verify_folder_pin, name="verify-folder"),
     path("assets/library/", views.gallery, name="gallery"),
 ]

--- a/appertivo/assets/views.py
+++ b/appertivo/assets/views.py
@@ -132,42 +132,31 @@ def _save_preview(
 def dashboard(request: HttpRequest) -> HttpResponse:
     """Render the internal workspace for generating image assets."""
 
-    model_form = AssetModelForm(prefix="model")
-    prompt_form = PromptTemplateForm(prefix="prompt")
     generation_form = AssetGenerationForm(prefix="generate")
     save_form = AssetSaveForm(prefix="save")
     preview_url: str | None = None
     preview_prompt: str = ""
     selected_model_id: int | None = None
     preview_storage_path: str | None = None
-    model_forms: dict[int, AssetModelForm] = {}
-    prompt_forms: dict[int, PromptTemplateForm] = {}
 
     if request.method == "POST":
         action = request.POST.get("action")
 
-        if action == "create-model":
-            model_form = AssetModelForm(request.POST, prefix="model")
-            if model_form.is_valid():
-                model_form.save()
-                messages.success(request, "Model saved. It is now available in the dropdown.")
-                return redirect("assets:dashboard")
-        elif action == "create-prompt":
-            prompt_form = PromptTemplateForm(request.POST, prefix="prompt")
-            if prompt_form.is_valid():
-                prompt = prompt_form.save()
-                messages.success(request, f'Prompt "{prompt.title}" added to the library.')
-                return redirect("assets:dashboard")
-        elif action == "generate-asset":
+        if action == "generate-asset":
             generation_form = AssetGenerationForm(request.POST, prefix="generate")
             model = None
             prompt_text = ""
             if generation_form.is_valid():
                 model = generation_form.cleaned_data["model"]
                 template = generation_form.cleaned_data["prompt_template"]
-                prompt_text = (generation_form.cleaned_data["prompt_text"] or "").strip()
-                if not prompt_text and template:
-                    prompt_text = template.text
+                additional_text = (generation_form.cleaned_data["prompt_text"] or "").strip()
+                if template:
+                    prompt_text = (template.text or "").strip()
+                if additional_text:
+                    if prompt_text:
+                        prompt_text = f"{prompt_text}\n\n{additional_text}".strip()
+                    else:
+                        prompt_text = additional_text
                 if not prompt_text:
                     generation_form.add_error(
                         "prompt_text",
@@ -223,72 +212,13 @@ def dashboard(request: HttpRequest) -> HttpResponse:
                     selected_model_id = None
                 preview_storage_path = save_form.data.get("save-storage_path") or None
 
-        elif action == "update-model":
-            try:
-                model_id = int(request.POST.get("model_id", ""))
-            except (TypeError, ValueError):
-                messages.error(request, "Invalid model selection.")
-            else:
-                model_instance = get_object_or_404(AssetModel, pk=model_id)
-                prefix = f"model-edit-{model_instance.pk}"
-                form = AssetModelForm(request.POST, prefix=prefix, instance=model_instance)
-                if form.is_valid():
-                    form.save()
-                    messages.success(request, "Model updated.")
-                    return redirect("assets:dashboard")
-                model_forms[model_instance.pk] = form
-        elif action == "delete-model":
-            try:
-                model_id = int(request.POST.get("model_id", ""))
-            except (TypeError, ValueError):
-                messages.error(request, "Invalid model selection.")
-            else:
-                model_instance = get_object_or_404(AssetModel, pk=model_id)
-                model_instance.delete()
-                messages.success(request, "Model deleted.")
-                return redirect("assets:dashboard")
-        elif action == "update-prompt":
-            try:
-                prompt_id = int(request.POST.get("prompt_id", ""))
-            except (TypeError, ValueError):
-                messages.error(request, "Invalid prompt selection.")
-            else:
-                prompt_instance = get_object_or_404(PromptTemplate, pk=prompt_id)
-                prefix = f"prompt-edit-{prompt_instance.pk}"
-                form = PromptTemplateForm(request.POST, prefix=prefix, instance=prompt_instance)
-                if form.is_valid():
-                    form.save()
-                    messages.success(request, "Prompt updated.")
-                    return redirect("assets:dashboard")
-                prompt_forms[prompt_instance.pk] = form
-        elif action == "delete-prompt":
-            try:
-                prompt_id = int(request.POST.get("prompt_id", ""))
-            except (TypeError, ValueError):
-                messages.error(request, "Invalid prompt selection.")
-            else:
-                prompt_instance = get_object_or_404(PromptTemplate, pk=prompt_id)
-                prompt_instance.delete()
-                messages.success(request, "Prompt deleted.")
-                return redirect("assets:dashboard")
-
     recent_assets: QuerySet[GeneratedAsset] = (
         GeneratedAsset.objects.select_related("model", "folder")
         .exclude(folder__is_locked=True)
         [:6]
     )
 
-    for model in AssetModel.objects.all():
-        prefix = f"model-edit-{model.pk}"
-        model_forms.setdefault(model.pk, AssetModelForm(prefix=prefix, instance=model))
-
-    for prompt in PromptTemplate.objects.all():
-        prefix = f"prompt-edit-{prompt.pk}"
-        prompt_forms.setdefault(prompt.pk, PromptTemplateForm(prefix=prefix, instance=prompt))
-
     context = {
-        "model_form": model_form,
-        "prompt_form": prompt_form,
         "generation_form": generation_form,
         "save_form": save_form,
         "preview_url": preview_url,
@@ -298,10 +228,112 @@ def dashboard(request: HttpRequest) -> HttpResponse:
         "has_replicate": replicate_client is not None,
         "preview_storage_path": preview_storage_path,
         "discard_preview_url": reverse("assets:discard-preview"),
-        "model_forms": model_forms,
-        "prompt_forms": prompt_forms,
     }
     return render(request, "assets/dashboard.html", context)
+
+
+@staff_member_required
+def manage_models(request: HttpRequest) -> HttpResponse:
+    """Create, update, or delete saved Replicate models."""
+
+    create_form = AssetModelForm(prefix="model")
+    edit_forms: dict[int, AssetModelForm] = {}
+
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "create-model":
+            create_form = AssetModelForm(request.POST, prefix="model")
+            if create_form.is_valid():
+                create_form.save()
+                messages.success(request, "Model saved. It is now available in the studio.")
+                return redirect("assets:manage-models")
+        elif action == "update-model":
+            try:
+                model_id = int(request.POST.get("model_id", ""))
+            except (TypeError, ValueError):
+                messages.error(request, "Invalid model selection.")
+            else:
+                instance = get_object_or_404(AssetModel, pk=model_id)
+                prefix = f"model-edit-{instance.pk}"
+                form = AssetModelForm(request.POST, prefix=prefix, instance=instance)
+                if form.is_valid():
+                    form.save()
+                    messages.success(request, "Model updated.")
+                    return redirect("assets:manage-models")
+                edit_forms[instance.pk] = form
+        elif action == "delete-model":
+            try:
+                model_id = int(request.POST.get("model_id", ""))
+            except (TypeError, ValueError):
+                messages.error(request, "Invalid model selection.")
+            else:
+                instance = get_object_or_404(AssetModel, pk=model_id)
+                instance.delete()
+                messages.success(request, "Model deleted.")
+                return redirect("assets:manage-models")
+
+    models = AssetModel.objects.all()
+    for model in models:
+        prefix = f"model-edit-{model.pk}"
+        edit_forms.setdefault(model.pk, AssetModelForm(prefix=prefix, instance=model))
+
+    context = {
+        "create_form": create_form,
+        "model_entries": [(model, edit_forms[model.pk]) for model in models],
+    }
+    return render(request, "assets/manage_models.html", context)
+
+
+@staff_member_required
+def manage_prompts(request: HttpRequest) -> HttpResponse:
+    """Allow staff to curate prompt templates."""
+
+    create_form = PromptTemplateForm(prefix="prompt")
+    edit_forms: dict[int, PromptTemplateForm] = {}
+
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "create-prompt":
+            create_form = PromptTemplateForm(request.POST, prefix="prompt")
+            if create_form.is_valid():
+                prompt = create_form.save()
+                messages.success(request, f'Prompt "{prompt.title}" added to the library.')
+                return redirect("assets:manage-prompts")
+        elif action == "update-prompt":
+            try:
+                prompt_id = int(request.POST.get("prompt_id", ""))
+            except (TypeError, ValueError):
+                messages.error(request, "Invalid prompt selection.")
+            else:
+                instance = get_object_or_404(PromptTemplate, pk=prompt_id)
+                prefix = f"prompt-edit-{instance.pk}"
+                form = PromptTemplateForm(request.POST, prefix=prefix, instance=instance)
+                if form.is_valid():
+                    form.save()
+                    messages.success(request, "Prompt updated.")
+                    return redirect("assets:manage-prompts")
+                edit_forms[instance.pk] = form
+        elif action == "delete-prompt":
+            try:
+                prompt_id = int(request.POST.get("prompt_id", ""))
+            except (TypeError, ValueError):
+                messages.error(request, "Invalid prompt selection.")
+            else:
+                instance = get_object_or_404(PromptTemplate, pk=prompt_id)
+                instance.delete()
+                messages.success(request, "Prompt deleted.")
+                return redirect("assets:manage-prompts")
+
+    prompts = PromptTemplate.objects.all()
+    for prompt in prompts:
+        prefix = f"prompt-edit-{prompt.pk}"
+        edit_forms.setdefault(prompt.pk, PromptTemplateForm(prefix=prefix, instance=prompt))
+
+    context = {
+        "create_form": create_form,
+        "prompt_entries": [(prompt, edit_forms[prompt.pk]) for prompt in prompts],
+    }
+    return render(request, "assets/manage_prompts.html", context)
 
 
 @staff_member_required
@@ -333,6 +365,11 @@ def gallery(request: HttpRequest) -> HttpResponse:
     folders = AssetFolder.objects.all()
     folder_form = AssetFolderForm(prefix="folder")
     folder_security_forms: dict[int, AssetFolderSecurityForm] = {}
+    unlocked_folder_ids = {
+        int(folder_id)
+        for folder_id in request.session.get("asset_unlocked_folders", [])
+        if isinstance(folder_id, int) or str(folder_id).isdigit()
+    }
     for folder in folders:
         prefix = f"folder-security-{folder.pk}"
         folder_security_forms[folder.pk] = AssetFolderSecurityForm(prefix=prefix, instance=folder)
@@ -409,7 +446,14 @@ def gallery(request: HttpRequest) -> HttpResponse:
                     messages.success(request, "Deleted the selected asset.")
                 return redirect("assets:gallery")
 
-    folder_entries = [(folder, folder_security_forms[folder.pk]) for folder in folders]
+    folder_entries = [
+        {
+            "folder": folder,
+            "form": folder_security_forms[folder.pk],
+            "is_unlocked": folder.pk in unlocked_folder_ids,
+        }
+        for folder in folders
+    ]
 
     context = {
         "assets": assets,
@@ -418,8 +462,35 @@ def gallery(request: HttpRequest) -> HttpResponse:
         "folder_entries": folder_entries,
         "selected_filter": selected_filter,
         "selected_folder_id": selected_folder_id,
+        "unlocked_folder_ids": sorted(unlocked_folder_ids),
     }
     return render(request, "assets/gallery.html", context)
+
+
+@staff_member_required
+@require_POST
+def verify_folder_pin(request: HttpRequest, folder_id: int) -> JsonResponse:
+    """Confirm a folder PIN before revealing protected assets."""
+
+    folder = get_object_or_404(AssetFolder, pk=folder_id)
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        payload = request.POST
+
+    pin = (payload.get("pin") or "").strip()
+
+    if folder.is_locked and not pin:
+        return JsonResponse({"status": "error", "message": "Enter the folder PIN."}, status=400)
+
+    if folder.is_locked and pin != folder.pin:
+        return JsonResponse({"status": "error", "message": "Incorrect PIN."}, status=400)
+
+    unlocked = set(request.session.get("asset_unlocked_folders", []))
+    unlocked.add(folder.pk)
+    request.session["asset_unlocked_folders"] = list(unlocked)
+
+    return JsonResponse({"status": "ok"})
 
 
 @staff_member_required


### PR DESCRIPTION
## Summary
- add top navigation and quick links on the studio dashboard for models, prompts, and gallery pages
- introduce dedicated management pages for models and prompts plus supporting view logic and routes
- redesign the gallery with compact folder controls, locked-asset handling, and PIN verification for private folders
- ensure ad-hoc prompt text augments saved templates when generating previews

## Testing
- python manage.py test appertivo.assets.tests.test_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68debb406eb48332a33468e7856878ad