### PR TITLE
Adjust swipe card backs for improved text layout

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -126,44 +126,76 @@
       min-height: 0;
       height: 100%;
       overscroll-behavior: contain;
-      padding: 1.5rem;
+      padding: 2.75rem 2rem 2rem;
+      gap: 1.5rem;
     }
 
-    .card-back-content .info-panel {
+    .card-back-body {
       flex: 1;
+      min-height: 0;
       display: flex;
       flex-direction: column;
+      gap: 0.85rem;
       overflow-y: auto;
     }
 
-    .card-back h2,
-    .card-back h3 {
+    .card-back-title {
       font-family: 'Playfair Display', serif;
-      letter-spacing: 0.02em;
-    }
-
-    .card-back p {
-      color: rgba(226, 232, 240, 0.9);
-    }
-
-    .info-panel {
-      border-radius: 24px;
-      background: rgba(15, 23, 42, 0.65);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      text-transform: uppercase;
+      letter-spacing: 0.28em;
+      font-weight: 500;
+      font-size: clamp(1.65rem, 5.2vw, 2.45rem);
+      line-height: 1.1;
       color: #f8fafc;
-      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .card-back-heading {
+      font-family: 'Playfair Display', serif;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      font-weight: 500;
+      font-size: clamp(1.4rem, 4.8vw, 2.1rem);
+      line-height: 1.15;
+      color: #f8fafc;
+    }
+
+    .card-back-subtitle {
+      text-transform: uppercase;
+      letter-spacing: 0.32em;
+      font-size: clamp(0.6rem, 1.5vw, 0.75rem);
+      color: rgba(203, 213, 225, 0.8);
+    }
+
+    .card-back-description {
+      font-size: clamp(0.85rem, 2.6vw, 1rem);
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    .card-back-price {
+      font-size: clamp(0.95rem, 2.8vw, 1.1rem);
+      font-weight: 600;
+      color: rgba(110, 231, 183, 0.9);
+    }
+
+    .card-back-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding-top: 0.25rem;
     }
 
     .tag-chip {
       display: inline-flex;
       align-items: center;
-      padding: 0.25rem 0.75rem;
+      padding: 0.15rem 0.6rem;
       border-radius: 9999px;
-      font-size: 0.75rem;
+      font-size: 0.65rem;
       font-weight: 600;
-      color: #f1f5f9;
-      background: rgba(148, 163, 184, 0.15);
-      border: 1px solid rgba(148, 163, 184, 0.25);
+      letter-spacing: 0.12em;
+      color: rgba(226, 232, 240, 0.85);
+      background: rgba(148, 163, 184, 0.18);
+      border: 1px solid rgba(148, 163, 184, 0.2);
     }
 
     .touch-area {
@@ -422,19 +454,17 @@
                           </svg>
                         </button>
                         <div class="card-back-content">
-                          <div class="info-panel p-6">
-                            <div class="space-y-4">
-                              <div class="flex flex-wrap gap-2">
-                                {% for tag in concept.meta_ingredients %}
-                                  <span class="tag-chip">{{ tag }}</span>
-                                {% empty %}
-                                  <span class="tag-chip">Seasonal</span>
-                                {% endfor %}
-                              </div>
-                              <h2 class="text-4xl font-medium tracking-[0.28em] uppercase">{{ concept.name }}</h2>
-                              <p class="text-xs tracking-[0.38em] uppercase text-slate-300/80">{{ concept.subtitle }}</p>
-                              <p class="text-sm leading-relaxed">{{ concept.meta_reasoning }}</p>
-                            </div>
+                          <div class="card-back-body">
+                            <h2 class="card-back-title">{{ concept.name }}</h2>
+                            <p class="card-back-subtitle">{{ concept.subtitle }}</p>
+                            <p class="card-back-description">{{ concept.meta_reasoning }}</p>
+                          </div>
+                          <div class="card-back-tags">
+                            {% for tag in concept.meta_ingredients %}
+                              <span class="tag-chip">{{ tag }}</span>
+                            {% empty %}
+                              <span class="tag-chip">Seasonal</span>
+                            {% endfor %}
                           </div>
                         </div>
                       </div>
@@ -468,17 +498,17 @@
                             </svg>
                           </button>
                           <div class="card-back-content">
-                            <div class="info-panel p-6">
-                              <div class="space-y-4">
-                                <div class="flex flex-wrap gap-2">
-                                  {% for ingredient in dish.ingredients %}
-                                    <span class="tag-chip">{{ ingredient }}</span>
-                                  {% endfor %}
-                                </div>
-                                <h3 class="text-3xl font-medium tracking-[0.22em] uppercase">{{ dish.name }}</h3>
-                                <p class="text-sm leading-relaxed">{{ dish.reasoning }}</p>
-                                <p class="text-base font-semibold text-emerald-300/90">{{ dish.price }}</p>
-                              </div>
+                            <div class="card-back-body">
+                              <h3 class="card-back-heading">{{ dish.name }}</h3>
+                              <p class="card-back-description">{{ dish.reasoning }}</p>
+                              {% if dish.price %}
+                                <p class="card-back-price">{{ dish.price }}</p>
+                              {% endif %}
+                            </div>
+                            <div class="card-back-tags">
+                              {% for ingredient in dish.ingredients %}
+                                <span class="tag-chip">{{ ingredient }}</span>
+                              {% endfor %}
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- remove the bordered info panel from swipe card backs so content can use the full area
- update typography, spacing, and tag placement to prevent copy from being clipped
- reduce tag chip sizing and restyle supporting metadata for consistent readability

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68efdf654a048332a790459503881565