### PR TITLE
Lazy load swipe card media assets

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -740,15 +740,22 @@
                   >
                     <div class="card-inner">
                       {% with concept_image=concept.display_sketch_url concept_placeholder="https://placehold.co/1200x800?text=Concept" %}
-                      <div class="card-face card-front" style="background-image: url('{{ concept_image }}');">
+                      <div
+                        class="card-face card-front"
+                        style="background-image: none;"
+                        data-background-placeholder="{{ concept_placeholder }}"
+                        data-background-image="{{ concept_image }}"
+                      >
                         <span class="card-note">{{ concept.name }}</span>
                         <img
-                          src="{{ concept_image }}"
+                          src="{{ concept_placeholder }}"
+                          data-src="{{ concept_image }}"
+                          data-placeholder="{{ concept_placeholder }}"
                           alt="{{ concept.name }} concept sketch"
                           class="card-media"
                           decoding="async"
                           loading="lazy"
-                          onerror="this.onerror=null;this.src='{{ concept_placeholder }}';"
+                          onerror="this.onerror=null;const p=this.dataset.placeholder||'';if(p){this.src=p;const f=this.closest('.card-face');if(f){f.style.backgroundImage='url(' + p + ')';}}"
                         >
                       </div>
                       {% endwith %}
@@ -825,14 +832,21 @@
                     >
                       <div class="card-inner">
                         {% with dish_image=dish.display_image_url dish_placeholder="https://placehold.co/800x600?text=Dish" %}
-                        <div class="card-face card-front" style="background-image: url('{{ dish_image }}');">
+                        <div
+                          class="card-face card-front"
+                          style="background-image: none;"
+                          data-background-placeholder="{{ dish_placeholder }}"
+                          data-background-image="{{ dish_image }}"
+                        >
                           <img
-                            src="{{ dish_image }}"
+                            src="{{ dish_placeholder }}"
+                            data-src="{{ dish_image }}"
+                            data-placeholder="{{ dish_placeholder }}"
                             alt="{{ dish.name }} presentation"
                             class="card-media"
                             decoding="async"
                             loading="lazy"
-                            onerror="this.onerror=null;this.src='{{ dish_placeholder }}';"
+                            onerror="this.onerror=null;const p=this.dataset.placeholder||'';if(p){this.src=p;const f=this.closest('.card-face');if(f){f.style.backgroundImage='url(' + p + ')';}}"
                           >
                         </div>
                         {% endwith %}
@@ -985,6 +999,67 @@
     const dismissIntro = document.getElementById('dismissIntro');
     const DISH_PLACEHOLDER = 'https://placehold.co/800x600?text=Dish';
     const conceptStates = {};
+
+    function loadCardMedia(card) {
+      if (!card || card.dataset.mediaLoaded === 'true') {
+        return;
+      }
+
+      const front = card.querySelector('.card-face.card-front');
+      const backgroundUrl = front ? front.dataset.backgroundImage : undefined;
+      const backgroundPlaceholder = front ? front.dataset.backgroundPlaceholder : undefined;
+
+      if (front) {
+        if (backgroundUrl) {
+          front.style.backgroundImage = `url('${backgroundUrl}')`;
+        } else if (backgroundPlaceholder) {
+          front.style.backgroundImage = `url('${backgroundPlaceholder}')`;
+        }
+      }
+
+      const img = front ? front.querySelector('.card-media') : null;
+      if (img) {
+        const actualSrc = img.dataset.src;
+        if (actualSrc) {
+          img.src = actualSrc;
+          delete img.dataset.src;
+        } else if (backgroundPlaceholder && front) {
+          front.style.backgroundImage = `url('${backgroundPlaceholder}')`;
+        }
+      }
+
+      card.dataset.mediaLoaded = 'true';
+    }
+
+    let cardObserver = null;
+
+    if ('IntersectionObserver' in window) {
+      cardObserver = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              loadCardMedia(entry.target);
+              if (cardObserver) {
+                cardObserver.unobserve(entry.target);
+              }
+            }
+          });
+        },
+        { rootMargin: '200px 0px', threshold: 0.1 },
+      );
+    }
+
+    function observeCard(card) {
+      if (!card || card.dataset.mediaLoaded === 'true') {
+        return;
+      }
+
+      if (cardObserver) {
+        cardObserver.observe(card);
+      } else {
+        loadCardMedia(card);
+      }
+    }
 
     function getConceptState(conceptId) {
       if (!conceptId) {
@@ -1151,21 +1226,30 @@
       inner.className = 'card-inner';
       card.appendChild(inner);
 
-      const imageUrl = dish.image_url || DISH_PLACEHOLDER;
+      const imageUrl = dish.image_url || '';
       const front = document.createElement('div');
       front.className = 'card-face card-front';
-      front.style.backgroundImage = `url('${imageUrl}')`;
+      front.style.backgroundImage = 'none';
+      front.dataset.backgroundPlaceholder = DISH_PLACEHOLDER;
+      if (imageUrl) {
+        front.dataset.backgroundImage = imageUrl;
+      }
 
       const img = document.createElement('img');
-      img.src = imageUrl;
+      img.src = DISH_PLACEHOLDER;
+      img.dataset.placeholder = DISH_PLACEHOLDER;
+      if (imageUrl) {
+        img.dataset.src = imageUrl;
+      }
       img.alt = `${dish.name || 'Dish'} presentation`;
       img.className = 'card-media';
       img.decoding = 'async';
       img.loading = 'lazy';
       img.addEventListener('error', () => {
-        img.onerror = null;
-        img.src = DISH_PLACEHOLDER;
-        front.style.backgroundImage = `url('${DISH_PLACEHOLDER}')`;
+        const placeholder = img.dataset.placeholder || DISH_PLACEHOLDER;
+        img.src = placeholder;
+        front.style.backgroundImage = `url('${placeholder}')`;
+        delete img.dataset.src;
       });
 
       front.appendChild(img);
@@ -1300,6 +1384,7 @@
 
     document.querySelectorAll('[data-card]').forEach((card) => {
       initializeCard(card);
+      observeCard(card);
     });
 
     const getSlideHeight = () => {
@@ -1466,6 +1551,7 @@
             const card = createDishCard(dish, targetConceptId);
             initializeCard(card);
             track.appendChild(card);
+            observeCard(card);
 
             if (window.htmx) {
               window.htmx.process(card);
@@ -1570,6 +1656,7 @@
         initializeCard(card);
         const track = placeholder.closest('.horizontal-track');
         placeholder.replaceWith(card);
+        observeCard(card);
         state.placeholder = null;
 
         if (window.htmx) {


### PR DESCRIPTION
## Summary
- render concept and dish cards with placeholder imagery and defer real URLs into data attributes
- add an IntersectionObserver helper that swaps in the actual background and image sources when cards enter the viewport
- keep lazy-loading attributes and placeholder fallbacks for both server-rendered and dynamically added cards

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f29bfbe20c8332bb96625b1690332b