### PR TITLE
Enhance asset studio prompts and layout

### DIFF
--- a/appertivo/assets/templates/assets/gallery.html
+++ b/appertivo/assets/templates/assets/gallery.html
@@ -28,13 +28,16 @@
     </div>
   {% endif %}
 
-  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <details class="rounded-2xl border border-slate-200 bg-white/80" data-folder-panel>
+    <summary class="flex cursor-pointer select-none items-center justify-between gap-4 px-6 py-4">
       <div>
         <h2 class="text-lg font-semibold text-slate-900">Folders</h2>
         <p class="mt-1 text-sm text-slate-600">Keep everything organized and locked when needed.</p>
       </div>
-      <form method="post" class="flex flex-wrap items-end gap-2 text-sm text-slate-600">
+      <span class="text-xs font-semibold uppercase tracking-wide text-purple-600">Manage</span>
+    </summary>
+    <div class="space-y-5 border-t border-slate-200 px-6 py-5 text-sm text-slate-600">
+      <form method="post" class="flex flex-wrap items-end gap-3">
         {% csrf_token %}
         <input type="hidden" name="action" value="create-folder" />
         <label class="flex flex-col" for="{{ folder_form.name.id_for_label }}">
@@ -54,62 +57,48 @@
           <span class="w-full text-xs text-rose-600">{{ folder_form.non_field_errors|join:', ' }}</span>
         {% endif %}
       </form>
+
+      {% if folders %}
+        <div class="grid gap-4">
+          {% for entry in folder_entries %}
+            <article class="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <h3 class="text-base font-semibold text-slate-900">{{ entry.folder.name }}</h3>
+                {% if entry.folder.is_locked %}
+                  <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-slate-600">🔒 {% if entry.is_unlocked %}Unlocked this session{% else %}Locked{% endif %}</span>
+                {% endif %}
+              </div>
+              <form method="post" class="mt-3 flex flex-wrap items-end gap-3 text-xs uppercase tracking-wide text-slate-500">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="update-folder-security" />
+                <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
+                <label class="flex flex-col gap-1" for="{{ entry.form.pin.id_for_label }}">
+                  <span class="font-semibold">PIN</span>
+                  {{ entry.form.pin }}
+                </label>
+                <label class="flex items-center gap-2 font-semibold" for="{{ entry.form.is_locked.id_for_label }}">
+                  {{ entry.form.is_locked }}
+                  <span>Locked</span>
+                </label>
+                <button type="submit" class="inline-flex items-center rounded bg-slate-900 px-3 py-2 font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save</button>
+                {% if entry.form.errors %}
+                  <span class="w-full text-rose-600 normal-case">{{ entry.form.errors|join:', ' }}</span>
+                {% endif %}
+              </form>
+              <form method="post" class="mt-3 flex justify-end" onsubmit="return confirm('Delete this folder? Assets will remain available.');">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="delete-folder" />
+                <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
+                <button type="submit" class="text-xs font-semibold uppercase tracking-wide text-rose-600 hover:text-rose-700">Delete folder</button>
+              </form>
+            </article>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="text-sm text-slate-500">No folders created yet. Add one using the quick form above.</p>
+      {% endif %}
     </div>
