### PR TITLE
Restrict card back positioning to content container

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -116,7 +116,7 @@
       z-index: 0;
     }
 
-    .card-back > * {
+    .card-back > .card-back-content {
       position: relative;
       z-index: 1;
     }


### PR DESCRIPTION
## Summary
- limit the `.card-back > *` selector to `.card-back-content` so floating buttons remain absolutely positioned on the back face

## Testing
- python manage.py runserver 0.0.0.0:8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68f1166052f08332be0229ac6f9bd0df