### PR TITLE
Summarize dashboard logs and expand asset API logging

### DIFF
--- a/appertivo/assets/views.py
+++ b/appertivo/assets/views.py
@@ -164,6 +164,10 @@ def dashboard(request: HttpRequest) -> HttpResponse:
                     )
 
             if generation_form.errors:
+                logger.warning(
+                    "Asset preview validation failed: %s",
+                    generation_form.errors,
+                )
                 return JsonResponse({"errors": generation_form.errors}, status=400)
 
             assert model is not None  # Satisfy type checkers.
@@ -175,6 +179,9 @@ def dashboard(request: HttpRequest) -> HttpResponse:
                 "appertivo.assets.tasks.run_preview_job",
                 job.pk,
                 timeout=180,
+            )
+            logger.info(
+                "Queued asset preview job %s for model %s", job.pk, model.pk
             )
             return JsonResponse(
                 {
@@ -344,6 +351,9 @@ def preview_status(request: HttpRequest, job_id: int) -> JsonResponse:
         return HttpResponseNotAllowed(["GET"])
 
     job = get_object_or_404(AssetPreviewJob, pk=job_id)
+    logger.info(
+        "Preview status requested for job %s (%s)", job.pk, job.status
+    )
     return JsonResponse(
         {
             "id": job.pk,
@@ -481,15 +491,30 @@ def verify_folder_pin(request: HttpRequest, folder_id: int) -> JsonResponse:
     pin = (payload.get("pin") or "").strip()
 
     if folder.is_locked and not pin:
+        logger.warning(
+            "Folder %s PIN missing for user %s",
+            folder.pk,
+            getattr(request.user, "pk", None),
+        )
         return JsonResponse({"status": "error", "message": "Enter the folder PIN."}, status=400)
 
     if folder.is_locked and pin != folder.pin:
+        logger.warning(
+            "Folder %s PIN mismatch for user %s",
+            folder.pk,
+            getattr(request.user, "pk", None),
+        )
         return JsonResponse({"status": "error", "message": "Incorrect PIN."}, status=400)
 
     unlocked = set(request.session.get("asset_unlocked_folders", []))
     unlocked.add(folder.pk)
     request.session["asset_unlocked_folders"] = list(unlocked)
 
+    logger.info(
+        "Folder %s unlocked by user %s",
+        folder.pk,
+        getattr(request.user, "pk", None),
+    )
     return JsonResponse({"status": "ok"})
 
 
@@ -505,18 +530,24 @@ def discard_preview(request: HttpRequest) -> JsonResponse:
 
     storage_path = (payload.get("storage_path") or "").strip()
     if not storage_path:
+        logger.info("Discard preview skipped: missing path")
         return JsonResponse({"status": "skipped"})
 
     if ".." in storage_path or storage_path.startswith("/"):
+        logger.warning("Discard preview rejected for unsafe path: %s", storage_path)
         return JsonResponse({"status": "invalid"}, status=400)
 
     if not storage_path.startswith("previews/"):
+        logger.warning(
+            "Discard preview rejected for unexpected prefix: %s", storage_path
+        )
         return JsonResponse({"status": "invalid"}, status=400)
 
     try:
         default_storage.delete(storage_path)
     except Exception:  # pragma: no cover - storage guard
-        logger.info("Failed to delete preview %s", storage_path, exc_info=True)
+        logger.error("Failed to delete preview %s", storage_path, exc_info=True)
         return JsonResponse({"status": "error"}, status=500)
 
+    logger.info("Discarded preview %s", storage_path)
     return JsonResponse({"status": "deleted"})

--- a/dashboard/tests/test_views.py
+++ b/dashboard/tests/test_views.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from pathlib import Path
 
 from django.conf import settings
@@ -170,10 +170,19 @@ class LogFeedViewTests(TestCase):
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         self.log_path.write_text("", encoding="utf-8")
 
-    def _write_entries(self, total: int) -> None:
+    def _write_entries(self, total: int, level: str = "ERROR") -> None:
+        base_time = datetime(2024, 1, 1, 0, 0, tzinfo=dt_timezone.utc)
         with self.log_path.open("w", encoding="utf-8") as stream:
             for index in range(total):
-                entry = {"message": f"entry-{index}", "index": index}
+                timestamp = (base_time + timedelta(minutes=index)).isoformat().replace(
+                    "+00:00", "Z"
+                )
+                entry = {
+                    "timestamp": timestamp,
+                    "level": level,
+                    "name": "appertivo.tests",
+                    "message": f"entry-{index}",
+                }
                 stream.write(json.dumps(entry) + "\n")
 
     def test_logs_require_staff(self) -> None:
@@ -191,7 +200,12 @@ class LogFeedViewTests(TestCase):
         self.client.force_login(self.staff)
         response = self.client.get(reverse("dashboard:logs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        payload = response.json()
+        self.assertIn("generated_at", payload)
+        self.assertEqual(payload["total_entries"], 0)
+        self.assertEqual(payload["levels"], {})
+        self.assertEqual(payload["top_errors"], [])
+        self.assertEqual(payload["recent_errors"], [])
 
     def test_logs_limit_to_recent_entries(self) -> None:
         """Only the most recent 200 log entries should be returned."""
@@ -201,6 +215,50 @@ class LogFeedViewTests(TestCase):
         response = self.client.get(reverse("dashboard:logs"))
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(len(payload), 200)
-        self.assertEqual(payload[0]["index"], 5)
-        self.assertEqual(payload[-1]["index"], 204)
+        self.assertEqual(payload["total_entries"], 200)
+        self.assertEqual(payload["levels"].get("ERROR"), 200)
+        self.assertEqual(len(payload["recent_errors"]), 20)
+        self.assertEqual(payload["recent_errors"][0]["message"], "entry-204")
+        self.assertEqual(payload["recent_errors"][-1]["message"], "entry-185")
+
+    def test_logs_group_errors(self) -> None:
+        """Error entries should be summarized for quick review."""
+
+        entries = [
+            {
+                "timestamp": "2024-01-01T00:00:00Z",
+                "level": "ERROR",
+                "name": "app.worker",
+                "message": "Boom",
+            },
+            {
+                "timestamp": "2024-01-01T00:05:00Z",
+                "level": "ERROR",
+                "name": "app.worker",
+                "message": "Boom",
+            },
+            {
+                "timestamp": "2024-01-01T00:10:00Z",
+                "level": "WARNING",
+                "name": "app.worker",
+                "message": "Heads up",
+            },
+        ]
+        with self.log_path.open("w", encoding="utf-8") as stream:
+            for entry in entries:
+                stream.write(json.dumps(entry) + "\n")
+
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("dashboard:logs"))
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["levels"].get("ERROR"), 2)
+        self.assertEqual(payload["levels"].get("WARNING"), 1)
+        self.assertEqual(len(payload["recent_errors"]), 2)
+        self.assertEqual(payload["recent_errors"][0]["timestamp"], "2024-01-01T00:05:00Z")
+        self.assertTrue(payload["top_errors"])
+        top_error = payload["top_errors"][0]
+        self.assertEqual(top_error["message"], "Boom")
+        self.assertEqual(top_error["count"], 2)
+        self.assertEqual(top_error["logger"], "app.worker")
+        self.assertEqual(top_error["last_seen"], "2024-01-01T00:05:00Z")

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -438,5 +439,53 @@ class LogFeedView(StaffOnlyMixin, View):
                     continue
                 if isinstance(payload, dict):
                     entries.append(payload)
+        level_counts: Counter[str] = Counter()
+        error_groups: dict[tuple[str, str], dict[str, Any]] = {}
+        error_entries: list[dict[str, str]] = []
+        error_levels = {"ERROR", "CRITICAL"}
 
-        return JsonResponse(entries, safe=False)
+        for entry in entries:
+            level = str(entry.get("level") or "INFO").upper()
+            message = str(entry.get("message") or "").strip()
+            logger_name = str(entry.get("name") or "").strip()
+            timestamp = str(entry.get("timestamp") or "").strip()
+
+            level_counts[level] += 1
+
+            if level in error_levels:
+                key = (message, logger_name)
+                group = error_groups.get(key)
+                if group is None:
+                    group = {
+                        "message": message or "(no message)",
+                        "logger": logger_name or "(unknown)",
+                        "count": 0,
+                        "last_seen": "",
+                    }
+                group["count"] += 1
+                if timestamp and (not group["last_seen"] or timestamp > group["last_seen"]):
+                    group["last_seen"] = timestamp
+                error_groups[key] = group
+                error_entries.append(
+                    {
+                        "message": group["message"],
+                        "logger": group["logger"],
+                        "timestamp": timestamp,
+                        "level": level,
+                    }
+                )
+
+        top_errors = sorted(
+            error_groups.values(), key=lambda item: (-item["count"], item["message"])
+        )
+        recent_errors = list(reversed(error_entries[-20:]))
+
+        payload = {
+            "generated_at": timezone.now().isoformat(),
+            "total_entries": len(entries),
+            "levels": dict(level_counts),
+            "top_errors": top_errors,
+            "recent_errors": recent_errors,
+        }
+
+        return JsonResponse(payload)


### PR DESCRIPTION
## Summary
- replace the internal log feed blob with a summarized payload that counts levels and highlights recent/top errors
- extend dashboard log tests to cover the new summary output
- add structured logging to key Asset Studio API responses so activity is captured in the app log

## Testing
- python manage.py test dashboard.tests.test_views.LogFeedViewTests
- python manage.py test appertivo.assets.tests.test_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dec1e208148332a6b724d3fc1c3e97