### PR TITLE
Simplify lead dashboard review list

### DIFF
--- a/appertivo/leads/templates/leads/dashboard.html
+++ b/appertivo/leads/templates/leads/dashboard.html
@@ -76,36 +76,37 @@
   <section class="space-y-4">
     <h2 class="text-lg font-semibold text-slate-900">Review &amp; manage leads</h2>
     {% if leads %}
-      <div class="space-y-3">
+      <div class="space-y-2">
         {% for lead in leads %}
-          <article class="rounded-2xl border border-slate-200 bg-white/70 p-5 text-sm text-slate-600 shadow-sm">
-            <div class="flex flex-col gap-4">
-              <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                <div>
-                  <div class="text-base font-semibold text-slate-900">{{ lead.name }}</div>
-                  <div class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</div>
-                </div>
-                <div class="flex flex-wrap gap-2">
-                  {% if lead.shortlisted %}
-                    <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">Approved</span>
-                  {% endif %}
-                  {% if lead.emailed %}
-                    <span class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">Email sent</span>
-                  {% endif %}
-                  {% if lead.opened %}
-                    <span class="inline-flex items-center rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-semibold text-indigo-700">Opened</span>
-                  {% endif %}
-                  {% if lead.email_bounced %}
-                    <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-semibold text-red-700">Bounced</span>
-                  {% endif %}
-                  {% if not lead.shortlisted and not lead.emailed and not lead.email_bounced %}
-                    <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600">Awaiting review</span>
-                  {% endif %}
-                </div>
+          <details class="group rounded-xl border border-slate-200 bg-white/70 text-sm text-slate-600 shadow-sm transition" {% if forloop.first %}open{% endif %}>
+            <summary class="flex cursor-pointer items-center justify-between gap-4 px-4 py-3">
+              <div class="flex min-w-0 flex-1 flex-col">
+                <span class="truncate text-sm font-semibold text-slate-900">{{ lead.name }}</span>
+                <span class="text-xs text-slate-500">{{ lead.city|default:"Unknown city" }}</span>
               </div>
+              <div class="flex flex-wrap items-center gap-1">
+                {% if lead.shortlisted %}
+                  <span class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">In pipeline</span>
+                {% endif %}
+                {% if lead.emailed %}
+                  <span class="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-semibold text-blue-700">Email sent</span>
+                {% endif %}
+                {% if lead.opened %}
+                  <span class="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700">Opened</span>
+                {% endif %}
+                {% if lead.email_bounced %}
+                  <span class="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold text-red-700">Bounced</span>
+                {% endif %}
+                {% if not lead.shortlisted and not lead.emailed and not lead.email_bounced %}
+                  <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600">Awaiting review</span>
+                {% endif %}
+              </div>
+            </summary>
 
-              <div class="space-y-3">
-                <div class="space-y-1 text-slate-600">
+            <div class="border-t border-slate-100 px-4 pb-4 pt-3 space-y-3">
+              <div class="grid gap-2 text-sm md:grid-cols-2">
+                <div class="space-y-1">
+                  <p class="text-xs font-medium uppercase tracking-wide text-slate-500">Contact</p>
                   {% if lead.email %}
                     <div class="flex flex-wrap items-center gap-1 text-slate-700">
                       <span class="font-medium">Email:</span>
@@ -118,36 +119,17 @@
                     <div class="text-slate-600"><span class="font-medium">Phone:</span> {{ lead.phone }}</div>
                   {% endif %}
                 </div>
-
-                <details class="rounded-lg border border-slate-200/80 bg-white/60 px-3 py-2 text-xs text-slate-600">
-                  <summary class="cursor-pointer text-purple-600 hover:text-purple-700">View details</summary>
-                  <div class="mt-2 space-y-2">
-                    {% if lead.json_data %}
-                      <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="inline-flex w-full items-center justify-center rounded border border-slate-200 px-2 py-1 font-medium text-purple-600 hover:border-purple-400 hover:text-purple-700">View JSON data</button>
-                    {% endif %}
-                  </div>
-                </details>
+                <div class="space-y-1">
+                  <p class="text-xs font-medium uppercase tracking-wide text-slate-500">Timeline</p>
+                  <div class="text-xs text-slate-500">Collected {{ lead.created_at|date:"M j, Y H:i" }}</div>
+                  {% if lead.landing_url %}
+                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-700">View landing</a>
+                  {% endif %}
+                </div>
               </div>
 
