### PR TITLE
Adjust tower layout for responsive two-column view

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -82,25 +82,39 @@
     }
 
     .tower-view-container {
-      padding: 7rem 3rem 3rem;
+      padding: 6.5rem 2.75rem 3.25rem;
     }
 
     .tower-view {
       display: grid;
-      gap: 2rem;
-      grid-template-columns: minmax(220px, 320px) 1fr;
-      align-items: stretch;
-      max-width: 1200px;
+      gap: 2.5rem;
+      grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+      align-items: start;
+      max-width: 1280px;
       margin: 0 auto;
-      height: min(70vh, calc(100vh - 12rem));
+      width: 100%;
     }
 
     .tower-sidebar {
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
+      position: sticky;
+      top: 6rem;
+      max-height: calc(100vh - 8.5rem);
       overflow-y: auto;
-      padding-right: 0.5rem;
+      padding-right: 0.75rem;
+      margin-right: 0.5rem;
+      scrollbar-width: thin;
+    }
+
+    .tower-sidebar::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .tower-sidebar::-webkit-scrollbar-thumb {
+      background: rgba(148, 163, 184, 0.35);
+      border-radius: 9999px;
     }
 
     .tower-concept {
@@ -173,22 +187,32 @@
       border-radius: 24px;
       border: 1px solid rgba(148, 163, 184, 0.25);
       background: rgba(15, 23, 42, 0.45);
-      padding: 1.5rem 1.25rem;
+      padding: 1.5rem 1.5rem 1.75rem;
       display: flex;
       flex-direction: column;
       gap: 1.5rem;
+      min-height: calc(100vh - 8.5rem);
     }
 
     .tower-track {
-      height: 100%;
+      flex: 1;
+      min-height: 0;
+      display: flex;
     }
 
     .tower-track-inner {
       display: flex;
-      gap: 1.5rem;
+      gap: 1.75rem;
       overflow-x: auto;
-      padding-bottom: 0.5rem;
+      align-items: stretch;
+      padding: 0.5rem 0.75rem 1.25rem 0.25rem;
       scroll-snap-type: x proximity;
+    }
+
+    .tower-track-inner > .card {
+      flex: 0 0 clamp(240px, 28vw, 300px);
+      max-width: clamp(240px, 28vw, 300px);
+      scroll-snap-align: start;
     }
 
     .tower-track-inner::-webkit-scrollbar {
@@ -201,26 +225,54 @@
     }
 
     @media (max-width: 1024px) {
+      .tower-view-container {
+        padding: 6rem 2rem 2.75rem;
+      }
+
       .tower-view {
         grid-template-columns: minmax(0, 1fr);
-        height: auto;
+        gap: 1.75rem;
       }
 
       .tower-sidebar {
+        position: static;
+        top: auto;
+        max-height: none;
         flex-direction: row;
         overflow-x: auto;
         overflow-y: hidden;
-        padding-bottom: 0.5rem;
+        padding: 0 0 0.75rem;
+        margin-right: 0;
+        scroll-snap-type: x proximity;
+      }
+
+      .tower-sidebar::-webkit-scrollbar {
+        width: auto;
+        height: 6px;
       }
 
       .tower-concept {
-        min-width: 14rem;
+        min-width: 13rem;
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+      }
+
+      .tower-dish-area {
+        min-height: 0;
       }
     }
 
     @media (max-width: 640px) {
       .tower-view-container {
-        padding: 6rem 1.5rem 2.5rem;
+        display: none !important;
+      }
+
+      .view-toggle [data-view-option='tower'] {
+        display: none;
+      }
+
+      #swipeView.hidden {
+        display: block !important;
       }
 
       .tower-dish-area {


### PR DESCRIPTION
## Summary
- pin the tower concept list to the left of the layout with viewport-height scrolling
- tune the tower dish strip to show two to three cards at once with horizontal overflow
- add responsive breakpoints that stack the tower layout on tablets and hide it entirely on very small screens

## Testing
- Not run (CSS-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f2b29162308332b0eb582e1cc4afa9