### PR TITLE
Add dashboard redirect route

### DIFF
--- a/specials/urls.py
+++ b/specials/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("terms/", app_views.terms_view, name="terms"),
     path("contact/", app_views.contact_view, name="contact"),
     path("dashboard/<uuid:restaurant_id>/", app_views.dashboard, name="dashboard"),
+    path("dashboard/", app_views.dashboard_redirect, name="dashboard-redirect"),
 
     ## onboarding
     path("onboarding/", app_views.onboarding_view, name="onboarding"),


### PR DESCRIPTION
## Summary
- register the dashboard redirect view under /dashboard/ so LOGIN_REDIRECT_URL can resolve

## Testing
- python manage.py test tests.test_navigation_dashboard_url.DashboardNavigationURLTests --keepdb
- python manage.py shell -c "from django.urls import reverse; print(reverse('dashboard-redirect'))"


------
https://chatgpt.com/codex/tasks/task_e_68ded26a513483329aad4248390ced3c