-    {% if folders %}
-      <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
-          <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
-            <tr>
-              <th class="px-3 py-2 text-left">Folder</th>
-              <th class="px-3 py-2 text-left">Security</th>
-              <th class="px-3 py-2 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-slate-200 bg-white/60">
-            {% for entry in folder_entries %}
-              <tr>
-                <td class="px-3 py-2 font-medium text-slate-800">{{ entry.folder.name }}</td>
-                <td class="px-3 py-2">
-                  <form method="post" class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                    {% csrf_token %}
-                    <input type="hidden" name="action" value="update-folder-security" />
-                    <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
-                    <label class="flex flex-col" for="{{ entry.form.pin.id_for_label }}">
-                      <span class="font-semibold uppercase">PIN</span>
-                      {{ entry.form.pin }}
-                    </label>
-                    <label class="flex items-center gap-2 font-semibold uppercase" for="{{ entry.form.is_locked.id_for_label }}">
-                      {{ entry.form.is_locked }}
-                      <span>Locked</span>
-                    </label>
-                    <button type="submit" class="inline-flex items-center rounded bg-slate-900 px-3 py-1 font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Save</button>
-                    {% if entry.form.errors %}
-                      <span class="w-full text-rose-600">{{ entry.form.errors|join:', ' }}</span>
-                    {% endif %}
-                  </form>
-                </td>
-                <td class="px-3 py-2 text-right">
-                  <div class="flex items-center justify-end gap-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    {% if entry.folder.is_locked %}
-                      <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-slate-600">🔒 {% if entry.is_unlocked %}Unlocked this session{% else %}Locked{% endif %}</span>
-                    {% endif %}
-                    <form method="post" class="inline" onsubmit="return confirm('Delete this folder? Assets will remain available.');">
-                      {% csrf_token %}
-                      <input type="hidden" name="action" value="delete-folder" />
-                      <input type="hidden" name="folder_id" value="{{ entry.folder.id }}" />
-                      <button type="submit" class="text-rose-600 hover:text-rose-700">Delete</button>
-                    </form>
-                  </div>
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    {% else %}
-      <p class="text-sm text-slate-500">No folders created yet. Add one using the quick form above.</p>
-    {% endif %}
-  </section>
+  </details>
   <section class="rounded-2xl border border-slate-200 bg-white/80 p-4">
     <div class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
       <span class="font-semibold text-slate-900">Filter:</span>
@@ -125,24 +114,27 @@
     <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {% for asset in assets %}
         {% with folder=asset.folder %}
-        <article class="flex flex-col rounded-2xl border border-slate-200 bg-white/80 shadow-sm" data-asset-card data-folder-id="{{ folder.id|default:'' }}" data-locked="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}true{% else %}false{% endif %}" data-original-prompt="{{ asset.prompt|escape }}">
+        <article class="overflow-hidden rounded-2xl border border-slate-200 bg-white/80 shadow-sm transition hover:shadow-md" data-asset-card data-folder-id="{{ folder.id|default:'' }}" data-locked="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}true{% else %}false{% endif %}">
           {% if asset.image %}
-            <div class="relative" data-locked-trigger tabindex="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}0{% else %}-1{% endif %}" role="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}button{% else %}presentation{% endif %}">
-              <img src="{{ asset.image.url }}" alt="{{ asset.model|default:'Asset' }}" class="h-56 w-full rounded-t-2xl object-cover{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %} blur-2xl{% endif %}" />
+            <button type="button" class="relative block w-full focus:outline-none" data-locked-trigger tabindex="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}0{% else %}-1{% endif %}" aria-label="{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}Unlock folder{% else %}Asset preview{% endif %}">
+              <img src="{{ asset.image.url }}" alt="{{ asset.model|default:'Asset' }}" class="h-56 w-full object-cover{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %} blur-2xl{% endif %}" />
               {% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}
-                <div class="absolute inset-0 flex items-center justify-center rounded-t-2xl bg-slate-900/50 text-sm font-semibold uppercase tracking-wide text-white">Locked • tap to unlock</div>
+                <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-900/55 text-sm font-semibold uppercase tracking-wide text-white">Locked • tap to unlock</div>
               {% endif %}
-            </div>
+            </button>
           {% else %}
-            <div class="flex h-56 w-full items-center justify-center rounded-t-2xl bg-slate-100 text-sm text-slate-500">No file saved</div>
+            <div class="flex h-56 w-full items-center justify-center bg-slate-100 text-sm text-slate-500">No file saved</div>
           {% endif %}
