### PR TITLE
Harden concept and dish CSRF handling

### DIFF
--- a/app/templates/_partials/contextual_ai_input.html
+++ b/app/templates/_partials/contextual_ai_input.html
@@ -21,6 +21,7 @@
         hx-indicator="#{{ indicator_id }}"
         class="space-y-4"
       >
+        {% csrf_token %}
         <div class="relative flex-1">
           <input
             type="text"

--- a/app/templates/concepts/_card.html
+++ b/app/templates/concepts/_card.html
@@ -111,6 +111,7 @@
               class="inline-flex items-center gap-1.5 rounded-full border border-[#f08000]/30 bg-[#f08000]/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-[#f08000] hover:bg-[#f08000]/15"
               hx-post="{% url 'dishes-generate' concept.id %}"
               hx-trigger="click"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               data-overlay="true"
               data-messages='["Cooking up ideas…", "Almost there…", "Plating concepts!"]'
               data-generate-button
@@ -128,6 +129,7 @@
               hx-trigger="click"
               hx-target="closest [data-concept-card]"
               hx-swap="outerHTML"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               aria-label="Delete {{ concept.name }}"
             >
               <i class="fa-solid fa-trash-can"></i>

--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -11,6 +11,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"
@@ -39,6 +40,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"

--- a/app/templates/concepts/grid.html
+++ b/app/templates/concepts/grid.html
@@ -28,6 +28,7 @@
           hx-post="{{ concept_generate_url }}"
           hx-target="#concepts-grid"
           hx-swap="beforeend"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           hx-include="#concepts-ai-input-slider"
           class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
           data-more-ideas

--- a/app/templates/dishes/page.html
+++ b/app/templates/dishes/page.html
@@ -40,6 +40,7 @@
           hx-post="{{ dishes_generate_url }}"
           hx-target="#dishes-grid"
           hx-swap="beforeend"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           class="relative inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-600"
         >
           <span class="inline-flex items-center gap-2">

--- a/app/views.py
+++ b/app/views.py
@@ -1085,9 +1085,19 @@ def tag_search_view(request):
 
 
 @login_required
+@require_POST
 def concepts_generate_view(request):
-    membership = models.Membership.objects.filter(user=request.user).first()
+    membership = (
+        models.Membership.objects.filter(user=request.user)
+        .select_related("account")
+        .first()
+    )
+    if not membership or not membership.account:
+        return HttpResponseForbidden("Restaurant access required.")
+
     restaurant = models.Restaurant.objects.filter(account=membership.account).first()
+    if not restaurant:
+        return HttpResponseBadRequest("Restaurant not found for account.")
     raw_prompt = (request.POST.get("prompt") or "").strip()
     user_prompt = raw_prompt[:280]
 
@@ -1317,8 +1327,15 @@ def concepts_generate_view(request):
     return redirect("concepts")
 
 @login_required
+@require_POST
 def concept_favorite_view(request, concept_id):
     concept = get_object_or_404(models.Concept, id=concept_id)
+    if concept.restaurant_id:
+        has_access = models.Membership.objects.filter(
+            user=request.user, account=concept.restaurant.account
+        ).exists()
+        if not has_access:
+            return HttpResponseForbidden("Not allowed to modify this concept.")
     fav, created = models.FavoriteConcept.objects.get_or_create(
         user=request.user, concept=concept, defaults={"favorited_at": timezone.now()}
     )
@@ -1668,11 +1685,16 @@ def ensure_dish_enhancement(dish: models.DishIdea, user: Optional[User]) -> Opti
     return enhancement
 
 @login_required
+@require_POST
 def dishes_generate_view(request, concept_id):
     """Generate nine dish ideas for a concept and return updated content."""
     concept = models.Concept.objects.select_related("restaurant").get(id=concept_id)
     restaurant = concept.restaurant
-    membership = models.Membership.objects.filter(user=request.user).first()
+    has_access = models.Membership.objects.filter(
+        user=request.user, account=restaurant.account
+    ).exists()
+    if not has_access:
+        return HttpResponseForbidden("Not allowed to generate dishes for this concept.")
     htmx_request = request.headers.get("HX-Request") == "true"
     slider_value, slider_temperature = _resolve_creativity_settings(restaurant)
     slider_override = _sanitize_slider_value(


### PR DESCRIPTION
## Summary
- require POST and membership checks on concept and dish generation endpoints and concept favorite toggles
- add CSRF tokens to the contextual AI form and ensure HTMX actions send CSRF headers
- extend HTMX buttons for concept and dish actions with explicit CSRF headers for reliable protection

## Testing
- pytest tests/test_appertivo_views.py tests/test_concept_dislikes.py *(fails: ModuleNotFoundError: No module named 'django_htmx')*

------
https://chatgpt.com/codex/tasks/task_e_68ed0c94d06c8332aeb1ea2428265201