### PR TITLE
Fix swipe card back background coverage

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -103,7 +103,17 @@
       padding: 0;
       position: relative;
       min-height: 0;
+      background: #0f172a;
+      isolation: isolate;
+    }
+
+    .card-back::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
       background: linear-gradient(180deg, rgba(15, 23, 42, 0.35) 0%, rgba(15, 23, 42, 0.85) 80%, rgba(8, 11, 19, 0.95) 100%);
+      z-index: 0;
     }
 
     .card-back > * {


### PR DESCRIPTION
## Summary
- ensure swipe card backs always render a full-coverage gradient by moving the background to a pseudo-element
- add a solid base color and isolate the stacking context so front images cannot bleed through when flipped

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: missing database tables in the ephemeral environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0e899ad5483328f548d6e44cca5ab