-          <div class="flex flex-1 flex-col gap-3 p-4 text-sm text-slate-600">
-            <div>
-              <p class="font-semibold text-slate-900">{{ asset.model|default:"Unknown model" }}</p>
-              <p class="text-xs uppercase tracking-wide text-slate-500">{{ asset.created_at|date:"M j, Y g:i a" }}</p>
-            </div>
-            <p class="flex-1 whitespace-pre-wrap" data-prompt-text>{% if folder and folder.is_locked and folder.id not in unlocked_folder_ids %}<span class="italic text-slate-500">Hidden for locked folder</span>{% else %}{{ asset.prompt }}{% endif %}</p>
-            <div class="space-y-3">
+          <div class="border-t border-slate-100 bg-white/70 p-4">
+            <button type="button" class="flex w-full items-center justify-between gap-2 text-sm font-semibold text-slate-600 transition hover:text-purple-600 focus:outline-none" data-toggle-details>
+              <span data-toggle-label>Show details</span>
+              <span aria-hidden="true" data-toggle-icon>▾</span>
+            </button>
+            <div class="mt-3 hidden flex-col gap-3 text-sm text-slate-600" data-detail-panel>
+              <div>
+                <p class="font-semibold text-slate-900">{{ asset.model|default:"Unknown model" }}</p>
+                <p class="text-xs uppercase tracking-wide text-slate-500">{{ asset.created_at|date:"M j, Y g:i a" }}</p>
+              </div>
               <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
                 <div class="flex flex-wrap items-center gap-2">
                   {% if asset.filename %}
@@ -201,26 +193,15 @@
       return tokenInput ? tokenInput.value : '';
     }
 
-    function decodePrompt(value) {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(`<span>${value}</span>`, 'text/html');
-      return doc.body.textContent || '';
-    }
-
     function markUnlocked(card) {
       card.dataset.locked = 'false';
       const image = card.querySelector('img');
-      const overlay = card.querySelector('.absolute');
+      const overlay = card.querySelector('.pointer-events-none');
       if (image) {
         image.classList.remove('blur-2xl');
       }
       if (overlay) {
         overlay.remove();
-      }
-      const promptElement = card.querySelector('[data-prompt-text]');
-      if (promptElement) {
-        const stored = decodePrompt(card.getAttribute('data-original-prompt') || '');
-        promptElement.textContent = stored;
       }
     }
 
@@ -279,6 +260,29 @@
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
           handler();
+        }
+      });
+    });
+
+    document.querySelectorAll('[data-toggle-details]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const card = button.closest('[data-asset-card]');
+        if (!card) {
+          return;
+        }
+        const panel = card.querySelector('[data-detail-panel]');
+        if (!panel) {
+          return;
+        }
+        const isOpen = !panel.classList.contains('hidden');
+        panel.classList.toggle('hidden', isOpen);
+        const label = button.querySelector('[data-toggle-label]');
+        if (label) {
+          label.textContent = isOpen ? 'Show details' : 'Hide details';
+        }
+        const icon = button.querySelector('[data-toggle-icon]');
+        if (icon) {
+          icon.textContent = isOpen ? '▾' : '▴';
         }
       });
     });

--- a/appertivo/assets/templates/assets/manage_models.html
+++ b/appertivo/assets/templates/assets/manage_models.html
@@ -49,16 +49,16 @@
     </form>
   </section>
 
-  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
-    <div class="flex items-center justify-between">
+  <div class="space-y-4">
+    <div class="flex flex-wrap items-center justify-between gap-2">
       <h2 class="text-lg font-semibold text-slate-900">Saved models</h2>
       <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ model_entries|length }} total</span>
     </div>
     {% if model_entries %}
-      <div class="space-y-4">
+      <div class="grid gap-4 md:grid-cols-2">
         {% for model, form in model_entries %}
-          <div class="rounded-xl border border-slate-200 bg-white/70 p-4">
-            <form method="post" class="grid gap-3 text-sm text-slate-600 md:grid-cols-[1fr_1fr_auto] md:items-end">
+          <article class="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm">
+            <form method="post" class="grid gap-3 text-sm text-slate-600">
               {% csrf_token %}
               <input type="hidden" name="action" value="update-model" />
               <input type="hidden" name="model_id" value="{{ model.id }}" />
