### PR TITLE
Add API activity panel to dashboard overview

### DIFF
--- a/dashboard/templates/dashboard/overview.html
+++ b/dashboard/templates/dashboard/overview.html
@@ -206,6 +206,36 @@
         </div>
       </section>
 
+      <section aria-labelledby="api-activity" class="mb-8">
+        <div class="rounded-2xl bg-white p-5 shadow-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 id="api-activity" class="text-lg font-semibold text-slate-900">API Calls &amp; Responses</h2>
+              <p class="text-sm text-slate-500">Most recent webhook payloads and AI run steps.</p>
+            </div>
+          </div>
+          <div class="mt-4 space-y-3">
+            {% for entry in api_activity %}
+              <details class="group rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+                <summary class="flex cursor-pointer flex-wrap items-center justify-between gap-3 text-sm font-semibold text-slate-900">
+                  <span class="flex flex-wrap items-center gap-2">
+                    <span class="text-xs font-medium text-slate-500">{{ entry.timestamp|date:"M j, g:i a" }}</span>
+                    <span>{{ entry.call }}</span>
+                    <span class="text-slate-500">{{ entry.actor }}</span>
+                  </span>
+                  <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">{{ entry.status_code }}</span>
+                </summary>
+                <div class="mt-3">
+                  <pre class="max-h-64 overflow-auto rounded-lg bg-slate-900 p-3 text-xs text-slate-100">{{ entry.payload }}</pre>
+                </div>
+              </details>
+            {% empty %}
+              <p class="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">No recent API calls recorded.</p>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+
       <section aria-labelledby="engagement" class="mb-8">
         <div class="rounded-2xl bg-white p-5 shadow-sm">
           <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">

--- a/dashboard/tests/test_views.py
+++ b/dashboard/tests/test_views.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime, timedelta, timezone as dt_timezone
 from pathlib import Path
 
+from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -120,6 +121,19 @@ class DashboardViewTests(TestCase):
             cost_cents=0,
         )
 
+        if django_apps.is_installed("articles"):
+            from articles import models as article_models
+
+            article_run = article_models.ArticleRun.objects.create(
+                created_by=self.staff,
+            )
+            article_models.RunStep.objects.create(
+                run=article_run,
+                name="draft",
+                status="ok",
+                raw_response={"result": "ok"},
+            )
+
     def test_dashboard_requires_staff(self) -> None:
         """Non-staff users should receive a forbidden response."""
 
@@ -143,7 +157,11 @@ class DashboardViewTests(TestCase):
         self.assertIn("onboarding", response.context)
         self.assertIn("subscriptions", response.context)
         self.assertIn("operations", response.context)
+        self.assertIn("api_activity", response.context)
         self.assertGreaterEqual(len(response.context["quick_actions"]), 1)
+        self.assertContains(response, "Outscraper")
+        if django_apps.is_installed("articles"):
+            self.assertContains(response, "Article: Draft")
 
 
 class LogFeedViewTests(TestCase):

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -18,6 +18,7 @@ from django.db.models.functions import TruncWeek
 from django.http import HttpResponseForbidden, JsonResponse
 from django.urls import reverse_lazy
 from django.utils import timezone
+from django.utils.safestring import mark_safe
 from django.views import View
 from django.views.generic import TemplateView
 
@@ -64,6 +65,7 @@ class DashboardView(StaffOnlyMixin, TemplateView):
                 "onboarding": self._build_onboarding_context(),
                 "subscriptions": self._build_subscription_context(),
                 "operations": self._build_operations_context(),
+                "api_activity": self._build_api_activity_context(),
                 "engagement": self._build_engagement_context(),
                 "business": self._build_business_metrics(),
                 "extras": self._build_extras_context(),
@@ -72,6 +74,86 @@ class DashboardView(StaffOnlyMixin, TemplateView):
             }
         )
         return context
+
+    def _build_api_activity_context(self) -> list[dict[str, Any]]:
+        """Return a combined feed of recent API calls and responses."""
+
+        entries: list[dict[str, Any]] = []
+
+        payload_status_map = {
+            app_models.OutscraperPayload.Status.SUCCEEDED: 200,
+            app_models.OutscraperPayload.Status.FAILED: 500,
+            app_models.OutscraperPayload.Status.RUNNING: 102,
+            app_models.OutscraperPayload.Status.QUEUED: 102,
+        }
+
+        for payload in (
+            app_models.OutscraperPayload.objects.select_related("restaurant")
+            .order_by("-created_at")[:20]
+        ):
+            payload_data: dict[str, Any] = (
+                payload.response_json
+                or payload.request_params
+                or ({"error": payload.error_message} if payload.error_message else {})
+            )
+            entries.append(
+                {
+                    "timestamp": payload.created_at,
+                    "call": "Outscraper",
+                    "actor": getattr(payload.restaurant, "name", "Unknown"),
+                    "status_code": payload_status_map.get(payload.status, 200),
+                    "payload": mark_safe(
+                        json.dumps(payload_data or {}, indent=2, sort_keys=True)
+                    ),
+                }
+            )
+
+        run_step_model = self._safe_get_model("articles", "RunStep")
+        if run_step_model is not None:
+            step_status_map = {
+                "ok": 200,
+                "failed": 500,
+                "running": 102,
+                "queued": 102,
+            }
+
+            run_steps = (
+                run_step_model.objects.select_related("run", "run__created_by")
+                .order_by("-started_at")[:20]
+            )
+            for step in run_steps:
+                run = getattr(step, "run", None)
+                actor_user = getattr(run, "created_by", None)
+                actor = "System"
+                if actor_user is not None:
+                    actor = (
+                        getattr(actor_user, "get_full_name", lambda: "")()
+                        or getattr(actor_user, "email", "")
+                        or getattr(actor_user, "username", "")
+                        or "System"
+                    )
+
+                payload_data = (
+                    step.raw_response
+                    or step.output_payload
+                    or step.input_payload
+                    or ({"error": step.error_message} if step.error_message else {})
+                )
+
+                entries.append(
+                    {
+                        "timestamp": step.started_at or getattr(run, "created_at", None),
+                        "call": f"Article: {step.name.title()}",
+                        "actor": actor,
+                        "status_code": step_status_map.get(step.status, 200),
+                        "payload": mark_safe(
+                            json.dumps(payload_data or {}, indent=2, sort_keys=True)
+                        ),
+                    }
+                )
+
+        entries.sort(key=lambda item: item["timestamp"], reverse=True)
+        return entries[:20]
 
     def _build_onboarding_context(self) -> dict[str, Any]:
         """Return counts and stalled records for onboarding progress."""


### PR DESCRIPTION
## Summary
- collect recent Outscraper payloads and article run steps into a combined API activity feed
- render an API Calls & Responses section on the dashboard overview template
- extend dashboard view tests to assert the new context key and rendered entries

## Testing
- python manage.py test dashboard.tests.test_views

------
https://chatgpt.com/codex/tasks/task_e_68deeaaad2f88332b8491ca4741b4635