### PR TITLE
Add creativity slider context to LLM prompts

### DIFF
--- a/swipe/llm_utils.py
+++ b/swipe/llm_utils.py
@@ -6,6 +6,7 @@ tests can run without network access.
 """
 
 import os
+import math
 import asyncio
 import threading
 import cloudinary
@@ -61,6 +62,8 @@ class GetConcepts:
         self.restaurant = restaurant
         self.restaurant_context = restaurant_context
         self.locale_summary = ""
+        self.creativity_slider_raw = self._determine_creativity_raw()
+        self.creativity_level = self._determine_creativity_level(self.creativity_slider_raw)
         # fire async task
         try:
             loop = asyncio.get_running_loop()
@@ -216,10 +219,48 @@ class GetConcepts:
         logger.info("Concept OpenAI response: %s", data)
         return data.get("concepts", [])
 
+    def _determine_creativity_raw(self) -> int:
+        """Return the restaurant's 0-100 creativity slider value with a safe default."""
+
+        slider_value: int = 50
+        if not self.restaurant:
+            return slider_value
+
+        try:
+            settings_obj = getattr(self.restaurant, "restaurantsettings")
+        except Exception:
+            settings_obj = None
+
+        candidate = getattr(settings_obj, "classic_creative_slider", None)
+        if candidate is None:
+            return slider_value
+
+        try:
+            numeric_candidate = int(candidate)
+        except (TypeError, ValueError):
+            return slider_value
+
+        return max(0, min(100, numeric_candidate))
+
+    @staticmethod
+    def _determine_creativity_level(raw_value: int) -> int:
+        """Convert a 0-100 slider into a 1-10 level."""
+
+        capped = max(0, min(100, int(raw_value or 0)))
+        level = math.ceil(capped / 10) if capped else 0
+        return max(1, min(10, level))
+
+    def _creativity_statement(self) -> str:
+        return (
+            f"The user has chosen {self.creativity_level} on a 1\N{EN DASH}10 classic-to-creative scale."
+        )
+
     def concept_prompt(self, restaurant_context: str):
         prompt = f"""
                 **Role**: You are a seasoned restaurant marketing consultant with deep knowledge of regional cuisines, seasonal ingredients, and cultural dining traditions.
                 **Task**: Generate exactly 3 unique, theme-based concepts for daily specials that emphasize regional flavors and seasonal ingredients.
+
+                Creativity preference: {self._creativity_statement()}
 
                 **Format Requirements for Each Concept**:
                 - **Name**: Maximum 30 characters
@@ -469,6 +510,8 @@ class GetConcepts:
             Restaurant Context:
             {restaurant_context}
 
+            Creativity preference: {self._creativity_statement()}
+
             Concept:
             {c["title"]} — {c.get("subtitle", "")}
             {c['reasoning']}
@@ -599,6 +642,7 @@ class GetConcepts:
 
         prompt = (
             "You are a culinary R&D assistant creating one menu-ready dish variation.\n"
+            f"{self._creativity_statement()}\n"
             f"Restaurant: {restaurant_name or 'Unknown restaurant'}\n"
             f"Concept: {concept_payload.get('title', '')} — {concept_payload.get('subtitle', '')}\n"
             f"Concept reasoning: {concept_payload.get('reasoning', '')}\n"

--- a/tests/test_swipe_llm_utils_creativity.py
+++ b/tests/test_swipe_llm_utils_creativity.py
@@ -1,0 +1,138 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from django.test import SimpleTestCase, TestCase
+
+from app import models
+from swipe.models import Concept, Dish
+from swipe.llm_utils import GetConcepts
+
+
+def _make_restaurant_namespace(slider_value: int) -> SimpleNamespace:
+    restaurant = SimpleNamespace(
+        id=1,
+        name="Test Bistro",
+        location_text="Testville",
+    )
+    restaurant.restaurantsettings = SimpleNamespace(classic_creative_slider=slider_value)
+    return restaurant
+
+
+class CreativityPromptUnitTests(SimpleTestCase):
+    def test_concept_prompt_includes_creativity_statement(self):
+        restaurant = _make_restaurant_namespace(75)
+
+        with patch.object(GetConcepts, "_load_locale", AsyncMock(return_value=None)):
+            helper = GetConcepts(restaurant=restaurant)
+
+        helper.openai_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=AsyncMock(
+                    return_value=SimpleNamespace(
+                        output=[
+                            SimpleNamespace(
+                                content=[
+                                    SimpleNamespace(text=json.dumps({"concepts": []}))
+                                ]
+                            )
+                        ]
+                    )
+                )
+            )
+        )
+
+        with patch.object(helper, "_get_restaurant_context", AsyncMock(return_value="Context")):
+            asyncio.run(helper._generate_concepts())
+
+        call_args = helper.openai_client.responses.create.call_args
+        system_prompt = call_args.kwargs["input"][0]["content"]
+
+        self.assertEqual(helper.creativity_slider_raw, 75)
+        self.assertEqual(helper.creativity_level, 8)
+        self.assertIn("The user has chosen 8 on a 1–10 classic-to-creative scale.", system_prompt)
+
+    def test_dish_prompt_includes_creativity_statement(self):
+        restaurant = _make_restaurant_namespace(65)
+
+        with patch.object(GetConcepts, "_load_locale", AsyncMock(return_value=None)):
+            helper = GetConcepts(restaurant=restaurant)
+
+        helper.openai_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=AsyncMock(
+                    return_value=SimpleNamespace(
+                        output=[
+                            SimpleNamespace(
+                                content=[
+                                    SimpleNamespace(text=json.dumps({"dishes": []}))
+                                ]
+                            )
+                        ]
+                    )
+                )
+            )
+        )
+
+        concept_payload = {
+            "title": "Cozy Night",
+            "subtitle": "Comfort classics",
+            "reasoning": "Comfort focus",
+            "tags": ["comfort"],
+        }
+
+        with patch.object(helper, "_get_restaurant_context", AsyncMock(return_value="Context")):
+            asyncio.run(helper._generate_dishes_for_concept(concept_payload))
+
+        call_args = helper.openai_client.responses.create.call_args
+        dish_prompt = call_args.kwargs["input"]
+
+        self.assertEqual(helper.creativity_slider_raw, 65)
+        self.assertEqual(helper.creativity_level, 7)
+        self.assertIn("The user has chosen 7 on a 1–10 classic-to-creative scale.", dish_prompt)
+
+
+class CreativityPromptIntegrationTests(TestCase):
+    def test_dish_variation_prompt_includes_creativity_statement(self):
+        account = models.Account.objects.create(name="Account")
+        restaurant = models.Restaurant.objects.create(
+            account=account,
+            name="Restaurant",
+            location_text="City",
+        )
+        models.RestaurantSettings.objects.create(
+            restaurant=restaurant,
+            classic_creative_slider=100,
+        )
+
+        concept = Concept.objects.create(
+            restaurant=restaurant,
+            name="Seasonal Concept",
+            subtitle="",
+        )
+
+        dish = Dish.objects.create(
+            concept=concept,
+            name="Autumn Roast",
+            reasoning="Rich and cozy.",
+            ingredients=["squash", "sage"],
+        )
+
+        with patch.object(GetConcepts, "_load_locale", AsyncMock(return_value=None)):
+            helper = GetConcepts(restaurant=restaurant)
+
+        helper.openai_client = SimpleNamespace(
+            responses=SimpleNamespace(create=AsyncMock(return_value=SimpleNamespace(output=[])))
+        )
+        helper._save_dishes = AsyncMock(return_value=[{"id": str(dish.id)}])
+        helper._get_restaurant_context = AsyncMock(return_value="Context")
+
+        asyncio.run(helper.generate_dish_variation(dish))
+
+        call_args = helper.openai_client.responses.create.call_args
+        variation_prompt = call_args.kwargs["input"]
+
+        self.assertEqual(helper.creativity_slider_raw, 100)
+        self.assertEqual(helper.creativity_level, 10)
+        self.assertIn("The user has chosen 10 on a 1–10 classic-to-creative scale.", variation_prompt)


### PR DESCRIPTION
## Summary
- derive a restaurant creativity level from the classic/creative slider and surface it on every concept and dish prompt
- add helper coverage ensuring concept, dish, and variation prompts include the creativity statement

## Testing
- pytest tests/test_swipe_llm_utils_creativity.py

------
https://chatgpt.com/codex/tasks/task_e_68f50be3d1b8833288dd22fd475c9222