@@ -76,7 +76,10 @@
                   <span class="text-xs text-rose-600">{{ form.identifier.errors|join:', ' }}</span>
                 {% endif %}
               </label>
-              <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
+              <div class="flex items-center justify-between text-xs uppercase tracking-wide">
+                <span class="text-slate-400">Created {{ model.created_at|date:"M j, Y" }}</span>
+                <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
+              </div>
             </form>
             <form method="post" class="mt-3 flex justify-end" onsubmit="return confirm('Delete this model?');">
               {% csrf_token %}
@@ -84,12 +87,12 @@
               <input type="hidden" name="model_id" value="{{ model.id }}" />
               <button type="submit" class="text-xs font-semibold uppercase tracking-wide text-rose-600 hover:text-rose-700">Delete</button>
             </form>
-          </div>
+          </article>
         {% endfor %}
       </div>
     {% else %}
       <p class="text-sm text-slate-600">No models added yet. Use the form above to register one.</p>
     {% endif %}
-  </section>
+  </div>
 </div>
 {% endblock %}

--- a/appertivo/assets/templates/assets/manage_prompts.html
+++ b/appertivo/assets/templates/assets/manage_prompts.html
@@ -2,7 +2,7 @@
 {% block title %}Manage Prompts · Appertivo{% endblock %}
 
 {% block content %}
-<div class="max-w-4xl mx-auto px-6 py-12 space-y-8">
+<div class="max-w-4xl mx-auto px-6 py-12 space-y-8" data-enhance-url="{% url 'assets:enhance-prompt' %}">
   <nav class="flex flex-wrap items-center gap-2 text-sm text-slate-600">
     <a href="{% url 'assets:dashboard' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Studio</a>
     <a href="{% url 'assets:manage-models' %}" class="rounded-full px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100">Models</a>
@@ -43,22 +43,23 @@
           <span class="text-xs text-rose-600">{{ create_form.text.errors|join:', ' }}</span>
         {% endif %}
       </label>
-      <div class="flex justify-end">
+      <div class="flex flex-wrap items-center justify-end gap-2 pt-1">
+        <button type="button" class="inline-flex items-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-purple-400 hover:text-purple-700" data-enhance-button data-target="#{{ create_form.text.id_for_label }}">Enhance with GPT-4.1 nano</button>
         <button type="submit" class="inline-flex items-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400">Add prompt</button>
       </div>
     </form>
   </section>
 
-  <section class="rounded-2xl border border-slate-200 bg-white/80 p-6 space-y-4">
-    <div class="flex items-center justify-between">
+  <div class="space-y-4">
+    <div class="flex flex-wrap items-center justify-between gap-2">
       <h2 class="text-lg font-semibold text-slate-900">Saved prompts</h2>
       <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ prompt_entries|length }} total</span>
     </div>
     {% if prompt_entries %}
-      <div class="space-y-4">
+      <div class="grid gap-4 md:grid-cols-2">
         {% for prompt, form in prompt_entries %}
-          <div class="rounded-xl border border-slate-200 bg-white/70 p-4">
-            <form method="post" class="grid gap-3 text-sm text-slate-600 md:grid-cols-2">
+          <article class="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm">
+            <form method="post" class="flex flex-col gap-3 text-sm text-slate-600">
               {% csrf_token %}
               <input type="hidden" name="action" value="update-prompt" />
               <input type="hidden" name="prompt_id" value="{{ prompt.id }}" />
@@ -69,17 +70,18 @@
                   <span class="text-xs text-rose-600">{{ form.title.errors|join:', ' }}</span>
                 {% endif %}
               </label>
