### PR TITLE
Add API alias for Outscraper webhook endpoint

### DIFF
--- a/appertivo/leads/tests/test_tasks.py
+++ b/appertivo/leads/tests/test_tasks.py
@@ -167,3 +167,24 @@ class OutscraperWebhookViewTests(TestCase):
         args, kwargs = mock_delay.call_args
         self.assertIn(lead.id, args[0])
         self.assertEqual(kwargs["run_id"], run.id)
+
+    @override_settings(OUTSCRAPER_API_KEY="test-key")
+    @patch.dict(os.environ, {"OUTSCRAPER_API_KEY": "test-key"}, clear=False)
+    def test_webhook_api_alias(self) -> None:
+        payload = {
+            "data": [
+                {
+                    "name": "Alias Bistro",
+                    "email": "alias@example.com",
+                }
+            ]
+        }
+
+        response = self.client.post(
+            reverse("outscraper_webhook_api"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Lead.objects.filter(email="alias@example.com").exists())

--- a/appertivo/leads/urls.py
+++ b/appertivo/leads/urls.py
@@ -8,6 +8,11 @@ from . import views
 urlpatterns = [
     path("leads/", views.lead_dashboard, name="lead-dashboard"),
     path("leads/outscraper-webhook/", views.outscraper_webhook, name="outscraper_webhook"),
+    path(
+        "api/leads/outscraper-webhook/",
+        views.outscraper_webhook,
+        name="outscraper_webhook_api",
+    ),
     path("leads/runs/start/", views.start_lead_run, name="lead-run-start"),
     path("leads/runs/<int:run_id>/delete/", views.delete_run, name="lead-run-delete"),
     path("leads/actions/", views.process_lead_actions, name="lead-actions"),


### PR DESCRIPTION
## Summary
- expose the Outscraper webhook under `/api/leads/outscraper-webhook/` to match incoming callbacks
- add a regression test ensuring the alias endpoint stores leads successfully

## Testing
- python manage.py test appertivo.leads.tests.test_tasks


------
https://chatgpt.com/codex/tasks/task_e_68dee6785a3c8332b063f4a73985e47e