### PR TITLE
Fix swipe card front images

### DIFF
--- a/swipe/models.py
+++ b/swipe/models.py
@@ -22,6 +22,10 @@ class SeenItem(models.Model):
         ]
 
 # Concept and Dish are lightweight; can be generated, cached, or persisted later.
+CONCEPT_PLACEHOLDER_URL = "https://placehold.co/1200x800?text=Concept"
+DISH_PLACEHOLDER_URL = "https://placehold.co/800x600?text=Dish"
+
+
 class Concept(models.Model):
     # NOTE: In production you'll likely want a Restaurant FK. Omitted for skeleton.
     restaurant = models.ForeignKey(Restaurant,on_delete=models.CASCADE,related_name="concepts")
@@ -36,6 +40,13 @@ class Concept(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def display_sketch_url(self) -> str:
+        url = (self.sketch_url or "").strip()
+        if not url or url.lower() in {"none", "null"}:
+            return CONCEPT_PLACEHOLDER_URL
+        return url
+
 
 class Dish(models.Model):
     concept = models.ForeignKey(Concept, on_delete=models.CASCADE, related_name="dishes")
@@ -47,6 +58,13 @@ class Dish(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.concept.name})"
+
+    @property
+    def display_image_url(self) -> str:
+        url = (self.image_url or "").strip()
+        if not url or url.lower() in {"none", "null"}:
+            return DISH_PLACEHOLDER_URL
+        return url
 
 
 class Favorite(models.Model):

--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -83,6 +83,8 @@
 
     .card-front {
       position: relative;
+      transform: rotateY(0deg);
+      z-index: 2;
     }
 
     .card-back {
@@ -333,13 +335,15 @@
                   <!-- Concept Card -->
                   <div class="card w-full h-[70vh]" data-card tabindex="0" role="button">
                     <div class="card-inner">
-                      {% with concept_image=concept.sketch_url|default:"https://placehold.co/1200x800?text=Concept" %}
-                      <div class="card-face card-front" style="background-image: url('{{ concept_image }}'); background-size: cover; background-position: center;">
+                      {% with concept_image=concept.display_sketch_url concept_placeholder="https://placehold.co/1200x800?text=Concept" %}
+                      <div class="card-face card-front">
                         <img
                           src="{{ concept_image }}"
                           alt="{{ concept.name }} concept sketch"
                           class="card-media"
                           decoding="async"
+                          loading="lazy"
+                          onerror="this.onerror=null;this.src='{{ concept_placeholder }}';"
                         >
                         <div class="card-hint">Tap to view details</div>
                       </div>
@@ -374,13 +378,15 @@
                   {% for dish in concept.dishes.all %}
                     <div class="card w-full h-[70vh]" data-card tabindex="0" role="button">
                       <div class="card-inner">
-                        {% with dish_image=dish.image_url|default:"https://placehold.co/800x600?text=Dish" %}
-                        <div class="card-face card-front" style="background-image: url('{{ dish_image }}'); background-size: cover; background-position: center;">
+                        {% with dish_image=dish.display_image_url dish_placeholder="https://placehold.co/800x600?text=Dish" %}
+                        <div class="card-face card-front">
                           <img
                             src="{{ dish_image }}"
                             alt="{{ dish.name }} presentation"
                             class="card-media"
                             decoding="async"
+                            loading="lazy"
+                            onerror="this.onerror=null;this.src='{{ dish_placeholder }}';"
                           >
                           <div class="card-hint">Tap to view details</div>
                         </div>


### PR DESCRIPTION
## Summary
- add helper properties on Concept and Dish to provide fallback image URLs
- update swipe card template to ensure images render on the front face with lazy loading
- tweak card CSS so the front face displays correctly when not flipped

## Testing
- python manage.py test swipe

------
https://chatgpt.com/codex/tasks/task_e_68eec9ad9298833287086bc99574211c