### PR TITLE
Filter deleted swipe concepts and dishes

### DIFF
--- a/swipe/views.py
+++ b/swipe/views.py
@@ -59,12 +59,15 @@ class SwipeHomeView(TemplateView):
 
         if restaurant:
             concept_qs = (
-                Concept.objects.filter(restaurant=restaurant)
+                Concept.objects.filter(
+                    restaurant=restaurant,
+                    is_deleted=False,
+                )
                 .order_by("-created_at")
                 .prefetch_related(
                     Prefetch(
                         "dishes",
-                        queryset=Dish.objects.filter().order_by("id"),
+                        queryset=Dish.objects.filter(is_deleted=False).order_by("id"),
                     )
                 )
             )


### PR DESCRIPTION
## Summary
- update the swipe index view to ignore concepts marked as deleted
- limit the prefetched dishes for swipe cards to only active dishes

## Testing
- python manage.py test swipe

------
https://chatgpt.com/codex/tasks/task_e_68f11a1d5a8483329ae15ca8da0ef4f4