### PR TITLE
Add concept title overlays to concept cards

### DIFF
--- a/swipe/templates/swipe/favorites.html
+++ b/swipe/templates/swipe/favorites.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@500;600;700&family=Shadows+Into+Light&display=swap"
     rel="stylesheet"
   >
   <style>
@@ -52,6 +52,26 @@
       cursor: pointer;
       transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
       outline: none;
+    }
+
+    .card-note {
+      position: absolute;
+      top: 1.1rem;
+      left: 1.1rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 0.65rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.55);
+      font-family: 'Shadows Into Light', cursive;
+      font-size: clamp(0.95rem, 2.2vw, 1.15rem);
+      color: rgba(248, 250, 252, 0.92);
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+      max-width: 75%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      z-index: 2;
+      pointer-events: none;
     }
 
     .concept-card:focus-visible {
@@ -510,6 +530,7 @@
           >
             {% with concept_image=group.concept.display_sketch_url concept_placeholder="https://placehold.co/600x600?text=Concept" %}
               <div class="concept-thumb">
+                <span class="card-note">{{ group.concept.name }}</span>
                 <img
                   src="{{ concept_image }}"
                   alt="{{ group.concept.name }} concept sketch"

--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@500;600;700&family=Shadows+Into+Light&display=swap"
     rel="stylesheet"
   >
   <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
@@ -45,6 +45,26 @@
     .card:focus-visible {
       outline: 2px solid rgba(248, 250, 252, 0.65);
       outline-offset: 4px;
+    }
+
+    .card-note {
+      position: absolute;
+      top: 1.1rem;
+      left: 1.1rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 0.65rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.55);
+      font-family: 'Shadows Into Light', cursive;
+      font-size: clamp(0.95rem, 2.2vw, 1.15rem);
+      color: rgba(248, 250, 252, 0.92);
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+      max-width: 75%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      z-index: 2;
+      pointer-events: none;
     }
 
     .card-inner {
@@ -609,6 +629,7 @@
                     <div class="card-inner">
                       {% with concept_image=concept.display_sketch_url concept_placeholder="https://placehold.co/1200x800?text=Concept" %}
                       <div class="card-face card-front" style="background-image: url('{{ concept_image }}');">
+                        <span class="card-note">{{ concept.name }}</span>
                         <img
                           src="{{ concept_image }}"
                           alt="{{ concept.name }} concept sketch"


### PR DESCRIPTION
## Summary
- add handwritten-style note overlay showing concept names on swipe cards
- mirror the handwritten concept name overlay for favorites concept thumbnails
- load a handwritten font on both views to support the new note styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1212c77608332b8e0b5d53ba432d0