### PR TITLE
Add swipe settings page with creativity slider placeholder

### DIFF
--- a/swipe/templates/swipe/settings.html
+++ b/swipe/templates/swipe/settings.html
@@ -1,0 +1,213 @@
+{% extends "swipe/base.html" %}
+{% load static %}
+
+{% block title %}
+  {% if restaurant %}{{ restaurant.name }} · Settings{% else %}Appertivo · Settings{% endif %}
+{% endblock %}
+
+{% block head %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@500;600;700&display=swap"
+    rel="stylesheet"
+  >
+  <style>
+    body {
+      background: radial-gradient(circle at 10% 20%, #1f2937 0%, rgba(15, 23, 42, 0.95) 55%, #0b1120 100%);
+      min-height: 100vh;
+      color: #e2e8f0;
+      font-family: 'Inter', sans-serif;
+      overflow-x: hidden;
+    }
+
+    .settings-card {
+      border-radius: 1.75rem;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      background: rgba(15, 23, 42, 0.65);
+      box-shadow: 0 32px 80px -48px rgba(8, 11, 19, 0.95);
+      backdrop-filter: saturate(140%) blur(12px);
+      padding: clamp(1.75rem, 3vw, 2.5rem);
+    }
+
+    .settings-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 100%;
+      height: 0.65rem;
+      border-radius: 9999px;
+      background: linear-gradient(90deg, rgba(185, 147, 214, 0.25), rgba(88, 176, 156, 0.35));
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      outline: none;
+      position: relative;
+    }
+
+    .settings-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 1.35rem;
+      height: 1.35rem;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #fcd34d, #f97316 65%, #7c2d12 100%);
+      border: 2px solid rgba(15, 23, 42, 0.9);
+      box-shadow: 0 12px 18px -8px rgba(249, 115, 22, 0.6);
+      cursor: pointer;
+    }
+
+    .settings-slider::-moz-range-thumb {
+      width: 1.35rem;
+      height: 1.35rem;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #fcd34d, #f97316 65%, #7c2d12 100%);
+      border: 2px solid rgba(15, 23, 42, 0.9);
+      box-shadow: 0 12px 18px -8px rgba(249, 115, 22, 0.6);
+      cursor: pointer;
+    }
+
+    .settings-label {
+      font-size: 0.72rem;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.85);
+    }
+
+    .settings-heading {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(1.75rem, 4vw, 2.8rem);
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: rgba(248, 250, 252, 0.92);
+    }
+
+    .info-grid {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    @media (min-width: 640px) {
+      .info-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .info-item {
+      border-radius: 1.25rem;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      background: rgba(15, 23, 42, 0.55);
+      padding: 1.1rem 1.25rem;
+    }
+
+    .info-item h4 {
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.32em;
+      color: rgba(226, 232, 240, 0.75);
+      margin-bottom: 0.4rem;
+    }
+
+    .info-item p,
+    .info-item a {
+      font-size: 0.95rem;
+      color: rgba(226, 232, 240, 0.9);
+      text-decoration: none;
+      word-break: break-word;
+    }
+
+    .info-item a:hover {
+      color: rgba(94, 234, 212, 0.95);
+    }
+
+    .description {
+      border-radius: 1.35rem;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(15, 23, 42, 0.5);
+      padding: 1.5rem 1.75rem;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.85);
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="max-w-5xl mx-auto px-6 pb-20 space-y-12">
+    <header class="settings-card flex flex-col sm:flex-row sm:items-end sm:justify-between gap-6">
+      <div class="space-y-3">
+        <p class="settings-label">Control Center</p>
+        <h1 class="settings-heading">Settings</h1>
+        <p class="max-w-xl text-sm text-slate-300">
+          Tune how inventive our ideas should feel and review the essentials we know about this restaurant.
+        </p>
+      </div>
+      <div class="text-sm text-slate-400 uppercase tracking-[0.35em]">
+        {% if restaurant %}
+          Updated {{ restaurant.updated_at|date:"M j, Y" }}
+        {% else %}
+          Awaiting restaurant data
+        {% endif %}
+      </div>
+    </header>
+
+    <section class="settings-card space-y-6">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold tracking-[0.3em] uppercase text-slate-100">Creativity Balance</h2>
+          <p class="text-sm text-slate-400">Slide between classic comfort and bold experimentation. (Coming soon)</p>
+        </div>
+        <div class="text-sm font-semibold tracking-[0.3em] uppercase text-amber-300">50 / 100</div>
+      </div>
+      <div class="space-y-3">
+        <div class="flex justify-between text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">
+          <span>Classic</span>
+          <span>Creative</span>
+        </div>
+        <input type="range" min="0" max="100" value="50" class="settings-slider">
+      </div>
+    </section>
+
+    <section class="settings-card space-y-8">
+      {% if restaurant %}
+        <div class="space-y-3">
+          <p class="settings-label">Restaurant Overview</p>
+          <h2 class="text-2xl font-semibold tracking-[0.24em] uppercase text-slate-100">{{ restaurant.name }}</h2>
+        </div>
+
+        <div class="info-grid">
+          {% if restaurant.location_text %}
+            <div class="info-item">
+              <h4>Location</h4>
+              <p>{{ restaurant.location_text }}</p>
+            </div>
+          {% endif %}
+          {% if restaurant.phone %}
+            <div class="info-item">
+              <h4>Phone</h4>
+              <p>{{ restaurant.phone }}</p>
+            </div>
+          {% endif %}
+          {% if restaurant.website %}
+            <div class="info-item">
+              <h4>Website</h4>
+              <a href="{{ restaurant.website }}" target="_blank" rel="noopener">{{ restaurant.website }}</a>
+            </div>
+          {% endif %}
+          {% if restaurant.google_place_id %}
+            <div class="info-item">
+              <h4>Google Place ID</h4>
+              <p>{{ restaurant.google_place_id }}</p>
+            </div>
+          {% endif %}
+        </div>
+
+        {% if restaurant.description %}
+          <div class="description">
+            {{ restaurant.description }}
+          </div>
+        {% endif %}
+      {% else %}
+        <div class="text-sm text-slate-300">
+          We do not have a restaurant selected yet. Once one is chosen, its key details will appear here.
+        </div>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}

--- a/swipe/urls.py
+++ b/swipe/urls.py
@@ -7,6 +7,7 @@ app_name = "swipe"
 urlpatterns = [
     path("", SwipeHomeView.as_view(), name="home"),
     path("favorites/", FavoritesView.as_view(), name="favorites"),
+    path("settings/", SettingsView.as_view(), name="settings"),
     path("generate-concepts/<uuid:restaurant_id>/", generate_concepts_view, name="generate_concepts"),
     path(
         "api/concepts/<int:concept_id>/dishes/",

--- a/swipe/views.py
+++ b/swipe/views.py
@@ -423,6 +423,25 @@ class FavoritesView(TemplateView):
         return context
 
 
+class SettingsView(TemplateView):
+    template_name = "swipe/settings.html"
+
+    def get_restaurant(self):
+        restaurant_id = self.kwargs.get("restaurant_id") or self.request.GET.get("restaurant_id")
+        if restaurant_id:
+            try:
+                return get_object_or_404(Restaurant, id=restaurant_id)
+            except (TypeError, ValueError):
+                logger.warning("Invalid restaurant_id supplied: %s", restaurant_id)
+        return Restaurant.objects.order_by("-created_at").first()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        restaurant = self.get_restaurant()
+        context.update({"restaurant": restaurant})
+        return context
+
+
 class MarkSeenAPI(LoginRequiredMixin, View):
     def post(self, request):
         import json


### PR DESCRIPTION
## Summary
- add a swipe settings view that surfaces the active restaurant to templates
- create a swipe settings page with the new creativity balance slider styling and restaurant overview cards
- register the settings route so the page is accessible from the swipe app URLs

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'onboarding')*

------
https://chatgpt.com/codex/tasks/task_e_68f02b23fa3883329d4054451d2b409e