### PR TITLE
Add dish variation endpoint and interface controls

### DIFF
--- a/swipe/llm_utils.py
+++ b/swipe/llm_utils.py
@@ -21,6 +21,7 @@ import logging
 import uuid
 logger = logging.getLogger(__name__)
 import json
+from typing import Any, Dict, Optional, Union
 
 class GetConcepts:
     """
@@ -524,6 +525,140 @@ class GetConcepts:
             },
                 }
         return schema
+
+    def single_dish_schema(self) -> Dict[str, Any]:
+        """Schema for a single structured dish variation."""
+
+        return {
+            "name": "dish_variation",
+            "type": "json_schema",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "dish": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "description": {"type": "string"},
+                            "suggested_price": {"type": "string"},
+                            "ingredient_overlap": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1,
+                            },
+                            "category_tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1,
+                            },
+                        },
+                        "required": [
+                            "title",
+                            "description",
+                            "ingredient_overlap",
+                            "category_tags",
+                            "suggested_price",
+                        ],
+                        "additionalProperties": False,
+                    }
+                },
+                "required": ["dish"],
+                "additionalProperties": False,
+            },
+        }
+
+    async def generate_dish_variation(self, dish: Union[Dish, int]) -> Dict[str, Any]:
+        """Generate and persist a single variation for the given dish."""
+
+        if isinstance(dish, Dish):
+            dish_obj = dish
+        else:
+            dish_obj = await asyncio.to_thread(
+                Dish.objects.select_related("concept__restaurant").get,
+                pk=dish,
+            )
+
+        concept_obj = dish_obj.concept
+        concept_payload = self._normalize_concept(concept_obj)
+
+        raw_ingredients = dish_obj.ingredients or []
+        if isinstance(raw_ingredients, str):
+            raw_ingredients = [raw_ingredients]
+        base_ingredients = [str(item) for item in raw_ingredients][:5]
+
+        dish_details = {
+            "title": dish_obj.name,
+            "description": dish_obj.reasoning or "",
+            "suggested_price": dish_obj.price or "",
+            "ingredient_overlap": base_ingredients,
+        }
+
+        restaurant_context = await self._get_restaurant_context()
+        restaurant_name = getattr(concept_obj.restaurant, "name", "") if concept_obj.restaurant_id else ""
+
+        prompt = (
+            "You are a culinary R&D assistant creating one menu-ready dish variation.\n"
+            f"Restaurant: {restaurant_name or 'Unknown restaurant'}\n"
+            f"Concept: {concept_payload.get('title', '')} — {concept_payload.get('subtitle', '')}\n"
+            f"Concept reasoning: {concept_payload.get('reasoning', '')}\n"
+            f"Restaurant context: {restaurant_context or 'No additional context.'}\n\n"
+            "Original dish details:\n"
+            f"- Name: {dish_details['title']}\n"
+            f"- Description: {dish_details['description']}\n"
+            f"- Suggested price: {dish_details['suggested_price'] or 'N/A'}\n"
+            f"- Ingredient overlap: {', '.join(base_ingredients) or 'None'}\n\n"
+            "Create one variation that keeps the spirit of the concept, reuses at least two of the ingredients listed,"
+            " and describes plating, flavor, or preparation changes in 40-60 words."
+        )
+
+        variation_payload: Optional[Dict[str, Any]] = None
+
+        if self.openai_client:
+            try:
+                response = await self.openai_client.responses.create(
+                    model="gpt-4.1-mini",
+                    input=prompt,
+                    text={"format": self.single_dish_schema()},
+                )
+                content = response.output[0].content[0].text if response.output else ""
+                data = json.loads(content) if content else {}
+                variation_payload = data.get("dish")
+            except Exception as exc:  # pragma: no cover - network guard
+                logger.warning("Dish variation generation failed: %s", exc)
+                variation_payload = None
+
+        if not variation_payload:
+            fallback_ingredients = base_ingredients or [concept_payload.get("title", "concept").lower()]
+            fallback_description = (
+                f"A refreshed take on {dish_details['title']} that keeps "
+                f"{', '.join(fallback_ingredients[:2])} at the center while aligning with "
+                f"{concept_payload.get('subtitle') or concept_payload.get('title', 'the concept')}"
+            )
+            variation_payload = {
+                "title": f"{dish_details['title']} Remix",
+                "description": fallback_description,
+                "suggested_price": dish_details["suggested_price"] or dish_obj.price or "$24",
+                "ingredient_overlap": fallback_ingredients,
+                "category_tags": [
+                    "variation",
+                    concept_payload.get("title", "concept"),
+                    "menu",
+                ],
+            }
+
+        ingredients_value = variation_payload.get("ingredient_overlap", [])
+        if isinstance(ingredients_value, str):
+            ingredients_value = [ingredients_value]
+        variation_payload["ingredient_overlap"] = [str(item) for item in ingredients_value][:5]
+
+        tags_value = variation_payload.get("category_tags", [])
+        if isinstance(tags_value, str):
+            tags_value = [tags_value]
+        variation_payload["category_tags"] = [str(item) for item in tags_value][:4]
+
+        saved = await self._save_dishes(concept_obj, [variation_payload])
+        return saved[0] if saved else {}
 
     async def _generate_dishes_for_concept(self, concept):
         concept_payload = self._normalize_concept(concept)

--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -299,6 +299,19 @@
       stroke: #ef4444;
     }
 
+    .variation-btn {
+      transition: transform 0.2s;
+    }
+
+    .variation-btn:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+    }
+
+    .variation-btn[data-loading="true"] svg {
+      animation: spin 0.9s linear infinite;
+    }
+
     .intro-overlay {
       position: fixed;
       inset: 0;
@@ -802,6 +815,18 @@
                             </svg>
                           </button>
                           <button type="button"
+                                  class="variation-btn absolute top-5 right-20 rounded-full border border-slate-100/40 bg-slate-900/60 p-3 shadow-lg z-10"
+                                  data-prevent-flip
+                                  data-variation-endpoint="{% url 'swipe:dish_variation' dish.id %}"
+                                  data-concept-id="{{ concept.id }}"
+                                  data-dish-id="{{ dish.id }}"
+                                  aria-label="Generate variation for {{ dish.name }}">
+                            <svg class="w-5 h-5 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4.5 9.75A7.5 7.5 0 0119.5 8m0 0v4m0-4h-4" />
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M19.5 14.25a7.5 7.5 0 01-15 1.75m0 0v-4m0 4h4" />
+                            </svg>
+                          </button>
+                          <button type="button"
                                   class="heart-btn absolute top-5 right-5 rounded-full border border-slate-100/40 bg-slate-900/60 p-3 shadow-lg z-10 {% if dish.is_favorite %}favorited{% endif %}"
                                   data-prevent-flip
                                   onclick="toggleFavorite(this, 'dish', '{{ dish.id }}')"
@@ -945,6 +970,10 @@
       return document.querySelector(`.horizontal-track[data-concept-index="${index}"]`);
     }
 
+    function getTrackByConceptId(conceptId) {
+      return document.querySelector(`.horizontal-track[data-concept-track="${conceptId}"]`);
+    }
+
     function getConceptIdByIndex(index) {
       const track = getTrackByConceptIndex(index);
       return track ? track.dataset.conceptTrack : null;
@@ -1070,13 +1099,14 @@
       }
     }
 
-    function createDishCard(dish) {
+    function createDishCard(dish, conceptId) {
       const card = document.createElement('div');
       card.className = 'card w-full';
       card.setAttribute('data-card', '');
       card.setAttribute('tabindex', '0');
       card.setAttribute('role', 'button');
       const dishId = dish.id ?? '';
+      const effectiveConceptId = conceptId ?? dish.concept_id ?? null;
 
       const shouldMarkSeen = dishId && (dish.is_seen === false || typeof dish.is_seen === 'undefined');
       if (shouldMarkSeen) {
@@ -1121,6 +1151,25 @@
       deleteButton.setAttribute('aria-label', `Delete ${dish.name || 'dish'}`);
       deleteButton.innerHTML = '<svg class="w-6 h-6 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 7h12M10 11v6m4-6v6m-7 4h10a1 1 0 001-1V7H6v13a1 1 0 001 1zm3-17h4l1 2H8l1-2z"></path></svg>';
       back.appendChild(deleteButton);
+
+      const variationEndpoint = dish.variation_endpoint;
+      if (variationEndpoint) {
+        const variationButton = document.createElement('button');
+        variationButton.type = 'button';
+        variationButton.className = 'variation-btn absolute top-5 right-20 rounded-full border border-slate-100/40 bg-slate-900/60 p-3 shadow-lg z-10';
+        variationButton.setAttribute('data-prevent-flip', '');
+        variationButton.dataset.variationEndpoint = variationEndpoint;
+        if (effectiveConceptId !== null && effectiveConceptId !== undefined) {
+          variationButton.dataset.conceptId = String(effectiveConceptId);
+        }
+        if (dishId) {
+          variationButton.dataset.dishId = String(dishId);
+        }
+        variationButton.setAttribute('aria-label', `Generate variation for ${dish.name || 'dish'}`);
+        variationButton.innerHTML = '<svg class="w-5 h-5 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4.5 9.75A7.5 7.5 0 0119.5 8m0 0v4m0-4h-4"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M19.5 14.25a7.5 7.5 0 01-15 1.75m0 0v-4m0 4h4"></path></svg>';
+        back.appendChild(variationButton);
+        attachVariationHandler(variationButton);
+      }
 
       const heartButton = document.createElement('button');
       heartButton.type = 'button';
@@ -1326,6 +1375,101 @@
       let currentConceptIndex = 0;
       let currentDishIndex = 0;
 
+      function attachVariationHandler(button) {
+        if (!button || button.dataset.variationReady === 'true') {
+          return;
+        }
+
+        button.dataset.variationReady = 'true';
+
+        button.addEventListener('click', async (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (button.dataset.loading === 'true') {
+            return;
+          }
+
+          const endpoint = button.dataset.variationEndpoint;
+          const conceptId = button.dataset.conceptId;
+          if (!endpoint || !conceptId) {
+            return;
+          }
+
+          const track = getTrackByConceptId(conceptId);
+          if (!track) {
+            return;
+          }
+
+          getConceptState(conceptId);
+
+          button.dataset.loading = 'true';
+          button.setAttribute('data-loading', 'true');
+          button.disabled = true;
+          button.setAttribute('aria-busy', 'true');
+
+          try {
+            const response = await fetch(endpoint, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken,
+              },
+              body: JSON.stringify({}),
+            });
+
+            if (!response.ok) {
+              throw new Error(`Request failed with status ${response.status}`);
+            }
+
+            const payload = await response.json();
+            const dish = payload?.dish;
+            if (!dish) {
+              throw new Error('Missing dish payload');
+            }
+
+            const targetConceptId = dish.concept_id ?? conceptId;
+            const card = createDishCard(dish, targetConceptId);
+            initializeCard(card);
+            track.appendChild(card);
+
+            if (window.htmx) {
+              window.htmx.process(card);
+            }
+
+            const conceptIndex = Number.parseInt(track.dataset.conceptIndex || '-1', 10);
+            if (conceptIndex >= 0) {
+              const currentCount = Number.isInteger(dishCounts[conceptIndex])
+                ? dishCounts[conceptIndex]
+                : 0;
+              dishCounts[conceptIndex] = currentCount + 1;
+
+              if (conceptIndex === currentConceptIndex) {
+                currentDishIndex = dishCounts[conceptIndex];
+                updateHorizontalPosition();
+                updatePositionIndicator();
+                updateNavigationButtons();
+              }
+            }
+
+            if (conceptIndex === currentConceptIndex && typeof card.focus === 'function') {
+              card.focus({ preventScroll: false });
+            }
+          } catch (error) {
+            console.error('Failed to fetch variation:', error);
+          } finally {
+            button.removeAttribute('aria-busy');
+            delete button.dataset.loading;
+            button.removeAttribute('data-loading');
+            button.disabled = false;
+          }
+        });
+      }
+
+      document.querySelectorAll('[data-variation-endpoint]').forEach((button) => {
+        attachVariationHandler(button);
+      });
+
       function createLoadingCard() {
         const card = document.createElement('div');
         card.className = 'card w-full flex items-center justify-center';
@@ -1388,7 +1532,7 @@
         }
 
         const dish = state.buffer.shift();
-        const card = createDishCard(dish);
+        const card = createDishCard(dish, conceptId);
         initializeCard(card);
         const track = placeholder.closest('.horizontal-track');
         placeholder.replaceWith(card);

--- a/swipe/urls.py
+++ b/swipe/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
         ConceptDishAppendView.as_view(),
         name="concept_append_dishes",
     ),
+    path(
+        "api/dishes/<int:dish_id>/variation/",
+        DishVariationView.as_view(),
+        name="dish_variation",
+    ),
     path("api/seen/", MarkSeenAPI.as_view(), name="mark_seen"),
     path("api/favorite/", ToggleFavoriteAPI.as_view(), name="api_favorite"),
     path("api/delete/", DeleteCardAPI.as_view(), name="delete_card"),

--- a/swipe/views.py
+++ b/swipe/views.py
@@ -7,6 +7,7 @@ from django.db.models import Prefetch
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView, View
+from django.urls import reverse
 from app.llm import *
 from app.models import Restaurant
 # Stub imports for future service integration
@@ -198,9 +199,21 @@ class ConceptDishAppendView(View):
             if isinstance(ingredients, str):
                 ingredients = [ingredients]
 
+            dish_id = dish.get("id")
+            concept_pk = dish.get("concept_id") or concept.id
+            try:
+                concept_pk_int = int(concept_pk)
+            except (TypeError, ValueError):
+                concept_pk_int = concept_pk
+
+            variation_endpoint = ""
+            if dish_id:
+                variation_endpoint = reverse("swipe:dish_variation", args=[dish_id])
+
             response_payload.append(
                 {
-                    "id": dish.get("id"),
+                    "id": dish_id,
+                    "concept_id": concept_pk_int,
                     "name": dish.get("title") or dish.get("name") or "",
                     "reasoning": dish.get("description")
                     or dish.get("reasoning")
@@ -209,10 +222,83 @@ class ConceptDishAppendView(View):
                     "price": dish.get("suggested_price") or dish.get("price") or "",
                     "image_url": dish.get("image_url") or "",
                     "is_seen": dish.get("is_seen", False),
+                    "variation_endpoint": variation_endpoint,
                 }
             )
 
         return JsonResponse({"dishes": response_payload})
+
+
+class DishVariationView(View):
+    """Generate a new variation for an existing dish."""
+
+    def post(self, request, dish_id: int):
+        dish = get_object_or_404(
+            Dish.objects.select_related("concept__restaurant").filter(
+                is_deleted=False,
+                concept__is_deleted=False,
+            ),
+            pk=dish_id,
+        )
+
+        concept = dish.concept
+        restaurant = concept.restaurant
+        generator = GetConcepts(
+            restaurant=restaurant,
+            restaurant_context=restaurant.context,
+        )
+
+        try:
+            saved_payload = asyncio.run(generator.generate_dish_variation(dish))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Failed to generate variation for dish %s: %s", dish_id, exc)
+            return JsonResponse(
+                {"error": "Unable to generate dish variation."},
+                status=500,
+            )
+
+        if not saved_payload:
+            return JsonResponse(
+                {"error": "No variation generated."},
+                status=500,
+            )
+
+        ingredients = (
+            saved_payload.get("ingredient_overlap")
+            or saved_payload.get("ingredients")
+            or []
+        )
+        if isinstance(ingredients, str):
+            ingredients = [ingredients]
+
+        dish_id_value = saved_payload.get("id")
+        concept_id_value = saved_payload.get("concept_id") or concept.id
+        try:
+            concept_id_int = int(concept_id_value)
+        except (TypeError, ValueError):
+            concept_id_int = concept_id_value
+
+        variation_endpoint = ""
+        if dish_id_value:
+            variation_endpoint = reverse("swipe:dish_variation", args=[dish_id_value])
+
+        response_payload = {
+            "id": dish_id_value,
+            "concept_id": concept_id_int,
+            "name": saved_payload.get("title") or saved_payload.get("name") or "",
+            "reasoning": saved_payload.get("description")
+            or saved_payload.get("reasoning")
+            or "",
+            "ingredients": ingredients,
+            "price": saved_payload.get("suggested_price")
+            or saved_payload.get("price")
+            or "",
+            "image_url": saved_payload.get("image_url") or "",
+            "is_seen": saved_payload.get("is_seen", False),
+            "variation_endpoint": variation_endpoint,
+        }
+
+        return JsonResponse({"dish": response_payload})
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/tests/test_concept_append_dishes_api.py
+++ b/tests/test_concept_append_dishes_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from asgiref.sync import sync_to_async
 from django.test import TransactionTestCase
@@ -88,7 +88,7 @@ class ConceptAppendDishesAPITests(TransactionTestCase):
 
         url = reverse("swipe:concept_append_dishes", args=[concept.id])
 
-        with patch.object(GetConcepts, "_load_locale", lambda *_: None):
+        with patch.object(GetConcepts, "_load_locale", AsyncMock(return_value=None)):
             with patch.object(GetConcepts, "append_dishes_to_concept", fake_append):
                 response = self.client.post(url)
 
@@ -103,12 +103,14 @@ class ConceptAppendDishesAPITests(TransactionTestCase):
                 set(dish_payload.keys()),
                 {
                     "id",
+                    "concept_id",
                     "name",
                     "reasoning",
                     "ingredients",
                     "price",
                     "image_url",
                     "is_seen",
+                    "variation_endpoint",
                 },
             )
             self.assertEqual(dish_payload["name"], source["title"])
@@ -117,6 +119,11 @@ class ConceptAppendDishesAPITests(TransactionTestCase):
             self.assertEqual(dish_payload["price"], source["suggested_price"])
             self.assertEqual(dish_payload["image_url"], source["image_url"])
             self.assertFalse(dish_payload["is_seen"])
+            self.assertEqual(dish_payload["concept_id"], concept.id)
+            self.assertEqual(
+                dish_payload["variation_endpoint"],
+                reverse("swipe:dish_variation", args=[dish_payload["id"]]),
+            )
 
         total_dishes = Dish.objects.filter(concept=concept).count()
         self.assertEqual(total_dishes, 1 + len(new_dish_payloads))

--- a/tests/test_dish_variation_api.py
+++ b/tests/test_dish_variation_api.py
@@ -1,0 +1,73 @@
+from django.test import TransactionTestCase
+from django.urls import reverse
+
+from app.models import Account, Restaurant
+from swipe.models import Concept, Dish
+
+
+class DishVariationAPITests(TransactionTestCase):
+    def setUp(self):
+        self.account = Account.objects.create(name="Account")
+        self.restaurant = Restaurant.objects.create(
+            account=self.account,
+            name="Variation Test Restaurant",
+            location_text="Test City",
+        )
+        self.concept = Concept.objects.create(
+            restaurant=self.restaurant,
+            name="Garden Evenings",
+            subtitle="Herbal comfort",
+            meta_ingredients=["herb"],
+            meta_reasoning="Fresh herb-forward dishes.",
+        )
+        self.dish = Dish.objects.create(
+            concept=self.concept,
+            name="Herb Roast",
+            reasoning="Roasted poultry with garden herbs.",
+            ingredients=["thyme", "rosemary", "garlic"],
+            price="$18",
+            image_url="https://example.com/herb.jpg",
+        )
+
+    def test_variation_endpoint_creates_dish_and_returns_payload(self):
+        url = reverse("swipe:dish_variation", args=[self.dish.id])
+        initial_count = Dish.objects.filter(concept=self.concept).count()
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        dish_payload = payload.get("dish")
+        self.assertIsInstance(dish_payload, dict)
+
+        self.assertEqual(
+            set(dish_payload.keys()),
+            {
+                "id",
+                "concept_id",
+                "name",
+                "reasoning",
+                "ingredients",
+                "price",
+                "image_url",
+                "is_seen",
+                "variation_endpoint",
+            },
+        )
+        self.assertEqual(dish_payload["concept_id"], self.concept.id)
+        self.assertFalse(dish_payload["is_seen"])
+        self.assertTrue(dish_payload["name"])
+        self.assertTrue(dish_payload["reasoning"])
+        self.assertTrue(dish_payload["price"])
+        self.assertTrue(dish_payload["image_url"])
+        self.assertTrue(dish_payload["variation_endpoint"])
+        self.assertIsInstance(dish_payload["ingredients"], list)
+        self.assertTrue(dish_payload["ingredients"])
+        self.assertEqual(
+            dish_payload["variation_endpoint"],
+            reverse("swipe:dish_variation", args=[dish_payload["id"]]),
+        )
+
+        new_count = Dish.objects.filter(concept=self.concept).count()
+        self.assertEqual(new_count, initial_count + 1)
+        self.assertTrue(Dish.objects.filter(pk=dish_payload["id"]).exists())


### PR DESCRIPTION
## Summary
- extend GetConcepts with dish variation generation that reuses the saver helper
- expose an API endpoint for requesting dish variations and include variation links in dish payloads
- add variation controls to the swipe UI and cover the new API behaviour with tests

## Testing
- pytest tests/test_concept_append_dishes_api.py tests/test_dish_variation_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f27964c1b8833289052fada9ebb871