### PR TITLE
Fix CSRF header for concept favorite button

### DIFF
--- a/app/templates/concepts/_favorite_button.html
+++ b/app/templates/concepts/_favorite_button.html
@@ -11,7 +11,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-headers='{"X-CSRFToken": "{{ request.COOKIES.csrftoken|default_if_none:''|default:''|escapejs }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"
@@ -40,7 +40,7 @@
               hx-post="{{ hx_post }}"
               hx-target="{{ hx_target }}"
               hx-swap="{{ hx_swap }}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-headers='{"X-CSRFToken": "{{ request.COOKIES.csrftoken|default_if_none:''|default:''|escapejs }}"}'
               class="concept-favorite-btn {{ base_classes }} {% if is_favorited %}concept-favorite-btn--favorited{% endif %}"
               aria-label="{% if is_favorited %}Unfavorite{% else %}Favorite{% endif %} {{ concept.name }}"
               data-concept-id="{{ concept.id }}"


### PR DESCRIPTION
## Summary
- ensure the concept favorite HTMX button copies the CSRF token from the cookie before posting

## Testing
- pytest tests/test_appertivo_views.py::AppertivoViewsTests::test_concept_favorite_htmx_redirects_to_dishes -q *(fails: ModuleNotFoundError: No module named 'django_htmx')*

------
https://chatgpt.com/codex/tasks/task_e_68ed2b5dd078833298ac23e0036e1002