### PR TITLE
Add chevron button to load more dishes

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -234,6 +234,10 @@
       border: 1px solid rgba(148, 163, 184, 0.2);
     }
 
+    .hidden {
+      display: none !important;
+    }
+
     .touch-area {
       display: block;
       position: fixed;
@@ -270,6 +274,89 @@
     .horizontal-track .card {
       flex: 0 0 100%;
       margin-bottom: 0;
+    }
+
+    .load-more-chevron {
+      position: relative;
+      flex: 0 0 auto;
+      width: 3.25rem;
+      border-radius: 1.5rem;
+      border: 1px solid rgba(244, 114, 182, 0.45);
+      background: linear-gradient(180deg, #f472b6 0%, #ec4899 100%);
+      box-shadow: 0 22px 45px -28px rgba(236, 72, 153, 0.85);
+      color: #fff;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 0;
+      height: 100%;
+      min-height: 10rem;
+      transition: transform 0.2s ease, box-shadow 0.3s ease;
+      animation: chevronPulse 2.6s ease-in-out infinite;
+    }
+
+    .load-more-chevron::before {
+      content: '';
+      position: absolute;
+      inset: 0.35rem;
+      border-radius: inherit;
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      opacity: 0.65;
+      pointer-events: none;
+    }
+
+    .load-more-chevron svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      transition: transform 0.2s ease;
+    }
+
+    .load-more-chevron:hover svg,
+    .load-more-chevron:focus-visible svg {
+      transform: translateX(2px);
+    }
+
+    .load-more-chevron[data-loading='true'] {
+      animation: none;
+      opacity: 0.8;
+      box-shadow: 0 12px 32px -20px rgba(236, 72, 153, 0.75);
+    }
+
+    .load-more-chevron[data-loading='true'] svg {
+      opacity: 0;
+    }
+
+    .load-chevron-spinner {
+      position: absolute;
+      width: 1.2rem;
+      height: 1.2rem;
+      border-radius: 9999px;
+      border: 2px solid rgba(255, 255, 255, 0.8);
+      border-top-color: transparent;
+      animation: spin 0.75s linear infinite;
+    }
+
+    .load-more-chevron:focus-visible {
+      outline: 2px solid rgba(248, 250, 252, 0.8);
+      outline-offset: 4px;
+    }
+
+    @keyframes chevronPulse {
+      0%,
+      100% {
+        box-shadow: 0 22px 45px -28px rgba(236, 72, 153, 0.85), 0 0 0 0 rgba(236, 72, 153, 0.35);
+      }
+
+      50% {
+        box-shadow: 0 28px 52px -24px rgba(236, 72, 153, 0.95), 0 0 0 12px rgba(236, 72, 153, 0);
+      }
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     .heart-btn {
@@ -757,6 +844,20 @@
                       <p class="text-slate-200/80 text-center tracking-[0.25em] uppercase">No dishes generated yet for this concept.</p>
                     </div>
                   {% endfor %}
+                  <button
+                    type="button"
+                    class="load-more-chevron"
+                    aria-label="Get more dishes for {{ concept.name }}"
+                    data-load-dishes
+                    data-concept-id="{{ concept.id }}"
+                    data-concept-index="{{ forloop.counter0 }}"
+                    data-endpoint="{% url 'swipe:concept_append_dishes' concept.id %}"
+                  >
+                    <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
+                    </svg>
+                    <span class="load-chevron-spinner hidden" data-spinner aria-hidden="true"></span>
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a gradient chevron button at the end of each concept's dish row to request more dishes
- introduce supporting styles for the new control, including pulse animation and loading spinner handling

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f147836f5083329ad1e5f70850fe03