### PR TITLE
Add creative balance controls to swipe pages

### DIFF
--- a/swipe/templates/swipe/index.html
+++ b/swipe/templates/swipe/index.html
@@ -1265,6 +1265,11 @@
         </div>
       </div>
     </div>
+    <div class="fixed inset-x-0 top-6 z-40 flex justify-center px-6 sm:px-0">
+      <div class="w-full max-w-md">
+        {% include "_partials/creative_balance_control.html" with action_url=update_creativity_url restaurant_settings=restaurant_settings section_classes="!bg-[#0f172a]/80 !border-slate-100/20 text-slate-100 shadow-xl" %}
+      </div>
+    </div>
     {% if not hide_restaurant_label %}
       <div class="fixed top-6 left-6 z-40 flex flex-col items-start gap-3">
         <div class="text-[0.7rem] tracking-[0.55em] uppercase text-slate-200/80">

--- a/swipe/templates/swipe/settings.html
+++ b/swipe/templates/swipe/settings.html
@@ -36,40 +36,6 @@
       padding: clamp(1.75rem, 3vw, 2.5rem);
     }
 
-    .settings-slider {
-      -webkit-appearance: none;
-      appearance: none;
-      width: 100%;
-      height: 0.65rem;
-      border-radius: 9999px;
-      background: linear-gradient(90deg, rgba(185, 147, 214, 0.25), rgba(88, 176, 156, 0.35));
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      outline: none;
-      position: relative;
-    }
-
-    .settings-slider::-webkit-slider-thumb {
-      -webkit-appearance: none;
-      appearance: none;
-      width: 1.35rem;
-      height: 1.35rem;
-      border-radius: 50%;
-      background: radial-gradient(circle at 30% 30%, #fcd34d, #f97316 65%, #7c2d12 100%);
-      border: 2px solid rgba(15, 23, 42, 0.9);
-      box-shadow: 0 12px 18px -8px rgba(249, 115, 22, 0.6);
-      cursor: pointer;
-    }
-
-    .settings-slider::-moz-range-thumb {
-      width: 1.35rem;
-      height: 1.35rem;
-      border-radius: 50%;
-      background: radial-gradient(circle at 30% 30%, #fcd34d, #f97316 65%, #7c2d12 100%);
-      border: 2px solid rgba(15, 23, 42, 0.9);
-      box-shadow: 0 12px 18px -8px rgba(249, 115, 22, 0.6);
-      cursor: pointer;
-    }
-
     .settings-label {
       font-size: 0.72rem;
       letter-spacing: 0.28em;
@@ -155,21 +121,8 @@
       </div>
     </header>
 
-    <section class="settings-card space-y-6">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 class="text-lg font-semibold tracking-[0.3em] uppercase text-slate-100">Creativity Balance</h2>
-          <p class="text-sm text-slate-400">Slide between classic comfort and bold experimentation. (Coming soon)</p>
-        </div>
-        <div class="text-sm font-semibold tracking-[0.3em] uppercase text-amber-300">50 / 100</div>
-      </div>
-      <div class="space-y-3">
-        <div class="flex justify-between text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">
-          <span>Classic</span>
-          <span>Creative</span>
-        </div>
-        <input type="range" min="0" max="100" value="50" class="settings-slider">
-      </div>
+    <section class="settings-card">
+      {% include "_partials/creative_balance_control.html" with action_url=update_creativity_url restaurant_settings=restaurant_settings section_classes="!bg-transparent !border-slate-100/20 !shadow-none text-slate-100" %}
     </section>
 
     <section class="settings-card space-y-8">

--- a/swipe/views.py
+++ b/swipe/views.py
@@ -10,10 +10,17 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView, View
 from django.urls import reverse
 from app.llm import *
-from app.models import Restaurant
+from app.models import Restaurant, RestaurantSettings
 # Stub imports for future service integration
 # from .services import generate_concepts_batch  # to be implemented
 from types import SimpleNamespace
+
+
+def _resolve_restaurant_settings(restaurant):
+    if not restaurant:
+        return SimpleNamespace(classic_creative_slider=50)
+    settings, _ = RestaurantSettings.objects.get_or_create(restaurant=restaurant)
+    return settings
 
 from swipe.llm_utils import GetConcepts
 from swipe.demo_data import build_demo_state
@@ -80,12 +87,18 @@ class SwipeHomeView(TemplateView):
             concepts = list(concept_qs)
 
         dish_counts = [len(list(c.dishes.all())) for c in concepts]
+        restaurant_settings = _resolve_restaurant_settings(restaurant)
+        update_creativity_url = (
+            reverse("update_creativity", args=[restaurant.id]) if restaurant else "#"
+        )
 
         context.update(
             {
                 "restaurant": restaurant,
                 "concepts": concepts,
                 "dish_counts": dish_counts,
+                "restaurant_settings": restaurant_settings,
+                "update_creativity_url": update_creativity_url,
             }
         )
         return context
@@ -108,6 +121,8 @@ class SwipeDemoView(SwipeHomeView):
             "buffers": {},
             "favorites": {"concept_ids": [], "dish_ids": []},
         }
+        context["restaurant_settings"] = SimpleNamespace(classic_creative_slider=50)
+        context["update_creativity_url"] = "#"
         return context
 
 
@@ -564,7 +579,17 @@ class SettingsView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         restaurant = self.get_restaurant()
-        context.update({"restaurant": restaurant})
+        restaurant_settings = _resolve_restaurant_settings(restaurant)
+        update_creativity_url = (
+            reverse("update_creativity", args=[restaurant.id]) if restaurant else "#"
+        )
+        context.update(
+            {
+                "restaurant": restaurant,
+                "restaurant_settings": restaurant_settings,
+                "update_creativity_url": update_creativity_url,
+            }
+        )
         return context
 
 
@@ -582,7 +607,14 @@ class DemoSettingsView(TemplateView):
             updated_at=None,
         )
 
-        context.update({"demo_mode": True, "restaurant": restaurant})
+        context.update(
+            {
+                "demo_mode": True,
+                "restaurant": restaurant,
+                "restaurant_settings": SimpleNamespace(classic_creative_slider=50),
+                "update_creativity_url": "#",
+            }
+        )
         return context
 
 

--- a/tests/test_swipe_creative_balance.py
+++ b/tests/test_swipe_creative_balance.py
@@ -1,0 +1,108 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Account, Restaurant, RestaurantSettings
+from swipe.views import SwipeDemoView
+
+
+class CreativeBalanceTests(TestCase):
+    def setUp(self):
+        self.account = Account.objects.create(name="Test Account")
+        self.restaurant = Restaurant.objects.create(
+            account=self.account,
+            name="Balance Bistro",
+            location_text="123 Flavor Street",
+        )
+        self.demo_restaurant = Restaurant.objects.create(
+            id=SwipeDemoView.DEMO_RESTAURANT_ID,
+            account=self.account,
+            name="Demo Data",
+            location_text="Demo City",
+        )
+
+    def test_home_view_includes_restaurant_settings(self):
+        RestaurantSettings.objects.create(
+            restaurant=self.restaurant, classic_creative_slider=77
+        )
+
+        response = self.client.get(
+            reverse("swipe:home"),
+            {"restaurant_id": str(self.restaurant.id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        context = response.context_data
+        self.assertEqual(
+            context["restaurant_settings"].classic_creative_slider,
+            77,
+        )
+        update_url = reverse("update_creativity", args=[self.restaurant.id])
+        self.assertEqual(context["update_creativity_url"], update_url)
+        self.assertIn(f'hx-post="{update_url}"', response.content.decode())
+
+    def test_creativity_value_persists_after_update(self):
+        self.assertFalse(
+            RestaurantSettings.objects.filter(restaurant=self.restaurant).exists()
+        )
+
+        update_url = reverse("update_creativity", args=[self.restaurant.id])
+        response = self.client.post(
+            update_url,
+            {"classic_creative_slider": 64},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(
+            reverse("swipe:home"),
+            {"restaurant_id": str(self.restaurant.id)},
+        )
+
+        context = response.context_data
+        self.assertEqual(
+            context["restaurant_settings"].classic_creative_slider,
+            64,
+        )
+
+    def test_settings_view_renders_creative_balance_control(self):
+        RestaurantSettings.objects.create(
+            restaurant=self.restaurant, classic_creative_slider=59
+        )
+
+        response = self.client.get(
+            reverse("swipe:settings"),
+            {"restaurant_id": str(self.restaurant.id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        context = response.context_data
+        self.assertEqual(
+            context["restaurant_settings"].classic_creative_slider,
+            59,
+        )
+        update_url = reverse("update_creativity", args=[self.restaurant.id])
+        html = response.content.decode()
+        self.assertIn("data-creative-balance", html)
+        self.assertIn(f'hx-post="{update_url}"', html)
+
+    def test_demo_views_provide_default_settings(self):
+        home_response = self.client.get(reverse("swipe:demo_home"))
+        settings_response = self.client.get(reverse("swipe:demo_settings"))
+
+        self.assertEqual(home_response.status_code, 200)
+        self.assertEqual(settings_response.status_code, 200)
+
+        home_context = home_response.context_data
+        settings_context = settings_response.context_data
+
+        self.assertEqual(
+            home_context["restaurant_settings"].classic_creative_slider,
+            50,
+        )
+        self.assertEqual(home_context["update_creativity_url"], "#")
+
+        self.assertEqual(
+            settings_context["restaurant_settings"].classic_creative_slider,
+            50,
+        )
+        self.assertEqual(settings_context["update_creativity_url"], "#")


### PR DESCRIPTION
## Summary
- ensure swipe and settings views always provide restaurant settings with sensible defaults
- surface the shared creative balance control on the swipe and settings templates
- add coverage confirming HTMX wiring and persistence of the creativity slider

## Testing
- python -m pytest tests/test_swipe_creative_balance.py

------
https://chatgpt.com/codex/tasks/task_e_68f50bdf6f98833297356683498d782f