### PR TITLE
Adjust concept card note styling

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -55,13 +55,12 @@
       position: absolute;
       top: 1.1rem;
       left: 1.1rem;
-      padding: 0.35rem 0.75rem;
-      border-radius: 0.65rem;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.55);
+      padding: 0;
+      border: none;
+      background: none;
       font-family: 'Shadows Into Light', cursive;
       font-size: clamp(0.95rem, 2.2vw, 1.15rem);
-      color: rgba(248, 250, 252, 0.92);
+      color: #475569;
       letter-spacing: 0.04em;
       white-space: nowrap;
       max-width: 75%;


### PR DESCRIPTION
## Summary
- update the front-facing concept card note styling to remove the background and use a slate text color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f14d3659c08332bd1523340e8d80a7