### PR TITLE
Align swipe card backs to fill layout

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -132,9 +132,9 @@
       overscroll-behavior: contain;
       padding: 2.75rem 2rem 2rem;
       gap: 1.5rem;
-      justify-content: center;
-      align-items: center;
-      text-align: center;
+      justify-content: space-between;
+      align-items: stretch;
+      text-align: left;
     }
 
     .card-back-body {
@@ -144,6 +144,7 @@
       flex-direction: column;
       gap: 0.85rem;
       overflow-y: auto;
+      align-items: flex-start;
     }
 
     .card-back-title {
@@ -190,6 +191,8 @@
       flex-wrap: wrap;
       gap: 0.5rem;
       padding-top: 0.25rem;
+      justify-content: center;
+      text-align: center;
     }
 
     .tag-chip {


### PR DESCRIPTION
## Summary
- align swipe card back content so text runs top-to-bottom without crowding corner controls
- let the body section expand while centering the tag row to preserve typography

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1166bd3448332b2213c7772d00761