### PR TITLE
Remove hardcoded asset preview timeout

### DIFF
--- a/appertivo/assets/tests/test_dashboard.py
+++ b/appertivo/assets/tests/test_dashboard.py
@@ -259,7 +259,6 @@ class AssetDashboardTests(TestCase):
         mock_async.assert_called_once_with(
             "appertivo.assets.tasks.run_preview_job",
             job.pk,
-            timeout=180,
         )
 
     @patch("appertivo.assets.tasks.run_preview_job")

--- a/appertivo/assets/views.py
+++ b/appertivo/assets/views.py
@@ -179,7 +179,6 @@ def dashboard(request: HttpRequest) -> HttpResponse:
             async_task(
                 "appertivo.assets.tasks.run_preview_job",
                 job.pk,
-                timeout=180,
             )
             logger.info(
                 "Queued asset preview job %s for model %s", job.pk, model.pk


### PR DESCRIPTION
## Summary
- remove the fixed 180-second timeout when queueing asset preview jobs
- update the dashboard test to expect the streamlined async_task call

## Testing
- python manage.py test appertivo.assets.tests.test_dashboard.AssetDashboardTests.test_generate_preview_flow


------
https://chatgpt.com/codex/tasks/task_e_68def2f3ca2083329b2d41a4a28119c9