### PR TITLE
Ensure load-more chevron is reachable at row end

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -234,6 +234,10 @@
       border: 1px solid rgba(148, 163, 184, 0.2);
     }
 
+    .hidden {
+      display: none !important;
+    }
+
     .touch-area {
       display: block;
       position: fixed;
@@ -270,6 +274,105 @@
     .horizontal-track .card {
       flex: 0 0 100%;
       margin-bottom: 0;
+    }
+
+    .load-more-chevron {
+      flex: 0 0 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      height: 100%;
+    }
+
+    .load-more-chevron-inner {
+      position: relative;
+      width: 3.25rem;
+      min-height: 10rem;
+      height: 100%;
+      border-radius: 1.5rem;
+      border: 1px solid rgba(244, 114, 182, 0.45);
+      background: linear-gradient(180deg, #f472b6 0%, #ec4899 100%);
+      box-shadow: 0 22px 45px -28px rgba(236, 72, 153, 0.85);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.2s ease, box-shadow 0.3s ease;
+      animation: chevronPulse 2.6s ease-in-out infinite;
+    }
+
+    .load-more-chevron-inner::before {
+      content: '';
+      position: absolute;
+      inset: 0.35rem;
+      border-radius: inherit;
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      opacity: 0.65;
+      pointer-events: none;
+    }
+
+    .load-more-chevron svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      transition: transform 0.2s ease;
+    }
+
+    .load-more-chevron:hover svg,
+    .load-more-chevron:focus-visible svg {
+      transform: translateX(2px);
+    }
+
+    .load-more-chevron[data-loading='true'] .load-more-chevron-inner {
+      animation: none;
+      opacity: 0.85;
+      box-shadow: 0 12px 32px -20px rgba(236, 72, 153, 0.75);
+    }
+
+    .load-more-chevron[data-loading='true'] svg {
+      opacity: 0;
+    }
+
+    .load-chevron-spinner {
+      position: absolute;
+      width: 1.2rem;
+      height: 1.2rem;
+      border-radius: 9999px;
+      border: 2px solid rgba(255, 255, 255, 0.8);
+      border-top-color: transparent;
+      animation: spin 0.75s linear infinite;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    .load-more-chevron:focus-visible {
+      outline: none;
+    }
+
+    .load-more-chevron:focus-visible .load-more-chevron-inner {
+      outline: 2px solid rgba(248, 250, 252, 0.8);
+      outline-offset: 4px;
+    }
+
+    @keyframes chevronPulse {
+      0%,
+      100% {
+        box-shadow: 0 22px 45px -28px rgba(236, 72, 153, 0.85), 0 0 0 0 rgba(236, 72, 153, 0.35);
+      }
+
+      50% {
+        box-shadow: 0 28px 52px -24px rgba(236, 72, 153, 0.95), 0 0 0 12px rgba(236, 72, 153, 0);
+      }
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     .heart-btn {
@@ -757,6 +860,22 @@
                       <p class="text-slate-200/80 text-center tracking-[0.25em] uppercase">No dishes generated yet for this concept.</p>
                     </div>
                   {% endfor %}
+                  <button
+                    type="button"
+                    class="load-more-chevron"
+                    aria-label="Get more dishes for {{ concept.name }}"
+                    data-load-dishes
+                    data-concept-id="{{ concept.id }}"
+                    data-concept-index="{{ forloop.counter0 }}"
+                    data-endpoint="{% url 'swipe:concept_append_dishes' concept.id %}"
+                  >
+                    <span class="load-more-chevron-inner">
+                      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
+                      </svg>
+                      <span class="load-chevron-spinner hidden" data-spinner aria-hidden="true"></span>
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1243,8 +1362,9 @@
           return;
         }
         const dishCount = dishCounts[currentConceptIndex] || 0;
+        const maxIndex = dishCount + 1;
         const newIndex = currentDishIndex + direction;
-        if (newIndex >= 0 && newIndex <= dishCount) {
+        if (newIndex >= 0 && newIndex <= maxIndex) {
           currentDishIndex = newIndex;
           updateHorizontalPosition();
           updatePositionIndicator();
@@ -1333,11 +1453,14 @@
         }
 
         const dishCount = dishCounts[currentConceptIndex] || 0;
-        const currentCard = currentDishIndex + 1;
+        const maxIndex = dishCount + 1;
 
         if (currentDishIndex === 0) {
           indicator.textContent = `${currentConceptIndex + 1} / ${totalConcepts}`;
+        } else if (currentDishIndex === maxIndex) {
+          indicator.textContent = `${currentConceptIndex + 1}.+ / ${totalConcepts}`;
         } else {
+          const currentCard = currentDishIndex + 1;
           indicator.textContent = `${currentConceptIndex + 1}.${currentCard} / ${totalConcepts}`;
         }
       }
@@ -1357,6 +1480,7 @@
         }
 
         const dishCount = dishCounts[currentConceptIndex] || 0;
+        const maxIndex = dishCount + 1;
         const isOnConceptCard = currentDishIndex === 0;
 
         if (navVerticalUp) {
@@ -1370,7 +1494,7 @@
           navHorizontalLeft.disabled = currentDishIndex === 0;
         }
         if (navHorizontalRight) {
-          navHorizontalRight.disabled = currentDishIndex >= dishCount;
+          navHorizontalRight.disabled = currentDishIndex >= maxIndex;
         }
       }
 
@@ -1540,8 +1664,9 @@
           const diffX = touchStartX - touchEndX;
 
           const dishCount = dishCounts[currentConceptIndex] || 0;
+          const maxIndex = dishCount + 1;
           const isOnConceptCard = currentDishIndex === 0;
-          const canGoRight = currentDishIndex < dishCount;
+          const canGoRight = currentDishIndex < maxIndex;
           const canGoLeft = currentDishIndex > 0;
 
           if (Math.abs(diffX) > Math.abs(diffY)) {


### PR DESCRIPTION
## Summary
- restyle the load-more chevron so it occupies a full slider slot while keeping a tall gradient inner control
- adjust navigation, indicator, and touch logic to treat the chevron as the final slide, making it reachable when users advance to the end of the row

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68f147836f5083329ad1e5f70850fe03