### PR TITLE
Align swipe card text to bottom

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -152,7 +152,7 @@
       overscroll-behavior: contain;
       padding: 2.75rem 2rem 2rem;
       gap: 1.5rem;
-      justify-content: space-between;
+      justify-content: flex-end;
       align-items: stretch;
       text-align: left;
     }


### PR DESCRIPTION
## Summary
- adjust the swipe card layout so card text is aligned toward the bottom of its container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f124a4a6508332892b5f9c1ad0970e