### PR TITLE
Ensure concept card back gradient covers full card

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -156,6 +156,7 @@
       align-items: stretch;
       text-align: left;
       box-sizing: border-box;
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.78) 0%, rgba(8, 11, 19, 0.96) 100%);
     }
 
     .card-back-content [data-load-dishes] {


### PR DESCRIPTION
## Summary
- add a full-height gradient background to the concept card back content container so empty areas are visually covered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f13343a0d88332ac677cc5ce1108be