### PR TITLE
Fix provisioning and webhook index names

### DIFF
--- a/app/migrations/0020_rename_app_provisioningjob_onboarding_created_idx_app_provisi_onboard_8e1ab0_idx_and_more.py
+++ b/app/migrations/0020_rename_app_provisioningjob_onboarding_created_idx_app_provisi_onboard_8e1ab0_idx_and_more.py
@@ -11,16 +11,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameIndex(
-            model_name='provisioningjob',
-            new_name='app_provisi_onboard_8e1ab0_idx',
-            old_name='app_provisioningjob_onboarding_created_idx',
-        ),
-        migrations.RenameIndex(
-            model_name='stripewebhookevent',
-            new_name='app_stripew_created_a077d9_idx',
-            old_name='app_stripewebhookevent_created_idx',
-        ),
         migrations.AlterField(
             model_name='provisioningjob',
             name='id',

--- a/app/models.py
+++ b/app/models.py
@@ -9,6 +9,9 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
+# Allow index names that match historical migrations.
+models.Index.max_name_length = 63
+
 
 class TimestampedModel(models.Model):
     """Abstract base model with UUID id and created_at."""
@@ -216,7 +219,12 @@ class ProvisioningJob(TimestampedModel):
     last_stripe_event_id = models.CharField(max_length=255, blank=True)
 
     class Meta:
-        indexes = [models.Index(fields=["onboarding", "-created_at"])]
+        indexes = [
+            models.Index(
+                fields=["onboarding", "-created_at"],
+                name="app_provisioningjob_onboarding_created_idx",
+            )
+        ]
 
 
 class OnboardingEvent(models.Model):
@@ -387,7 +395,12 @@ class StripeWebhookEvent(TimestampedModel):
     payload = models.JSONField(default=dict)
 
     class Meta:
-        indexes = [models.Index(fields=["-created_at"])]
+        indexes = [
+            models.Index(
+                fields=["-created_at"],
+                name="app_stripewebhookevent_created_idx",
+            )
+        ]
 
 
 class Concept(TimestampedModel):


### PR DESCRIPTION
## Summary
- pin ProvisioningJob and StripeWebhookEvent indexes to the historical names baked into migration 0019
- remove the unnecessary RenameIndex operations from migration 0020 and allow long index identifiers in the model definitions

## Testing
- python manage.py makemigrations
- python manage.py migrate

------
https://chatgpt.com/codex/tasks/task_e_68dff5766ccc8332aa65cb95a012a9fe