### PR TITLE
Improve floating controls responsiveness on swipe view

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -603,6 +603,40 @@
       background: rgba(15, 23, 42, 0.8);
     }
 
+    @media (max-width: 600px) {
+      .floating-controls {
+        width: calc(100% - 2rem);
+        bottom: 1.5rem;
+      }
+
+      .floating-controls-inner {
+        width: 100%;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      .floating-controls button {
+        width: 2.25rem;
+        height: 2.25rem;
+      }
+
+      .generate-btn,
+      .floating-controls button.generate-btn {
+        width: 2.6rem;
+        height: 2.6rem;
+      }
+
+      .floating-controls-indicator {
+        width: 100%;
+        text-align: center;
+        font-size: 0.75rem;
+        letter-spacing: 0.2em;
+        white-space: normal;
+      }
+    }
+
     @keyframes spin {
       from {
         transform: rotate(0deg);


### PR DESCRIPTION
## Summary
- adjust floating controls layout on the swipe page to better fit narrow screens
- allow buttons and indicator to wrap while reducing spacing and sizing under 600px width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f280af2f18833287d71ff224ef2c23