### PR TITLE
Fix initial payload logging order in fetch_leads

### DIFF
--- a/appertivo/leads/tasks.py
+++ b/appertivo/leads/tasks.py
@@ -220,8 +220,8 @@ def fetch_leads(
     except requests.RequestException as exc:  # pragma: no cover - network failure
         logger.exception("Outscraper request failed: %s", exc)
         return []
-    logger.info(initial_payload)
     initial_payload = response.json()
+    logger.info(initial_payload)
     payload = resolve_outscraper_payload(initial_payload, headers)
     job_id = extract_outscraper_job_id(payload) or extract_outscraper_job_id(initial_payload)
     if run is not None and job_id and run.outscraper_job_id != job_id:


### PR DESCRIPTION
## Summary
- ensure fetch_leads parses the Outscraper response before logging the payload to avoid referencing an undefined variable

## Testing
- pytest appertivo/leads/tests/

------
https://chatgpt.com/codex/tasks/task_e_68dec0d24bc4833284d0de5400034ddf