### PR TITLE
Add manual onboarding trigger controls to internal dashboard

### DIFF
--- a/dashboard/templates/dashboard/overview.html
+++ b/dashboard/templates/dashboard/overview.html
@@ -19,6 +19,16 @@
         </p>
       </header>
 
+      {% if messages %}
+        <div class="mb-6 space-y-2">
+          {% for message in messages %}
+            <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700">
+              {{ message }}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
       <section aria-labelledby="quick-actions" class="mb-8">
         <div class="rounded-2xl bg-white p-5 shadow-sm">
           <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -66,6 +76,44 @@
               </div>
             </dl>
           </div>
+          <div class="mt-5 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Trigger onboarding provisioning</h3>
+              <form method="post" action="{% url 'dashboard:run_onboarding' %}" class="mt-3 space-y-3">
+                {% csrf_token %}
+                {% if onboarding.run_targets %}
+                  <label for="onboarding-run-select" class="block text-xs font-semibold uppercase text-slate-500">Select restaurant</label>
+                  <select id="onboarding-run-select" name="onboarding_id" class="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-200">
+                    {% for target in onboarding.run_targets %}
+                      <option value="{{ target.id }}">{{ target.restaurant }} • {{ target.email }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-purple-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-700">
+                    Run onboarding
+                  </button>
+                {% else %}
+                  <p class="text-sm text-slate-500">No restaurants are ready for manual provisioning.</p>
+                {% endif %}
+                <p class="text-xs text-slate-500">Queues the full onboarding flow exactly as a paid checkout completion would.</p>
+              </form>
+            </div>
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Eligible restaurants</h3>
+              <ul class="mt-3 space-y-2">
+                {% for target in onboarding.run_targets %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                    <p class="font-semibold text-slate-900">{{ target.restaurant }}</p>
+                    <p class="text-xs text-slate-500">{{ target.email }} • {{ target.state }} • {{ target.updated_at|timesince }} ago</p>
+                    {% if target.job_status %}
+                      <p class="text-xs text-slate-500">Last job: {{ target.job_status }}{% if target.job_step_label %} • {{ target.job_step_label }}{% endif %}</p>
+                    {% endif %}
+                  </li>
+                {% empty %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500">No recent onboarding signups linked to restaurants.</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
           <div class="mt-5 overflow-hidden rounded-xl border border-slate-200">
             <table class="min-w-full divide-y divide-slate-200 text-left text-sm">
               <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
@@ -91,6 +139,39 @@
                 {% endfor %}
               </tbody>
             </table>
+          </div>
+          <div class="mt-5 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Recent provisioning jobs</h3>
+              <ul class="mt-3 space-y-2">
+                {% for job in onboarding.recent_jobs %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                    <p class="font-semibold text-slate-900">{{ job.restaurant|default:"—" }}</p>
+                    <p class="text-xs text-slate-500">{{ job.status|title }}{% if job.step_label %} • {{ job.step_label }}{% endif %}</p>
+                    <p class="text-xs text-slate-500">{{ job.created_at|timesince }} ago{% if job.finished_at %} • wrapped {{ job.finished_at|timesince }} ago{% endif %}</p>
+                  </li>
+                {% empty %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500">No provisioning jobs have run yet.</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Latest onboarding events</h3>
+              <ul class="mt-3 space-y-2">
+                {% for event in onboarding.recent_events %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                    <p class="font-semibold text-slate-900">{{ event.restaurant|default:"—" }}</p>
+                    <p class="text-xs text-slate-500">{{ event.from_label }} → {{ event.to_label }}</p>
+                    {% if event.message %}
+                      <p class="text-xs text-slate-500">{{ event.message }}</p>
+                    {% endif %}
+                    <p class="text-xs text-slate-500">{{ event.created_at|timesince }} ago</p>
+                  </li>
+                {% empty %}
+                  <li class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500">No onboarding events captured yet.</li>
+                {% endfor %}
+              </ul>
+            </div>
           </div>
         </div>
       </section>
@@ -207,13 +288,14 @@
       </section>
 
       <section aria-labelledby="api-activity" class="mb-8">
-        <div class="rounded-2xl bg-white p-5 shadow-sm">
-          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <details class="rounded-2xl bg-white p-5 shadow-sm">
+          <summary class="flex cursor-pointer flex-col gap-2 text-left md:flex-row md:items-center md:justify-between">
             <div>
               <h2 id="api-activity" class="text-lg font-semibold text-slate-900">API Calls &amp; Responses</h2>
               <p class="text-sm text-slate-500">Most recent webhook payloads and AI run steps.</p>
             </div>
-          </div>
+            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Expand log</span>
+          </summary>
           <div class="mt-4 space-y-3">
             {% for entry in api_activity %}
               <details class="group rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
@@ -233,7 +315,7 @@
               <p class="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">No recent API calls recorded.</p>
             {% endfor %}
           </div>
-        </div>
+        </details>
       </section>
 
       <section aria-labelledby="engagement" class="mb-8">

--- a/dashboard/tests/test_views.py
+++ b/dashboard/tests/test_views.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from datetime import datetime, timedelta, timezone as dt_timezone
 from pathlib import Path
+from unittest import mock
 
 from django.apps import apps as django_apps
 from django.conf import settings
@@ -68,10 +69,16 @@ class DashboardViewTests(TestCase):
         )
         self.new_user.date_joined = now - timedelta(days=1)
         self.new_user.save(update_fields=["date_joined"])
-        app_models.Onboarding.objects.create(
+        self.onboarding = app_models.Onboarding.objects.create(
             user=self.new_user,
             restaurant=self.restaurant,
             state=app_models.Onboarding.State.EMAIL_CONFIRMED,
+        )
+        app_models.OnboardingEvent.objects.create(
+            onboarding=self.onboarding,
+            from_state=app_models.Onboarding.State.CREATED,
+            to_state=self.onboarding.state,
+            message="Created during test",
         )
         app_models.Job.objects.create(
             account=self.account,
@@ -154,14 +161,50 @@ class DashboardViewTests(TestCase):
         response = self.client.get(reverse("dashboard:overview"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "SaaS Health Dashboard")
-        self.assertIn("onboarding", response.context)
-        self.assertIn("subscriptions", response.context)
-        self.assertIn("operations", response.context)
-        self.assertIn("api_activity", response.context)
-        self.assertGreaterEqual(len(response.context["quick_actions"]), 1)
+        context = response.context_data
+        self.assertIn("onboarding", context)
+        self.assertIn("subscriptions", context)
+        self.assertIn("operations", context)
+        self.assertIn("api_activity", context)
+        self.assertGreaterEqual(len(context["quick_actions"]), 1)
         self.assertContains(response, "Outscraper")
+        onboarding_ctx = context["onboarding"]
+        self.assertIn("run_targets", onboarding_ctx)
+        self.assertIn("recent_jobs", onboarding_ctx)
+        self.assertIn("recent_events", onboarding_ctx)
+        self.assertContains(response, "Trigger onboarding provisioning")
         if django_apps.is_installed("articles"):
             self.assertContains(response, "Article: Draft")
+
+    def test_manual_onboarding_trigger_creates_job(self) -> None:
+        """Staff can queue the onboarding flow for a restaurant."""
+
+        self.client.force_login(self.staff)
+        with mock.patch("dashboard.views.provision_onboarding.delay") as mock_delay:
+            response = self.client.post(
+                reverse("dashboard:run_onboarding"),
+                {"onboarding_id": str(self.onboarding.id)},
+                follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        jobs = app_models.ProvisioningJob.objects.filter(onboarding=self.onboarding)
+        self.assertEqual(jobs.count(), 1)
+        job = jobs.first()
+        assert job is not None
+        self.assertEqual(job.status, app_models.ProvisioningJob.Status.PENDING)
+        mock_delay.assert_called_once_with(job.id)
+        self.onboarding.refresh_from_db()
+        self.assertEqual(
+            self.onboarding.state,
+            app_models.Onboarding.State.SCRAPE_QUEUED,
+        )
+        self.assertTrue(
+            app_models.OnboardingEvent.objects.filter(
+                onboarding=self.onboarding,
+                to_state=app_models.Onboarding.State.SCRAPE_QUEUED,
+            ).exists()
+        )
 
 
 class LogFeedViewTests(TestCase):

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -2,11 +2,12 @@
 
 from django.urls import path
 
-from .views import DashboardView, LogFeedView
+from .views import DashboardView, LogFeedView, RunOnboardingView
 
 app_name = "dashboard"
 
 urlpatterns = [
     path("", DashboardView.as_view(), name="overview"),
     path("logs/", LogFeedView.as_view(), name="logs"),
+    path("onboarding/run/", RunOnboardingView.as_view(), name="run_onboarding"),
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
@@ -11,11 +12,13 @@ from typing import Any, Iterable
 
 from django.apps import apps
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.db.models import Count, Q
 from django.db.models.functions import TruncWeek
 from django.http import HttpResponseForbidden, JsonResponse
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -23,8 +26,11 @@ from django.views import View
 from django.views.generic import TemplateView
 
 from app import models as app_models
+from onboarding.tasks import provision_onboarding
 
 User = get_user_model()
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -152,6 +158,36 @@ class DashboardView(StaffOnlyMixin, TemplateView):
                     }
                 )
 
+        for log in (
+            app_models.LlmCallLog.objects.filter(step="onboarding")
+            .select_related("user")
+            .order_by("-created_at")[:20]
+        ):
+            actor_user = getattr(log, "user", None)
+            actor = "System"
+            if actor_user is not None:
+                actor = (
+                    getattr(actor_user, "get_full_name", lambda: "")()
+                    or getattr(actor_user, "email", "")
+                    or getattr(actor_user, "username", "")
+                    or "System"
+                )
+            metadata = log.metadata or {}
+            status_code = metadata.get("status_code") or metadata.get("status")
+            try:
+                status_value = int(status_code)
+            except (TypeError, ValueError):
+                status_value = 200
+            entries.append(
+                {
+                    "timestamp": log.created_at,
+                    "call": f"{log.provider.title()} {log.function_name}",
+                    "actor": actor,
+                    "status_code": status_value,
+                    "payload": mark_safe(json.dumps(metadata, indent=2, sort_keys=True)),
+                }
+            )
+
         entries.sort(key=lambda item: item["timestamp"], reverse=True)
         return entries[:20]
 
@@ -164,11 +200,13 @@ class DashboardView(StaffOnlyMixin, TemplateView):
         stalled_cutoff = now - timedelta(days=self.STALLED_DAYS)
 
         onboardings = (
-            app_models.Onboarding.objects.select_related("user")
-            .order_by("-created_at")
+            app_models.Onboarding.objects.select_related("user", "restaurant")
+            .order_by("-updated_at")
             .all()
         )
         records: list[dict[str, Any]] = []
+        run_targets: list[dict[str, Any]] = []
+        state_labels = dict(app_models.Onboarding.State.choices)
         for onboarding in onboardings[:25]:
             updated_at = onboarding.updated_at or onboarding.created_at
             is_complete = onboarding.state == app_models.Onboarding.State.COMPLETE
@@ -184,11 +222,66 @@ class DashboardView(StaffOnlyMixin, TemplateView):
                 }
             )
 
+            if onboarding.restaurant_id:
+                job = onboarding.provisioning_jobs.order_by("-created_at").first()
+                run_targets.append(
+                    {
+                        "id": str(onboarding.id),
+                        "restaurant": getattr(onboarding.restaurant, "name", ""),
+                        "email": onboarding.user.email if onboarding.user_id else "-",
+                        "state": onboarding.get_state_display(),
+                        "progress": onboarding.progress,
+                        "updated_at": updated_at,
+                        "job_status": getattr(job, "status", ""),
+                        "job_step": getattr(job, "current_step", ""),
+                        "job_step_label": (
+                            getattr(job, "current_step", "") or ""
+                        ).replace("_", " ").title(),
+                    }
+                )
+
+        recent_jobs = []
+        for job in (
+            app_models.ProvisioningJob.objects.select_related("onboarding", "onboarding__restaurant")
+            .order_by("-created_at")[:10]
+        ):
+            recent_jobs.append(
+                {
+                    "id": str(job.id),
+                    "restaurant": getattr(job.onboarding.restaurant, "name", ""),
+                    "status": job.status,
+                    "step": job.current_step,
+                    "step_label": (job.current_step or "").replace("_", " ").title(),
+                    "created_at": job.created_at,
+                    "finished_at": job.finished_at,
+                }
+            )
+
+        recent_events = []
+        for event in (
+            app_models.OnboardingEvent.objects.select_related("onboarding", "onboarding__restaurant")
+            .order_by("-created_at")[:12]
+        ):
+            recent_events.append(
+                {
+                    "restaurant": getattr(event.onboarding.restaurant, "name", ""),
+                    "from_state": event.from_state,
+                    "to_state": event.to_state,
+                    "from_label": state_labels.get(event.from_state, event.from_state),
+                    "to_label": state_labels.get(event.to_state, event.to_state),
+                    "message": event.message,
+                    "created_at": event.created_at,
+                }
+            )
+
         return {
             "signups_7": User.objects.filter(date_joined__gte=seven_days).count(),
             "signups_30": User.objects.filter(date_joined__gte=thirty_days).count(),
             "stalled_days": self.STALLED_DAYS,
             "records": records,
+            "run_targets": run_targets[:10],
+            "recent_jobs": recent_jobs,
+            "recent_events": recent_events,
         }
 
     def _build_subscription_context(self) -> dict[str, Any]:
@@ -448,6 +541,14 @@ class DashboardView(StaffOnlyMixin, TemplateView):
             "support_messages": support_messages,
         }
 
+    def _safe_get_model(self, app_label: str, model_name: str):
+        """Return a model when present without failing the dashboard."""
+
+        try:
+            return apps.get_model(app_label, model_name)
+        except LookupError:
+            return None
+
     def _build_quick_actions(self) -> list[QuickAction]:
         """Return lightweight links for common follow-up workflows."""
 
@@ -494,14 +595,57 @@ class DashboardView(StaffOnlyMixin, TemplateView):
             ),
         ]
 
-    def _safe_get_model(self, app_label: str, model_name: str):
-        """Return a model when present without failing the dashboard."""
 
-        try:
-            return apps.get_model(app_label, model_name)
-        except LookupError:
-            return None
+class RunOnboardingView(StaffOnlyMixin, View):
+    """Allow staff to manually trigger onboarding provisioning."""
 
+    def post(self, request, *args: Any, **kwargs: Any):
+        onboarding_id = request.POST.get("onboarding_id", "").strip()
+        if not onboarding_id:
+            messages.error(request, "Select a restaurant before running onboarding.")
+            return redirect("dashboard:overview")
+
+        onboarding = get_object_or_404(
+            app_models.Onboarding.objects.select_related("restaurant", "user"),
+            id=onboarding_id,
+        )
+
+        if not onboarding.restaurant_id:
+            messages.error(
+                request,
+                "This onboarding record is missing a restaurant and cannot be queued.",
+            )
+            return redirect("dashboard:overview")
+
+        job = app_models.ProvisioningJob.objects.create(
+            onboarding=onboarding,
+            status=app_models.ProvisioningJob.Status.PENDING,
+            stripe_session_id="internal-dashboard",
+        )
+
+        logger.info(
+            "Manual onboarding provisioning queued",
+            extra={
+                "onboarding_id": str(onboarding.id),
+                "job_id": str(job.id),
+                "restaurant_id": str(onboarding.restaurant_id),
+            },
+        )
+
+        if onboarding.progress < 10:
+            onboarding.mark(
+                app_models.Onboarding.State.SCRAPE_QUEUED,
+                progress=10,
+                message="Queued from internal dashboard",
+            )
+
+        provision_onboarding.delay(job.id)
+
+        messages.success(
+            request,
+            f"Provisioning started for {onboarding.restaurant.name}.",
+        )
+        return redirect("dashboard:overview")
 
 class LogFeedView(StaffOnlyMixin, View):
     """Expose the most recent structured application logs as JSON."""

--- a/onboarding/tasks.py
+++ b/onboarding/tasks.py
@@ -442,7 +442,19 @@ def provision_onboarding(self, provisioning_job_id: UUID) -> None:
                     .get(id=job.onboarding_id)
                 )
                 _update_job(job, step_name)
+                logger.info(
+                    "Onboarding %s running step %s",
+                    onboarding.id,
+                    step_name,
+                    extra={"job_id": str(job.id)},
+                )
                 func(onboarding)
+                logger.info(
+                    "Onboarding %s finished step %s",
+                    onboarding.id,
+                    step_name,
+                    extra={"job_id": str(job.id)},
+                )
         with transaction.atomic():
             job = models.ProvisioningJob.objects.select_for_update().get(id=provisioning_job_id)
             onboarding = (
@@ -455,6 +467,11 @@ def provision_onboarding(self, provisioning_job_id: UUID) -> None:
             job.status = models.ProvisioningJob.Status.SUCCEEDED
             job.finished_at = _now()
             job.save(update_fields=["status", "finished_at"])
+            logger.info(
+                "Onboarding %s provisioning complete",
+                onboarding.id,
+                extra={"job_id": str(job.id)},
+            )
     except Exception as exc:  # pragma: no cover - orchestrator level guard
         logger.exception("Provisioning job %s failed", provisioning_job_id)
         with transaction.atomic():


### PR DESCRIPTION
## Summary
- add manual onboarding run controls and restaurant insights to the internal dashboard
- expose a staff-only endpoint to queue provisioning jobs with detailed logging and api feed updates
- improve onboarding task logging and expand dashboard view tests for the new flow

## Testing
- pytest dashboard/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68e02844297c8332bf9ff5d82259a1a5