### PR TITLE
Add API for appending concept dishes

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -581,7 +581,11 @@
           {% for concept in concepts %}
             <div class="concept-slide" data-concept-index="{{ forloop.counter0 }}">
               <div id="horizontalSlider{{ forloop.counter0 }}" class="horizontal-slider slide-container w-full">
-                <div class="horizontal-track">
+                <div
+                  class="horizontal-track"
+                  data-concept-track="{{ concept.id }}"
+                  data-concept-index="{{ forloop.counter0 }}"
+                >
                   <!-- Concept Card -->
                   <div class="card w-full" data-card tabindex="0" role="button">
                     <div class="card-inner">
@@ -620,6 +624,22 @@
                               <span class="tag-chip">Seasonal</span>
                             {% endfor %}
                           </div>
+                          <button
+                            type="button"
+                            class="mt-4 inline-flex items-center gap-3 self-start rounded-full border border-slate-100/40 bg-slate-900/70 px-5 py-2 text-[0.55rem] font-semibold uppercase tracking-[0.3em] text-slate-100 transition hover:bg-slate-800/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-100/70"
+                            data-prevent-flip
+                            data-load-dishes
+                            data-concept-id="{{ concept.id }}"
+                            data-concept-index="{{ forloop.counter0 }}"
+                            data-endpoint="{% url 'swipe:concept_append_dishes' concept.id %}"
+                          >
+                            <span data-label>Get more dishes</span>
+                            <span
+                              class="ml-2 hidden h-4 w-4 animate-spin rounded-full border-2 border-white/60 border-t-transparent"
+                              data-spinner
+                              aria-hidden="true"
+                            ></span>
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -736,6 +756,137 @@
     const verticalSlider = document.getElementById('verticalSlider');
     const introOverlay = document.getElementById('introOverlay');
     const dismissIntro = document.getElementById('dismissIntro');