-              <label class="flex flex-col gap-1 md:col-span-2">
+              <label class="flex flex-col gap-1">
                 <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Prompt text</span>
                 {{ form.text }}
                 {% if form.text.errors %}
                   <span class="text-xs text-rose-600">{{ form.text.errors|join:', ' }}</span>
                 {% endif %}
               </label>
-              <div class="md:col-span-2 flex justify-between text-xs uppercase tracking-wide">
+              <div class="flex flex-wrap items-center justify-between gap-2 text-xs uppercase tracking-wide">
                 <span class="text-slate-400">Created {{ prompt.created_at|date:"M j, Y" }}</span>
-                <div class="flex items-center gap-3">
-                  <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
+                <div class="flex flex-wrap items-center gap-2">
+                  <button type="button" class="inline-flex items-center rounded-lg border border-slate-200 bg-white px-3 py-2 font-semibold text-slate-600 shadow-sm transition hover:border-purple-400 hover:text-purple-700" data-enhance-button data-target="#{{ form.text.id_for_label }}">Enhance</button>
+                  <button type="submit" class="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 font-semibold text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500">Update</button>
                 </div>
               </div>
             </form>
@@ -89,12 +91,90 @@
               <input type="hidden" name="prompt_id" value="{{ prompt.id }}" />
               <button type="submit" class="text-xs font-semibold uppercase tracking-wide text-rose-600 hover:text-rose-700">Delete</button>
             </form>
-          </div>
+          </article>
         {% endfor %}
       </div>
     {% else %}
       <p class="text-sm text-slate-600">No prompts saved yet. Add one using the form above.</p>
     {% endif %}
-  </section>
+  </div>
 </div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const root = document.querySelector('[data-enhance-url]');
+    if (!root) {
+      return;
+    }
+
+    const enhanceUrl = root.getAttribute('data-enhance-url');
+
+    function getCsrfToken() {
+      const token = document.querySelector('input[name="csrfmiddlewaretoken"]');
+      return token ? token.value : '';
+    }
+
+    function setLoading(button, isLoading) {
+      if (!button) {
+        return;
+      }
+      button.disabled = isLoading;
+      button.dataset.loading = isLoading ? 'true' : 'false';
+      if (isLoading) {
+        button.dataset.originalText = button.dataset.originalText || button.textContent;
+        button.textContent = 'Enhancing…';
+      } else if (button.dataset.originalText) {
+        button.textContent = button.dataset.originalText;
+      }
+    }
+
+    async function enhance(button) {
+      const targetSelector = button.getAttribute('data-target');
+      if (!targetSelector) {
+        return;
+      }
+      const textarea = root.querySelector(targetSelector);
+      if (!textarea) {
+        return;
+      }
+
+      const value = textarea.value.trim();
+      if (!value) {
+        window.alert('Add some text before enhancing.');
+        return;
+      }
+
+      setLoading(button, true);
+
+      try {
+        const response = await fetch(enhanceUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ text: value }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.error || 'Enhancement failed.');
+        }
+
+        textarea.value = data.enhanced_text || value;
+      } catch (error) {
+        window.alert(error.message || 'Unable to enhance the prompt right now.');
+      } finally {
+        setLoading(button, false);
+      }
+    }
+
+    root.querySelectorAll('[data-enhance-button]').forEach((button) => {
+      button.addEventListener('click', function () {
+        enhance(button);
+      });
+    });
+  });
+</script>
 {% endblock %}

--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.deconstruct import deconstructible
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "specials.settings")
 django.setup()
 
 from appertivo.assets import tasks
@@ -212,6 +214,25 @@ class AssetDashboardTests(TestCase):
         )
         self.assertEqual(delete_response.status_code, 302)
         self.assertFalse(PromptTemplate.objects.filter(pk=prompt.pk).exists())
