### PR TITLE
Refresh auth templates with new home styling

### DIFF
--- a/app/templates/auth/base.html
+++ b/app/templates/auth/base.html
@@ -1,21 +1,38 @@
 {% extends "layouts/auth.html" %}
 
 {% block content %}
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 space-y-4">
-    <h1 class="text-3xl font-bold text-center text-[#2E005D]">{% block auth_title %}{% endblock %}</h1>
-    {% if error %}
-      <div class="rounded-xl bg-red-50 border border-red-200 text-red-700 px-4 py-3 text-sm">
-        {{ error }}
+  <div class="relative isolate w-full max-w-3xl px-4">
+    <div class="absolute -top-40 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-gradient-to-r from-[#a78bfa]/40 to-[#ec4899]/40 blur-[120px]"></div>
+    <div class="absolute -bottom-24 right-0 h-64 w-64 rounded-full bg-[#ec4899]/20 blur-[120px]"></div>
+    <div class="absolute -bottom-32 left-0 h-52 w-52 rounded-full bg-[#38bdf8]/10 blur-[100px]"></div>
+
+    <div class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 backdrop-blur-2xl shadow-2xl p-10 md:p-12 space-y-8">
+      <div class="space-y-4 text-center">
+        <span class="text-xs uppercase tracking-[0.6em] text-slate-400">Appertivo</span>
+        <h1 class="text-3xl md:text-4xl font-light text-slate-100">{% block auth_title %}{% endblock %}</h1>
+        <p class="text-sm text-slate-400 max-w-md mx-auto">Curate signature menus, coordinate your team, and elevate every service.</p>
       </div>
-    {% endif %}
-    <form method="post" class="space-y-4">
-      {% csrf_token %}
-      {% block form_fields %}{% endblock %}
-      <button type="submit"
-              class="w-full bg-gradient-to-r from-[#FF8300] to-[#FF5C00] text-white font-semibold py-3 rounded-xl shadow-md hover:scale-105 transition">
-        {% block submit_label %}Continue{% endblock %}
-      </button>
-    </form>
-    {% block auth_footer %}{% endblock %}
+
+      {% if error %}
+        <div class="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {{ error }}
+        </div>
+      {% endif %}
+
+      <form method="post" class="space-y-5">
+        {% csrf_token %}
+        <div class="space-y-5">
+          {% block form_fields %}{% endblock %}
+        </div>
+        <button type="submit"
+                class="w-full rounded-full bg-gradient-to-r from-[#a78bfa] via-[#8b5cf6] to-[#ec4899] px-6 py-3 text-base font-medium text-white shadow-[0_20px_45px_rgba(59,130,246,0.25)] transition hover:translate-y-[-2px] hover:shadow-[0_24px_55px_rgba(147,51,234,0.35)] focus:outline-none focus:ring-2 focus:ring-[#a78bfa]/70">
+          {% block submit_label %}Continue{% endblock %}
+        </button>
+      </form>
+
+      <div class="text-center text-sm text-slate-400">
+        {% block auth_footer %}{% endblock %}
+      </div>
+    </div>
   </div>
 {% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -6,21 +6,22 @@
 
 {% block form_fields %}
   <div>
-    <label class="block text-sm font-medium text-slate-700">Email</label>
+    <label class="block text-sm font-medium text-slate-200">Email</label>
     <input type="email" name="email" value="{{ form_data.email }}" required autofocus
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
   <div>
-    <label class="block text-sm font-medium text-slate-700">Password</label>
+    <label class="block text-sm font-medium text-slate-200">Password</label>
     <input type="password" name="password" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
 {% endblock %}
 
 {% block submit_label %}Log In{% endblock %}
 
 {% block auth_footer %}
-  <p class="text-center text-sm text-slate-600">
-    Don’t have an account? <a href="{% url 'signup' %}" class="text-[#5C008B] font-semibold hover:underline">Sign up</a>
-  </p>
+  Don’t have an account?
+  <a href="{% url 'signup' %}" class="font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#a78bfa] to-[#ec4899] hover:opacity-80">
+    Sign up
+  </a>
 {% endblock %}

--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -12,40 +12,41 @@
 
 {% block form_fields %}
   <div>
-    <label class="block text-sm font-medium text-slate-700">Email</label>
+    <label class="block text-sm font-medium text-slate-200">Email</label>
     <input type="email" name="email" value="{{ form_data.email }}" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
   <div>
-    <label class="block text-sm font-medium text-slate-700">Password</label>
+    <label class="block text-sm font-medium text-slate-200">Password</label>
     <input type="password" name="password1" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
   <div>
-    <label class="block text-sm font-medium text-slate-700">Confirm Password</label>
+    <label class="block text-sm font-medium text-slate-200">Confirm Password</label>
     <input type="password" name="password2" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
   <div>
-    <label class="block text-sm font-medium text-slate-700">Restaurant Name</label>
+    <label class="block text-sm font-medium text-slate-200">Restaurant Name</label>
     <input type="text" name="restaurant_name" value="{{ form_data.restaurant_name }}" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
   <div>
-    <label class="block text-sm font-medium text-slate-700">Location</label>
+    <label class="block text-sm font-medium text-slate-200">Location</label>
     <input type="text" name="location" value="{{ form_data.location }}" required
-           class="mt-1 w-full rounded-xl border border-slate-300 px-4 py-2 focus:ring-2 focus:ring-[#FF8300] focus:border-[#FF8300] outline-none">
+           class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-900/50 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-transparent focus:ring-2 focus:ring-[#a78bfa]/60 focus:outline-none">
   </div>
-  <p class="text-xs text-slate-500">We'll grab the public details for your restaurant automatically after signup.</p>
+  <p class="text-xs text-slate-400">We'll grab the public details for your restaurant automatically after signup.</p>
   <input type="hidden" name="recaptcha_token" id="recaptcha_token">
 {% endblock %}
 
 {% block submit_label %}Sign Up{% endblock %}
 
 {% block auth_footer %}
-  <p class="text-center text-sm text-slate-600">
-    Already have an account? <a href="{% url 'login' %}" class="text-[#5C008B] font-semibold hover:underline">Log in</a>
-  </p>
+  Already have an account?
+  <a href="{% url 'login' %}" class="font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#a78bfa] to-[#ec4899] hover:opacity-80">
+    Log in
+  </a>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/app/templates/layouts/auth.html
+++ b/app/templates/layouts/auth.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
-{% block body_class %}bg-gradient-to-br from-[#2E005D] via-[#5C008B] to-[#8E008B] min-h-screen flex flex-col{% endblock %}
+{% block body_class %}min-h-screen bg-gradient-to-b from-[#0b1220] via-[#0f172a] to-[#111c34] text-slate-100 flex flex-col overflow-hidden{% endblock %}
 
-{% block main_class %}flex-1 flex items-center justify-center px-4 py-12{% endblock %}
+{% block main_class %}relative flex-1 flex items-center justify-center px-4 py-16{% endblock %}


### PR DESCRIPTION
## Summary
- align the authentication layout background with the new dark gradient aesthetic
- restyle the shared auth container to introduce glassmorphism, gradients, and updated messaging
- update login and signup fields, buttons, and links to match the new home page visual language

## Testing
- not run (styling-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f01c9d4adc8332b01c45c0af010566