### PR TITLE
Fix spacing on swipe card back layout

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -152,10 +152,14 @@
       overscroll-behavior: contain;
       padding: 4.5rem 2rem 2rem;
       gap: 1.5rem;
-      justify-content: space-between;
+      justify-content: flex-start;
       align-items: stretch;
       text-align: left;
       box-sizing: border-box;
+    }
+
+    .card-back-content [data-load-dishes] {
+      margin-top: auto;
     }
 
     .card-back-body {


### PR DESCRIPTION
## Summary
- align the swipe card back column to start so trailing gaps disappear
- let the load dishes button take up remaining space to keep the context flush with the bottom edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f12a48198c8332a53eabfdd887f226