### PR TITLE
Center favorites concept grid and align card widths

### DIFF
--- a/swipe/templates/swipe/favorites.html
+++ b/swipe/templates/swipe/favorites.html
@@ -23,8 +23,12 @@
 
     .concept-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(0, 320px));
       gap: 1rem;
+      justify-content: center;
+      max-width: 1024px;
+      margin: 0 auto;
+      width: 100%;
     }
 
     @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- center the favorites concept grid within the page layout
- limit grid width and column sizing so cards match the swipe view proportions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1060c30d883329f1ba690eee397b5