### PR TITLE
Filter queue kwargs from async_task stub

### DIFF
--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import django
+from django_q.tasks import async_task as queue_async_task
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage, default_storage
@@ -239,6 +240,43 @@ class AssetDashboardTests(TestCase):
             job.pk,
             timeout=180,
         )
+
+    @patch("appertivo.assets.tasks.run_preview_job")
+    @patch("appertivo.assets.views.async_task")
+    def test_generate_preview_filters_queue_kwargs(self, mock_async: Mock, mock_run: Mock) -> None:
+        """Queue-specific kwargs are not passed to the job callable."""
+
+        captured_ids: list[int] = []
+
+        def fake_run(job_id: int) -> None:
+            captured_ids.append(job_id)
+
+        mock_run.side_effect = fake_run
+
+        def fake_async(func_path: str, *args, timeout=None, **kwargs):
+            call_kwargs = dict(kwargs)
+            if timeout is not None:
+                call_kwargs["timeout"] = timeout
+            return queue_async_task(func_path, *args, **call_kwargs)
+
+        mock_async.side_effect = fake_async
+
+        self.client.force_login(self.staff_user)
+        response = self.client.post(
+            reverse("assets:dashboard"),
+            {
+                "action": "generate-asset",
+                "generate-model": str(self.model.pk),
+                "generate-prompt_text": "Queue options",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            HTTP_ACCEPT="application/json",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(captured_ids, [payload["job_id"]])
+        self.assertEqual(mock_run.call_count, 1)
 
     @patch("appertivo.assets.views.async_task")
     def test_generate_preview_appends_additional_text(self, mock_async: Mock) -> None:

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -1,7 +1,36 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import Any, Dict
+
+
+# Queue-specific kwargs supported by Django-Q that should not reach the task.
+QUEUE_OPTION_KEYS = {
+    "ack_failure",
+    "ack_late",
+    "broker",
+    "bulk",
+    "cached",
+    "channel",
+    "count",
+    "delay",
+    "group",
+    "group_meta",
+    "hook",
+    "iter_then",
+    "iterable",
+    "meta",
+    "priority",
+    "queue",
+    "result",
+    "retries",
+    "retry",
+    "save",
+    "status",
+    "sync",
+    "timeout",
+    "user",
+}
 
 
 def async_task(func_path: str, *args: Any, **kwargs: Any) -> Any:
@@ -11,7 +40,13 @@ def async_task(func_path: str, *args: Any, **kwargs: Any) -> Any:
     satisfying the dependency on the Django-Q2 interface.
     """
 
+    call_kwargs: Dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if key in QUEUE_OPTION_KEYS or key == "q_options":
+            continue
+        call_kwargs[key] = value
+
     module_path, func_name = func_path.rsplit(".", 1)
     module = import_module(module_path)
     func = getattr(module, func_name)
-    return func(*args, **kwargs)
+    return func(*args, **call_kwargs)


### PR DESCRIPTION
## Summary
- update the Django-Q async task stub to drop queue-only keyword arguments before calling the target function
- add a regression test for the asset generation endpoint to ensure queue kwargs do not reach the job callable

## Testing
- python manage.py test appertivo.assets.tests.test_dashboard.AssetDashboardTests.test_generate_preview_filters_queue_kwargs


------
https://chatgpt.com/codex/tasks/task_e_68dedc46a9008332a473e7bb753590c4