### PR TITLE
Ensure HTMX favorite buttons send CSRF tokens

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -11,6 +11,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"
@@ -39,6 +40,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"

--- a/app/templates/dishes/_favorite_button.html
+++ b/app/templates/dishes/_favorite_button.html
@@ -4,6 +4,7 @@
   hx-trigger="click"
   hx-swap="outerHTML"
   hx-target="closest .dish-card-wrapper"
+  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
   class="{{ base_class }} transition {% if dish.is_favorited %}text-red-500{% else %}text-slate-500 hover:text-red-400{% endif %}"
   aria-label="{% if dish.is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ dish.title }}"
   aria-pressed="{{ dish.is_favorited|yesno:'true,false' }}"


### PR DESCRIPTION
## Summary
- ensure the dish favorite HTMX toggle sends the current CSRF token header with each HTMX request
- add the same CSRF header configuration to concept favorite buttons to avoid inconsistent failures

## Testing
- pytest tests/test_concept_background.py::ConceptFavoriteToggleTests::test_favoriting_returns_loading_card_markup

------
https://chatgpt.com/codex/tasks/task_e_68e03264359c833281fd0da95e6cba47