### PR TITLE
Fix missing threading import in GetConcepts

### DIFF
--- a/swipe/llm_utils.py
+++ b/swipe/llm_utils.py
@@ -7,6 +7,7 @@ tests can run without network access.
 
 import os
 import asyncio
+import threading
 import cloudinary
 from openai import AsyncOpenAI
 from replicate import Client as ReplicateClient


### PR DESCRIPTION
## Summary
- import the threading module in `swipe.llm_utils.GetConcepts`
- allow the background locale loading helper to run without raising NameError

## Testing
- `pytest` *(fails: existing asset dashboard tests are red in the current tree)*

------
https://chatgpt.com/codex/tasks/task_e_68efe05f9a588332bb82ce27fb10b39a