### PR TITLE
Adjust card back content spacing

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -150,11 +150,12 @@
       height: 100%;
       width: 100%;
       overscroll-behavior: contain;
-      padding: 2.75rem 2rem 2rem;
+      padding: 4.5rem 2rem 2rem;
       gap: 1.5rem;
-      justify-content: flex-end;
+      justify-content: space-between;
       align-items: stretch;
       text-align: left;
+      box-sizing: border-box;
     }
 
     .card-back-body {


### PR DESCRIPTION
## Summary
- extend the card back content padding so the dark blue panel fills the card while leaving room for the top action buttons
- use a space-between layout and border-box sizing so the body and tags distribute across the full height without overlapping the controls

## Testing
- not run (not needed for CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1267549148332a8b1fe547e3850a4