### PR TITLE
Fix seen API payload parsing and badge styling

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -31,7 +31,7 @@
       backdrop-filter: saturate(140%) blur(8px);
       perspective: 1600px;
       cursor: pointer;
-      overflow: hidden;
+      overflow: visible;
       height: min(64vh, calc(100vh - 15rem));
       margin-bottom: 1.5rem;
     }
@@ -651,7 +651,7 @@
                         hx-encoding="json"
                         hx-swap="outerHTML"
                       >
-                        New Arrival
+                        New
                       </div>
                     {% endif %}
                     <div class="card-inner">
@@ -667,7 +667,7 @@
                             hx-encoding="json"
                             hx-swap="outerHTML"
                           >
-                            New Arrival
+                            New
                           </span>
                         {% endif %}
                         <span class="card-note">{{ concept.name }}</span>
@@ -744,35 +744,35 @@
                       tabindex="0"
                       role="button"
                     >
-                      {% if not dish.is_seen %}
-                        <div
-                          class="new-badge"
-                          hx-post="{% url 'swipe:mark_seen' %}"
-                          hx-trigger="revealed delay:3s"
-                          hx-vals='{"type":"dish","id":"{{ dish.id }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token|escapejs }}", "Content-Type": "application/json"}'
-                          hx-encoding="json"
-                          hx-swap="outerHTML"
-                        >
-                          New Arrival
-                        </div>
-                      {% endif %}
+                    {% if not dish.is_seen %}
+                      <div
+                        class="new-badge"
+                        hx-post="{% url 'swipe:mark_seen' %}"
+                        hx-trigger="revealed delay:3s"
+                        hx-vals='{"type":"dish","id":"{{ dish.id }}"}'
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token|escapejs }}", "Content-Type": "application/json"}'
+                        hx-encoding="json"
+                        hx-swap="outerHTML"
+                      >
+                        New
+                      </div>
+                    {% endif %}
                       <div class="card-inner">
                         {% with dish_image=dish.display_image_url dish_placeholder="https://placehold.co/800x600?text=Dish" %}
                         <div class="card-face card-front" style="background-image: url('{{ dish_image }}');">
-                          {% if not dish.is_seen %}
-                            <span
-                              class="new-badge"
-                              hx-post="{% url 'swipe:mark_seen' %}"
-                              hx-trigger="revealed delay:3s"
-                              hx-vals='{"type":"dish","id":"{{ dish.id }}"}'
-                              hx-headers='{"X-CSRFToken": "{{ csrf_token|escapejs }}", "Content-Type": "application/json"}'
-                              hx-encoding="json"
-                              hx-swap="outerHTML"
-                            >
-                              New Arrival
-                            </span>
-                          {% endif %}
+                        {% if not dish.is_seen %}
+                          <span
+                            class="new-badge"
+                            hx-post="{% url 'swipe:mark_seen' %}"
+                            hx-trigger="revealed delay:3s"
+                            hx-vals='{"type":"dish","id":"{{ dish.id }}"}'
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token|escapejs }}", "Content-Type": "application/json"}'
+                            hx-encoding="json"
+                            hx-swap="outerHTML"
+                          >
+                            New
+                          </span>
+                        {% endif %}
                           <img
                             src="{{ dish_image }}"
                             alt="{{ dish.name }} presentation"
@@ -901,7 +901,7 @@
 
       const badge = document.createElement('span');
       badge.className = 'new-badge';
-      badge.textContent = 'New Arrival';
+      badge.textContent = 'New';
       badge.setAttribute('hx-post', markSeenEndpoint);
       badge.setAttribute('hx-trigger', 'revealed delay:3s');
       badge.setAttribute('hx-swap', 'outerHTML');

--- a/swipe/views.py
+++ b/swipe/views.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse, QueryDict
 from django.db.models import Prefetch
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -252,10 +252,20 @@ class DeleteCardAPI(LoginRequiredMixin, View):
     def post(self, request):
         import json
 
-        try:
-            payload = json.loads(request.body.decode("utf-8"))
-        except json.JSONDecodeError:
-            return HttpResponseBadRequest("Invalid JSON payload")
+        body = request.body.decode("utf-8").strip()
+        payload = {}
+
+        if body:
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                payload = QueryDict(body).dict()
+
+        if not payload:
+            payload = request.POST.dict()
+
+        if not payload:
+            return HttpResponseBadRequest("Invalid payload")
 
         type_ = payload.get("type")
         item_id = payload.get("id")
@@ -418,10 +428,20 @@ class MarkSeenAPI(View):
     def post(self, request):
         import json
 
-        try:
-            payload = json.loads(request.body.decode("utf-8"))
-        except json.JSONDecodeError:
-            return HttpResponseBadRequest("Invalid JSON payload")
+        body = request.body.decode("utf-8").strip()
+        payload = {}
+
+        if body:
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                payload = QueryDict(body).dict()
+
+        if not payload:
+            payload = request.POST.dict()
+
+        if not payload:
+            return HttpResponseBadRequest("Invalid payload")
 
         type_ = payload.get("type")
         item_id = payload.get("id")


### PR DESCRIPTION
## Summary
- allow the swipe card badge to render fully above the card and shorten the label to “New”
- tolerate non-JSON HTMX payloads when marking concepts and dishes as seen to stop 400 errors

## Testing
- pytest tests/test_swipe_seen.py

------
https://chatgpt.com/codex/tasks/task_e_68f132e16a248332b774dcb3e3ad5300