+
+    @patch("appertivo.assets.views.openai_client")
+    def test_enhance_prompt_endpoint(self, mock_client) -> None:
+        """Prompt enhancement returns richer copy from the LLM."""
+
+        self.client.force_login(self.staff_user)
+        fake_response = SimpleNamespace(output=[{"content": [{"type": "output_text", "text": "Improved prompt"}]}])
+        mock_client.responses.create.return_value = fake_response
+
+        response = self.client.post(
+            reverse("assets:enhance-prompt"),
+            data=json.dumps({"text": "Original prompt"}),
+            content_type="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("enhanced_text"), "Improved prompt")
+        mock_client.responses.create.assert_called_once()
 
     @patch("appertivo.assets.views.async_task")
     def test_generate_preview_flow(self, mock_async: Mock) -> None:

--- a/appertivo/assets/urls.py
+++ b/appertivo/assets/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("assets/", views.dashboard, name="dashboard"),
     path("assets/models/", views.manage_models, name="manage-models"),
     path("assets/prompts/", views.manage_prompts, name="manage-prompts"),
+    path("assets/prompts/enhance/", views.enhance_prompt, name="enhance-prompt"),
     path("assets/preview-jobs/<int:job_id>/", views.preview_status, name="preview-status"),
     path("assets/previews/discard/", views.discard_preview, name="discard-preview"),
     path("assets/folders/<int:folder_id>/verify/", views.verify_folder_pin, name="verify-folder"),

--- a/appertivo/assets/views.py
+++ b/appertivo/assets/views.py
@@ -22,7 +22,8 @@ from django.utils.text import slugify
 from django.views.decorators.http import require_POST
 from django_q.tasks import async_task
 
-from app.llm import replicate_client
+from app.llm import client as openai_client, replicate_client
+from articles.openai_helpers import extract_output_text
 
 from .forms import (
     AssetDeleteForm,
@@ -341,6 +342,47 @@ def manage_prompts(request: HttpRequest) -> HttpResponse:
         "prompt_entries": [(prompt, edit_forms[prompt.pk]) for prompt in prompts],
     }
     return render(request, "assets/manage_prompts.html", context)
+
+
+@staff_member_required
+@require_POST
+def enhance_prompt(request: HttpRequest) -> JsonResponse:
+    """Send prompt text to OpenAI for a richer version."""
+
+    if openai_client is None:
+        return JsonResponse({"error": "LLM client is not configured."}, status=503)
+
+    try:
+        payload = json.loads(request.body.decode("utf-8")) if request.body else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = {}
+
+    text = (payload.get("text") or "").strip()
+    if not text:
+        return JsonResponse({"error": "Add some prompt text first."}, status=400)
+
+    instructions = (
+        "You are refining an image generation prompt for a food photography model. "
+        "Rewrite the prompt with vivid scene details, plating, lighting, mood, and camera cues. "
+        "Keep it under 80 words and avoid repeating the words 'prompt' or 'rewrite'. "
+        "Return only the improved prompt text.\n\n"
+        f"Original prompt:\n{text}"
+    )
+
+    try:
+        response = openai_client.responses.create(
+            model="gpt-4.1-nano",
+            input=instructions,
+        )
+    except Exception as exc:  # pragma: no cover - network or client error
+        logger.warning("Prompt enhancement failed: %s", exc, exc_info=True)
+        return JsonResponse({"error": "We could not reach the enhancement service."}, status=502)
+
+    enhanced = extract_output_text(response).strip()
+    if not enhanced:
+        return JsonResponse({"error": "The model did not return any text."}, status=502)
+
+    return JsonResponse({"enhanced_text": enhanced})
 
 
 @staff_member_required


### PR DESCRIPTION
## Summary
- add a GPT-4.1 nano-backed endpoint and UI controls to enhance prompt text directly from the asset studio
- refresh the models, prompts, and gallery templates so saved items float as lightweight cards with collapsible details
- collapse folder management into a details panel and simplify gallery cards to show only the image until expanded

## Testing
- python manage.py test appertivo.assets.tests

------
https://chatgpt.com/codex/tasks/task_e_68dee1259a8883328dd68e22f2be2893