### PR TITLE
Add marketing Stripe checkout endpoints and setup placeholder

### DIFF
--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1164,9 +1164,12 @@
           <h3 class="text-xl font-semibold text-[#FF5C00]">Pro</h3>
           <p class="mt-4 text-slate-600">Unlock enhancements, menu building, and AI-powered features.</p>
           <p class="mt-6 text-3xl font-bold text-[#FF5C00]">$59/mo</p>
-          <a href="{% url 'signup' %}" class="mt-6 inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-5 py-3 text-sm font-semibold text-white transition hover:scale-105">
-            Upgrade Now
-          </a>
+          <form method="post" action="{% url 'billing-create-checkout-session' %}" class="mt-6">
+            {% csrf_token %}
+            <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF8300] to-[#FF5C00] px-5 py-3 text-sm font-semibold text-white transition hover:scale-105">
+              Upgrade Now
+            </button>
+          </form>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-8 text-center shadow-sm">
           <h3 class="text-xl font-semibold text-[#2E005D]">Enterprise</h3>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -1,0 +1,20 @@
+{% extends "layouts/marketing.html" %}
+
+{% block title %}Complete your workspace setup{% endblock %}
+
+{% block content %}
+  <section class="py-24">
+    <div class="max-w-2xl mx-auto px-6 text-center space-y-6">
+      <h1 class="text-3xl md:text-4xl font-bold text-[#2E005D]">You're all set!</h1>
+      <p class="text-lg text-slate-600">
+        We received your subscription. Keep this tab open while we finish preparing your workspace.
+      </p>
+      {% if session_id %}
+        <p class="text-sm text-slate-500">
+          Checkout reference: <span class="font-mono text-slate-700">{{ session_id }}</span>
+        </p>
+      {% endif %}
+      <p class="text-sm text-slate-500">You can close this page or bookmark it to return later.</p>
+    </div>
+  </section>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -478,6 +478,13 @@ def contact_view(request):
     return render(request, "contact.html", context)
 
 
+def setup_view(request):
+    """Render the setup placeholder page shown after checkout."""
+
+    context = {"session_id": request.GET.get("session_id", "")}
+    return render(request, "setup.html", context)
+
+
 def signup_view(request):
     """Register a new user and restaurant."""
     if request.method == "POST":

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 from django.contrib.auth import views as auth_views
 
 from app import outscraper, views as app_views
+from views import billing as billing_views
 from articles import admin_views as articles_admin_views
 from articles.sitemaps import ArticlesSitemap
 from app.outscraper import outscraper_webhook
@@ -20,6 +21,7 @@ urlpatterns = [
     path("privacy/", app_views.privacy_view, name="privacy"),
     path("terms/", app_views.terms_view, name="terms"),
     path("contact/", app_views.contact_view, name="contact"),
+    path("setup/", app_views.setup_view, name="setup"),
     path("dashboard/<uuid:restaurant_id>/", app_views.dashboard, name="dashboard"),
     path("dashboard/", app_views.dashboard_redirect, name="dashboard-redirect"),
 
@@ -75,6 +77,16 @@ urlpatterns = [
     path("billing/", app_views.billing_view, name="billing"),
     path("billing/upgrade/", app_views.billing_upgrade_view, name="billing-upgrade"),
     path("billing/cancel/", app_views.billing_cancel_view, name="billing-cancel"),
+    path(
+        "billing/create-checkout-session/",
+        billing_views.create_checkout_session,
+        name="billing-create-checkout-session",
+    ),
+    path(
+        "billing/portal/",
+        billing_views.create_billing_portal_session,
+        name="billing-portal",
+    ),
     path("checkout/create/", app_views.create_checkout_session_view, name="create-checkout"),
     path("checkout/success/", app_views.checkout_success_view, name="checkout-success"),
     path("checkout/cancel/", app_views.checkout_cancel_view, name="checkout-cancel"),

--- a/tests/test_public_billing.py
+++ b/tests/test_public_billing.py
@@ -1,0 +1,79 @@
+"""Tests for public Stripe billing entry points."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import django
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+django.setup()
+
+
+class BillingViewsTests(TestCase):
+    """Verify marketing billing endpoints integrate with Stripe correctly."""
+
+    @override_settings(
+        STRIPE_PRICE_ID="price_123",
+        STRIPE_SECRET_KEY="sk_test_123",
+        MARKETING_DOMAIN="https://example.com",
+    )
+    def test_create_checkout_session_redirects_to_stripe(self):
+        """POSTing to the checkout endpoint should create a session and redirect."""
+
+        with patch("views.billing.stripe.checkout.Session.create") as mock_create:
+            mock_create.return_value = SimpleNamespace(
+                url="https://checkout.stripe.com/test"
+            )
+            response = self.client.post(reverse("billing-create-checkout-session"))
+
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response["Location"], "https://checkout.stripe.com/test")
+
+        kwargs = mock_create.call_args.kwargs
+        self.assertEqual(kwargs["mode"], "subscription")
+        self.assertEqual(kwargs["line_items"], [{"price": "price_123", "quantity": 1}])
+        self.assertEqual(kwargs["consent_collection"], {"terms_of_service": "required"})
+        self.assertEqual(kwargs["customer_creation"], "always")
+        self.assertEqual(kwargs["payment_method_collection"], "always")
+        self.assertEqual(
+            kwargs["success_url"],
+            "https://example.com/setup?session_id={CHECKOUT_SESSION_ID}",
+        )
+        self.assertEqual(kwargs["cancel_url"], "https://example.com/pricing")
+
+    @override_settings(
+        STRIPE_SECRET_KEY="sk_test_123",
+        MARKETING_DOMAIN="https://example.com",
+    )
+    def test_create_billing_portal_session_redirects(self):
+        """The billing portal endpoint returns the Stripe portal URL."""
+
+        with patch("views.billing.stripe.billing_portal.Session.create") as mock_create:
+            mock_create.return_value = SimpleNamespace(
+                url="https://billing.stripe.com/abc"
+            )
+            response = self.client.post(
+                reverse("billing-portal"),
+                {"customer_id": "cus_123"},
+            )
+
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response["Location"], "https://billing.stripe.com/abc")
+
+        kwargs = mock_create.call_args.kwargs
+        self.assertEqual(kwargs["customer"], "cus_123")
+        self.assertEqual(kwargs["return_url"], "https://example.com/setup")
+
+
+class SetupPageTests(TestCase):
+    """Ensure the setup placeholder renders successfully."""
+
+    def test_setup_page_renders_with_session_id(self):
+        """The setup page should render even with only a session id."""
+
+        response = self.client.get(reverse("setup"), {"session_id": "cs_test_123"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"cs_test_123", response.content)

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for Django view modules."""

--- a/views/billing.py
+++ b/views/billing.py
@@ -1,0 +1,121 @@
+"""Public Stripe billing views for marketing flows."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+from django.conf import settings
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseServerError,
+)
+from django.views.decorators.http import require_POST
+import stripe
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_api_key() -> str:
+    """Ensure Stripe's API key is set and return it."""
+
+    api_key = os.getenv("STRIPE_API_KEY") or getattr(settings, "STRIPE_SECRET_KEY", "")
+    if api_key and stripe.api_key != api_key:
+        stripe.api_key = api_key
+    return api_key
+
+
+def _marketing_domain(request: HttpRequest) -> str:
+    """Return the base marketing domain for redirects."""
+
+    domain = (
+        os.getenv("DOMAIN")
+        or getattr(settings, "MARKETING_DOMAIN", "")
+        or getattr(settings, "SITE_URL", "")
+    )
+    if domain:
+        return domain.rstrip("/")
+    return request.build_absolute_uri("/").rstrip("/")
+
+
+def _see_other(location: str) -> HttpResponse:
+    """Return a HTTP 303 response to the provided location."""
+
+    response = HttpResponse(status=303)
+    response["Location"] = location
+    return response
+
+
+@require_POST
+def create_checkout_session(request: HttpRequest) -> HttpResponse:
+    """Start a Stripe Checkout session for the self-serve subscription."""
+
+    api_key = _ensure_api_key()
+    price_id = getattr(settings, "STRIPE_PRICE_ID", "")
+
+    if not api_key or not price_id:
+        logger.warning("Stripe configuration missing for checkout.")
+        return HttpResponseServerError("payments_unavailable")
+
+    domain = _marketing_domain(request)
+    session_kwargs: dict[str, Any] = {
+        "mode": "subscription",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "consent_collection": {"terms_of_service": "required"},
+        "customer_creation": "always",
+        "allow_promotion_codes": True,
+        "payment_method_collection": "always",
+        "success_url": f"{domain}/setup?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{domain}/pricing",
+    }
+
+    try:
+        session = stripe.checkout.Session.create(**session_kwargs)
+    except stripe.error.StripeError:
+        logger.exception("Unable to create Stripe Checkout session", exc_info=True)
+        return HttpResponseServerError("checkout_unavailable")
+
+    session_url = getattr(session, "url", "")
+    if not session_url:
+        logger.error("Stripe Checkout session created without a URL")
+        return HttpResponseServerError("checkout_unavailable")
+
+    return _see_other(session_url)
+
+
+@require_POST
+def create_billing_portal_session(request: HttpRequest) -> HttpResponse:
+    """Create a Stripe Billing Portal session and redirect the customer."""
+
+    api_key = _ensure_api_key()
+    customer_id = request.POST.get("customer_id", "")
+
+    if not api_key:
+        logger.warning("Stripe configuration missing for billing portal.")
+        return HttpResponseServerError("payments_unavailable")
+
+    if not customer_id:
+        return HttpResponseBadRequest("missing_customer_id")
+
+    domain = _marketing_domain(request)
+    try:
+        portal_session = stripe.billing_portal.Session.create(
+            customer=customer_id,
+            return_url=f"{domain}/setup",
+        )
+    except stripe.error.StripeError:
+        logger.exception("Unable to create Stripe billing portal session", exc_info=True)
+        return HttpResponseServerError("billing_portal_unavailable")
+
+    portal_url = getattr(portal_session, "url", "")
+    if not portal_url:
+        logger.error("Stripe billing portal session created without a URL")
+        return HttpResponseServerError("billing_portal_unavailable")
+
+    return _see_other(portal_url)


### PR DESCRIPTION
## Summary
- add public Stripe checkout and billing portal views used by marketing flows
- wire the new endpoints into the public URLs and pricing CTA with a setup landing page
- cover the new checkout flow with automated tests

## Testing
- pytest tests/test_public_billing.py

------
https://chatgpt.com/codex/tasks/task_e_68dfda27c53c83329a33e41f90d5ec9d