-              {% if lead.json_data %}
-                <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
-                  <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
-                    <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-                      <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
-                      <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
-                    </div>
-                    <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
-                      <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
-                    </div>
-                  </div>
-                </div>
-              {% endif %}
-
-              <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div class="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
-                  {% if lead.landing_url %}
-                    <a href="{{ lead.landing_url }}" target="_blank" rel="noopener" class="inline-flex items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600">View landing</a>
-                  {% endif %}
+              <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div class="flex flex-1 flex-col gap-2 md:flex-row md:items-center md:gap-2">
                   <form method="post" action="{% url 'lead-actions' %}" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
                     {% csrf_token %}
                     <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
@@ -160,18 +142,34 @@
                         {% endfor %}
                       </select>
                     {% endif %}
-                    <button type="submit" name="action" value="approve" onclick="return confirm('Approve this lead, generate a landing page, and send the email?');" class="inline-flex w-full items-center justify-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">Approve</button>
+                    <button type="submit" name="action" value="approve" onclick="return confirm('Move this lead into the pipeline, generate a landing page, and send the email?');" class="inline-flex w-full items-center justify-center rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 md:w-auto">Move to pipeline</button>
                   </form>
                   <form method="post" action="{% url 'lead-actions' %}" class="flex">
                     {% csrf_token %}
                     <input type="hidden" name="lead_ids" value="{{ lead.id }}" />
-                    <button type="submit" name="action" value="delete" onclick="return confirm('Delete this lead?');" class="inline-flex items-center justify-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700">Delete</button>
+                    <button type="submit" name="action" value="delete" onclick="return confirm('Reject this lead?');" class="inline-flex items-center justify-center rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300 hover:text-red-700">Reject</button>
                   </form>
                 </div>
-                <div class="text-[11px] text-slate-400">Collected {{ lead.created_at|date:"M j, Y H:i" }}</div>
+                {% if lead.json_data %}
+                  <button type="button" data-json-modal-target="lead-json-{{ lead.id }}" class="inline-flex w-full items-center justify-center rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-purple-400 hover:text-purple-600 md:w-auto">View raw data</button>
+                {% endif %}
               </div>
             </div>
-          </article>
+
+            {% if lead.json_data %}
+              <div id="lead-json-{{ lead.id }}" data-json-modal class="fixed inset-0 z-50 hidden bg-slate-900/60 p-4">
+                <div role="dialog" aria-modal="true" aria-labelledby="lead-json-title-{{ lead.id }}" class="mx-auto flex h-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
+                  <div class="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+                    <h3 id="lead-json-title-{{ lead.id }}" class="text-sm font-semibold text-slate-800">Lead JSON details</h3>
+                    <button type="button" data-json-modal-close class="rounded-md border border-slate-200 px-2 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-800">Close</button>
+                  </div>
+                  <div class="flex-1 overflow-auto bg-slate-50 px-4 py-3">
+                    <pre class="whitespace-pre-wrap text-[11px] leading-relaxed text-slate-700">{{ lead.json_data|pprint }}</pre>
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          </details>
         {% endfor %}
       </div>
     {% else %}


### PR DESCRIPTION
## Summary
- present leads on the dashboard as an expandable list so the default view stays compact while keeping context in the expanded panel
- refresh the action labels and layout so it is clearer how to move a lead into the pipeline, reject it, or inspect the raw data

## Testing
- python manage.py test appertivo.leads.tests.test_dashboard -v 2

------
https://chatgpt.com/codex/tasks/task_e_68ded2f5f5148332a41f163e5886033e