+    const DISH_PLACEHOLDER = 'https://placehold.co/800x600?text=Dish';
+
+    function initializeCard(card) {
+      if (!card || card.dataset.cardReady === 'true') {
+        return;
+      }
+
+      const inner = card.querySelector('.card-inner');
+      if (!inner) return;
+
+      const toggleFlip = () => {
+        card.classList.toggle('is-flipped');
+      };
+
+      card.addEventListener('click', (event) => {
+        if (event.target.closest('[data-prevent-flip]')) {
+          return;
+        }
+        toggleFlip();
+      });
+
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggleFlip();
+        }
+      });
+
+      card.dataset.cardReady = 'true';
+    }
+
+    function setButtonLoading(button, isLoading) {
+      if (!button) return;
+      button.disabled = isLoading;
+      button.setAttribute('aria-busy', String(isLoading));
+
+      const spinner = button.querySelector('[data-spinner]');
+      if (spinner) {
+        spinner.classList.toggle('hidden', !isLoading);
+      }
+    }
+
+    function createDishCard(dish) {
+      const card = document.createElement('div');
+      card.className = 'card w-full';
+      card.setAttribute('data-card', '');
+      card.setAttribute('tabindex', '0');
+      card.setAttribute('role', 'button');
+
+      const inner = document.createElement('div');
+      inner.className = 'card-inner';
+      card.appendChild(inner);
+
+      const imageUrl = dish.image_url || DISH_PLACEHOLDER;
+      const front = document.createElement('div');
+      front.className = 'card-face card-front';
+      front.style.backgroundImage = `url('${imageUrl}')`;
+
+      const img = document.createElement('img');
+      img.src = imageUrl;
+      img.alt = `${dish.name || 'Dish'} presentation`;
+      img.className = 'card-media';
+      img.decoding = 'async';
+      img.loading = 'lazy';
+      img.addEventListener('error', () => {
+        img.onerror = null;
+        img.src = DISH_PLACEHOLDER;
+        front.style.backgroundImage = `url('${DISH_PLACEHOLDER}')`;
+      });
+
+      front.appendChild(img);
+      inner.appendChild(front);
+
+      const back = document.createElement('div');
+      back.className = 'card-face card-back';
+      inner.appendChild(back);
+
+      const heartButton = document.createElement('button');
+      heartButton.type = 'button';
+      heartButton.className = 'heart-btn absolute top-5 right-5 rounded-full border border-slate-100/40 bg-slate-900/60 p-3 shadow-lg z-10';
+      heartButton.setAttribute('data-prevent-flip', '');
+      const dishId = dish.id ?? '';
+      heartButton.dataset.id = String(dishId);
+      heartButton.innerHTML = '<svg class="w-6 h-6 text-rose-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path></svg>';
+      heartButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        if (typeof window.toggleFavorite === 'function') {
+          window.toggleFavorite(heartButton, 'dish', String(dishId));
+        }
+      });
+      back.appendChild(heartButton);
+
+      const content = document.createElement('div');
+      content.className = 'card-back-content';
+      back.appendChild(content);
+
+      const body = document.createElement('div');
+      body.className = 'card-back-body';
+      content.appendChild(body);
+
+      const heading = document.createElement('h3');
+      heading.className = 'card-back-heading';
+      heading.textContent = dish.name || 'Dish';
+      body.appendChild(heading);
+
+      const description = document.createElement('p');
+      description.className = 'card-back-description';
+      description.textContent = dish.reasoning || '';
+      body.appendChild(description);
+
+      if (dish.price) {
+        const price = document.createElement('p');
+        price.className = 'card-back-price';
+        price.textContent = dish.price;
+        body.appendChild(price);
+      }
+
+      const tags = document.createElement('div');
+      tags.className = 'card-back-tags';
+      content.appendChild(tags);
+
+      const ingredients = Array.isArray(dish.ingredients) ? dish.ingredients : [];
+      ingredients.forEach((ingredient) => {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.textContent = ingredient;
+        tags.appendChild(chip);
+      });
+
+      return card;
+    }
 
     if (introOverlay && dismissIntro) {
       const cleanupIntroListeners = () => {
@@ -776,26 +927,7 @@
     }
 
     document.querySelectorAll('[data-card]').forEach((card) => {
-      const inner = card.querySelector('.card-inner');
-      if (!inner) return;
-
-      const toggleFlip = () => {
-        card.classList.toggle('is-flipped');
-      };
-
-      card.addEventListener('click', (event) => {
-        if (event.target.closest('[data-prevent-flip]')) {
-          return;
-        }
-        toggleFlip();
-      });
-
-      card.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          toggleFlip();
-        }
-      });
+      initializeCard(card);
     });
 
     const getSlideHeight = () => {
@@ -904,6 +1036,83 @@
     } else {
       let currentConceptIndex = 0;
       let currentDishIndex = 0;
+
+      const loadButtons = document.querySelectorAll('[data-load-dishes]');
+      loadButtons.forEach((button) => {
+        button.addEventListener('click', async () => {
+          if (button.dataset.loading === 'true') {
+            return;
+          }
+
+          const endpoint = button.dataset.endpoint;
+          const conceptId = button.dataset.conceptId;
+          const conceptIndex = Number.parseInt(button.dataset.conceptIndex || '0', 10);
+
+          if (!endpoint || !conceptId) {
+            return;
+          }
+
+          button.dataset.loading = 'true';
+          setButtonLoading(button, true);
+
+          try {
+            const response = await fetch(endpoint, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken,
+              },
+              body: JSON.stringify({}),
+            });
+
+            if (!response.ok) {
+              throw new Error(`Request failed with status ${response.status}`);
+            }
+
+            const payload = await response.json();
+            const dishes = Array.isArray(payload.dishes) ? payload.dishes : [];
+            if (dishes.length === 0) {
+              return;
+            }
+
+            const track = document.querySelector(
+              `.horizontal-track[data-concept-track="${conceptId}"]`
+            );
+            if (!track) {
+              return;
+            }
+
+            const conceptCard = track.querySelector('.card');
+            const referenceNode = conceptCard ? conceptCard.nextElementSibling : null;
+
+            const newCards = dishes.map((dish) => {
+              const card = createDishCard(dish);
+              initializeCard(card);
+              return card;
+            });
+
+            newCards.forEach((card) => {
+              track.insertBefore(card, referenceNode);
+            });
+
+            const currentCount = Number.isInteger(dishCounts[conceptIndex])
+              ? dishCounts[conceptIndex]
+              : 0;
+            dishCounts[conceptIndex] = currentCount + newCards.length;
+
+            if (conceptIndex === currentConceptIndex) {
+              updateHorizontalPosition({ instant: true });
+              updatePositionIndicator();
+              updateNavigationButtons();
+            }
+          } catch (error) {
+            console.error('Failed to load dishes:', error);
+          } finally {
+            delete button.dataset.loading;
+            setButtonLoading(button, false);
+          }
+        });
+      });
 
       document.querySelectorAll('.horizontal-slider').forEach((slider) => {
         slider.style.transform = '';

--- a/swipe/urls.py
+++ b/swipe/urls.py
@@ -8,6 +8,11 @@ urlpatterns = [
     path("", SwipeHomeView.as_view(), name="home"),
     path("favorites/", FavoritesView.as_view(), name="favorites"),
     path("generate-concepts/<uuid:restaurant_id>/", generate_concepts_view, name="generate_concepts"),
+    path(
+        "api/concepts/<int:concept_id>/dishes/",
+        ConceptDishAppendView.as_view(),
+        name="concept_append_dishes",
+    ),
     path("api/seen/", MarkSeenAPI.as_view(), name="mark_seen"),
     path("api/favorite/", ToggleFavoriteAPI.as_view(), name="api_favorite"),
     path("health/", HealthView.as_view(), name="health"),

--- a/swipe/views.py
+++ b/swipe/views.py
@@ -189,6 +189,48 @@ class SwipeConceptBatchView(View):
         return JsonResponse({"results": results, "limit": limit, "offset": offset})
 
 
+class ConceptDishAppendView(View):
+    """Append freshly generated dishes to an existing concept."""
+
+    def post(self, request, concept_id):
+        concept = get_object_or_404(
+            Concept.objects.select_related("restaurant"), pk=concept_id
+        )
+
+        generator = GetConcepts(restaurant=concept.restaurant)
+
+        try:
+            saved_dishes = asyncio.run(generator.append_dishes_to_concept(concept))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to append dishes for concept %s: %s", concept_id, exc
+            )
+            return JsonResponse(
+                {"error": "Unable to fetch additional dishes."}, status=500
+            )
+
+        response_payload = []
+        for dish in saved_dishes:
+            ingredients = dish.get("ingredient_overlap") or dish.get("ingredients") or []
+            if isinstance(ingredients, str):
+                ingredients = [ingredients]
+
+            response_payload.append(
+                {
+                    "id": dish.get("id"),
+                    "name": dish.get("title") or dish.get("name") or "",
+                    "reasoning": dish.get("description")
+                    or dish.get("reasoning")
+                    or "",
+                    "ingredients": ingredients,
+                    "price": dish.get("suggested_price") or dish.get("price") or "",
+                    "image_url": dish.get("image_url") or "",
+                }
+            )
+
+        return JsonResponse({"dishes": response_payload})
+
+
 @method_decorator(csrf_exempt, name="dispatch")
 class ToggleFavoriteAPI(View):
     """

--- a/tests/test_concept_append_dishes_api.py
+++ b/tests/test_concept_append_dishes_api.py
@@ -1,0 +1,113 @@
+from unittest.mock import patch
+
+from asgiref.sync import sync_to_async
+from django.test import TransactionTestCase
+from django.urls import reverse
+
+from app.models import Account, Restaurant
+from swipe.llm_utils import GetConcepts
+from swipe.models import Concept, Dish
+
+
+class ConceptAppendDishesAPITests(TransactionTestCase):
+    def setUp(self):
+        self.account = Account.objects.create(name="Account")
+        self.restaurant = Restaurant.objects.create(
+            account=self.account,
+            name="Test Restaurant",
+            location_text="Test City",
+        )
+        self.concept = Concept.objects.create(
+            restaurant=self.restaurant,
+            name="Seaside Evenings",
+            subtitle="Coastal comfort",
+            meta_ingredients=["citrus", "herb"],
+            meta_reasoning="Inspired by shoreline suppers.",
+        )
+        Dish.objects.create(
+            concept=self.concept,
+            name="Existing Dish",
+            reasoning="Starter",
+            ingredients=["lemon"],
+            price="$10",
+            image_url="https://example.com/existing.jpg",
+        )
+
+    def test_append_dishes_returns_payload_and_updates_count(self):
+        concept = self.concept
+        new_dish_payloads = [
+            {
+                "title": "Grilled Octopus",
+                "description": "Charred octopus with smoked paprika aioli.",
+                "ingredient_overlap": ["octopus", "paprika", "citrus"],
+                "suggested_price": "$24",
+                "image_url": "https://example.com/octopus.jpg",
+            },
+            {
+                "title": "Citrus Panna Cotta",
+                "description": "Silky panna cotta with orange reduction.",
+                "ingredient_overlap": ["cream", "orange", "thyme"],
+                "suggested_price": "$12",
+                "image_url": "https://example.com/pannacotta.jpg",
+            },
+        ]
+
+        test_self = self
+
+        async def fake_append(_generator, concept_arg):  # pragma: no cover - helper closure
+            test_self.assertEqual(concept_arg.id, concept.id)
+
+            def create():
+                dishes = []
+                for payload in new_dish_payloads:
+                    dishes.append(
+                        Dish.objects.create(
+                            concept=concept,
+                            name=payload["title"],
+                            reasoning=payload["description"],
+                            ingredients=payload["ingredient_overlap"],
+                            price=payload["suggested_price"],
+                            image_url=payload["image_url"],
+                        )
+                    )
+                return dishes
+
+            created_dishes = await sync_to_async(create)()
+            return [
+                {
+                    "id": dish.id,
+                    "concept_id": dish.concept_id,
+                    "title": dish.name,
+                    "description": dish.reasoning,
+                    "ingredient_overlap": dish.ingredients,
+                    "suggested_price": dish.price,
+                    "image_url": dish.image_url,
+                }
+                for dish in created_dishes
+            ]
+
+        url = reverse("swipe:concept_append_dishes", args=[concept.id])
+
+        with patch.object(GetConcepts, "_load_locale", lambda *_: None):
+            with patch.object(GetConcepts, "append_dishes_to_concept", fake_append):
+                response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        dishes = payload.get("dishes", [])
+        self.assertEqual(len(dishes), len(new_dish_payloads))
+
+        for dish_payload, source in zip(dishes, new_dish_payloads):
+            self.assertEqual(
+                set(dish_payload.keys()),
+                {"id", "name", "reasoning", "ingredients", "price", "image_url"},
+            )
+            self.assertEqual(dish_payload["name"], source["title"])
+            self.assertEqual(dish_payload["reasoning"], source["description"])
+            self.assertEqual(dish_payload["ingredients"], source["ingredient_overlap"])
+            self.assertEqual(dish_payload["price"], source["suggested_price"])
+            self.assertEqual(dish_payload["image_url"], source["image_url"])
+
+        total_dishes = Dish.objects.filter(concept=concept).count()
+        self.assertEqual(total_dishes, 1 + len(new_dish_payloads))


### PR DESCRIPTION
## Summary
- add a POST endpoint that appends freshly generated dishes to an existing concept and returns normalized dish fields
- register the new URL and enhance the swipe template with a “Get more dishes” control and client-side insertion logic
- cover the endpoint with a transaction test that verifies the response payload and dish count growth

## Testing
- pytest tests/test_concept_append_dishes_api.py

------
https://chatgpt.com/codex/tasks/task_e_68efe9bfd00483329869852c4e022a33