### PR TITLE
Add Google Places capture to signup flow

### DIFF
--- a/app/billing.py
+++ b/app/billing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from decimal import Decimal, InvalidOperation
 from typing import Any
 from . import tasks
 from dotenv import load_dotenv
@@ -75,10 +76,34 @@ def create_checkout_session(request: HttpRequest, onboarding_id ) -> HttpRespons
 
     stripe.api_key = os.getenv("STRIPE_TEST_KEY")
     price_id = os.getenv("STRIPE_TEST_PRO")
+    metadata: dict[str, str] = {"onboarding_id": str(onboarding_id)}
+    place_details = {}
+    if hasattr(request, "session"):
+        place_details = (
+            request.session.get("signup_place_details", {}).get(str(onboarding_id), {})
+        )
+    if isinstance(place_details, dict) and place_details:
+        place_metadata = {
+            "place_id": place_details.get("place_id"),
+            "place_address": place_details.get("formatted_address"),
+            "place_lat": place_details.get("latitude"),
+            "place_lng": place_details.get("longitude"),
+            "place_phone": place_details.get("formatted_phone_number"),
+            "place_website": place_details.get("website"),
+        }
+        metadata.update(
+            {k: str(v) for k, v in place_metadata.items() if v not in (None, "")}
+        )
+        if getattr(request, "session", None) is not None:
+            details_store = request.session.get("signup_place_details", {})
+            details_store.pop(str(onboarding_id), None)
+            request.session["signup_place_details"] = details_store
+            request.session.modified = True
+
     try:
         session = stripe.checkout.Session.create(
             mode="subscription",
-            metadata={"onboarding_id": str(onboarding_id)},
+            metadata=metadata,
             line_items=[{"price": price_id, "quantity": 1}],
             subscription_data={
                 "trial_period_days": 14,
@@ -165,6 +190,53 @@ def stripe_webhook(request: HttpRequest) -> HttpResponse:
     if not onboarding_id:
         logger.warning(f"No onboarding_id found in metadata: {data_object.get('id')}")
         return HttpResponse()
+
+    metadata = data_object.get("metadata", {}) or {}
+    place_id = metadata.get("place_id", "").strip()
+    place_address = metadata.get("place_address", "").strip()
+    place_lat = metadata.get("place_lat", "").strip()
+    place_lng = metadata.get("place_lng", "").strip()
+    place_phone = metadata.get("place_phone", "").strip()
+    place_website = metadata.get("place_website", "").strip()
+
+    if any([place_id, place_address, place_lat, place_lng, place_phone, place_website]):
+        try:
+            onboarding = models.Onboarding.objects.select_related("restaurant").get(
+                uuid=onboarding_id
+            )
+        except models.Onboarding.DoesNotExist:
+            logger.warning("Onboarding %s not found for place metadata", onboarding_id)
+        else:
+            restaurant = onboarding.restaurant
+            if restaurant:
+                update_fields: list[str] = []
+                if place_id:
+                    restaurant.google_place_id = place_id
+                    update_fields.append("google_place_id")
+                if place_address:
+                    restaurant.location_text = place_address
+                    update_fields.append("location_text")
+                if place_phone:
+                    restaurant.phone = place_phone
+                    update_fields.append("phone")
+                if place_website:
+                    restaurant.website = place_website
+                    update_fields.append("website")
+                if place_lat:
+                    try:
+                        restaurant.latitude = Decimal(place_lat)
+                        update_fields.append("latitude")
+                    except (InvalidOperation, TypeError):
+                        logger.warning("Invalid latitude from metadata: %s", place_lat)
+                if place_lng:
+                    try:
+                        restaurant.longitude = Decimal(place_lng)
+                        update_fields.append("longitude")
+                    except (InvalidOperation, TypeError):
+                        logger.warning("Invalid longitude from metadata: %s", place_lng)
+
+                if update_fields:
+                    restaurant.save(update_fields=list(dict.fromkeys(update_fields)))
 
     logger.info(f"Stripe webhook onboarding_id: {onboarding_id}")
     run_onboarding_pipeline.delay(onboarding_id)

--- a/app/migrations/0007_restaurant_coordinates.py
+++ b/app/migrations/0007_restaurant_coordinates.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0006_newslettersubscriber"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="restaurant",
+            name="latitude",
+            field=models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True),
+        ),
+        migrations.AddField(
+            model_name="restaurant",
+            name="longitude",
+            field=models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True),
+        ),
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -89,6 +89,8 @@ class Restaurant(TimestampedModel):
     phone = models.TextField(null=True, blank=True)
     website = models.TextField(null=True, blank=True)
     google_place_id = models.TextField(null=True, blank=True)
+    latitude = models.DecimalField(max_digits=9, decimal_places=6, null=True, blank=True)
+    longitude = models.DecimalField(max_digits=9, decimal_places=6, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
     websearch_json = models.JSONField(null=True, blank=True)     # OPENAI Websearch 
     websearch_markdown = models.CharField(max_length=11128, blank=True)

--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -210,6 +210,7 @@
                 <p class="form-helper">We’ll pull public details to fine-tune the AI once you’re in.</p>
 
                 <input type="hidden" name="recaptcha_token" id="recaptcha_token">
+                <input type="hidden" name="place_details_json" id="place_details_json">
 
                 <button type="submit" class="btn btn-primary">
                     Start Your 14 Day Free Trial
@@ -227,6 +228,142 @@
 {% endblock %}
 
 {% block extra_scripts %}
+{% if GOOGLE_API_KEY %}
+<script>
+    (function() {
+        let autocomplete;
+        let sessionToken = null;
+        let placesService;
+        let lastDetails = null;
+
+        function ensureSessionToken() {
+            if (!sessionToken && window.google && google.maps && google.maps.places) {
+                sessionToken = new google.maps.places.AutocompleteSessionToken();
+                if (autocomplete) {
+                    autocomplete.setOptions({sessionToken: sessionToken});
+                }
+            }
+            return sessionToken;
+        }
+
+        function serializeDetails(details) {
+            if (!details) {
+                return null;
+            }
+            const geometry = details.geometry && details.geometry.location;
+            const lat = geometry && typeof geometry.lat === 'function' ? geometry.lat() : null;
+            const lng = geometry && typeof geometry.lng === 'function' ? geometry.lng() : null;
+            return {
+                place_id: details.place_id || '',
+                name: details.name || '',
+                formatted_address: details.formatted_address || '',
+                latitude: lat,
+                longitude: lng,
+                formatted_phone_number: details.formatted_phone_number || '',
+                website: details.website || '',
+                types: Array.isArray(details.types) ? details.types : [],
+            };
+        }
+
+        function updateHiddenField(value) {
+            const hiddenField = document.getElementById('place_details_json');
+            if (!hiddenField) {
+                return;
+            }
+            if (value) {
+                hiddenField.value = JSON.stringify(value);
+            } else {
+                hiddenField.value = '';
+            }
+        }
+
+        function handlePlaceSelection() {
+            const place = autocomplete.getPlace();
+            if (!place || !place.place_id) {
+                lastDetails = null;
+                updateHiddenField(null);
+                return;
+            }
+
+            const token = ensureSessionToken();
+            if (!placesService && window.google && google.maps) {
+                placesService = new google.maps.places.PlacesService(document.createElement('div'));
+            }
+            if (!placesService) {
+                return;
+            }
+
+            placesService.getDetails(
+                {
+                    placeId: place.place_id,
+                    sessionToken: token,
+                    fields: [
+                        'place_id',
+                        'name',
+                        'formatted_address',
+                        'geometry.location',
+                        'formatted_phone_number',
+                        'website',
+                        'types',
+                    ],
+                },
+                function(details, status) {
+                    if (status !== google.maps.places.PlacesServiceStatus.OK || !details) {
+                        return;
+                    }
+                    lastDetails = serializeDetails(details);
+                    updateHiddenField(lastDetails);
+                    sessionToken = null;
+                }
+            );
+        }
+
+        function attachFormSync() {
+            const form = document.querySelector('form');
+            if (!form) {
+                return;
+            }
+            form.addEventListener('submit', function() {
+                if (lastDetails) {
+                    updateHiddenField(lastDetails);
+                }
+            });
+        }
+
+        window.initAppertivoAutocomplete = function() {
+            const input = document.getElementById('location');
+            if (!input || !window.google || !google.maps || !google.maps.places) {
+                return;
+            }
+
+            autocomplete = new google.maps.places.Autocomplete(input, {
+                fields: ['place_id', 'formatted_address', 'name'],
+                types: ['establishment'],
+                sessionToken: ensureSessionToken(),
+            });
+
+            input.addEventListener('input', function() {
+                if (!input.value) {
+                    lastDetails = null;
+                    updateHiddenField(null);
+                }
+                ensureSessionToken();
+            });
+
+            autocomplete.addListener('place_changed', handlePlaceSelection);
+            attachFormSync();
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            attachFormSync();
+        });
+    })();
+</script>
+<script
+    src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_API_KEY }}&libraries=places&callback=initAppertivoAutocomplete"
+    async defer
+></script>
+{% endif %}
 {% if RECAPTCHA_SITE_KEY %}
 <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/app/views.py
+++ b/app/views.py
@@ -531,7 +531,10 @@ def setup_view(request):
 def signup_view(request):
     """Register a new user and restaurant."""
 
-    context = {"RECAPTCHA_SITE_KEY": getattr(settings, "RECAPTCHA_SITE_KEY", "")}
+    context = {
+        "RECAPTCHA_SITE_KEY": getattr(settings, "RECAPTCHA_SITE_KEY", ""),
+        "GOOGLE_API_KEY": getattr(settings, "GOOGLE_API_KEY", ""),
+    }
     if request.method != "POST":
         return render(request, "auth/signup.html", context)
 
@@ -547,6 +550,14 @@ def signup_view(request):
     email = (data.get("email") or "").strip()
     restaurant_name = (data.get("restaurant_name") or "").strip()
     location = (data.get("location") or "").strip()
+    place_details_raw = data.get("place_details_json") or ""
+    place_details: dict[str, object] | None = None
+    if place_details_raw:
+        try:
+            place_details = json.loads(place_details_raw)
+        except (TypeError, json.JSONDecodeError):
+            place_details = None
+
     form_data = {
         "email": email,
         "restaurant_name": restaurant_name,
@@ -599,10 +610,16 @@ def signup_view(request):
             password=password,
             restaurant_name=restaurant_name,
             location=location,
-            
+
         )
         from django.contrib.auth import login
         login(request, signup_result.user)
+        if place_details:
+            places_by_onboarding = request.session.setdefault(
+                "signup_place_details", {}
+            )
+            places_by_onboarding[str(signup_result.onboarding.uuid)] = place_details
+            request.session.modified = True
     except IntegrityError:
         logger.exception("Signup failed due to database error", extra={"email": email})
         error_message = "We couldn't sign you up right now. Please try again."

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -109,6 +109,7 @@ STRIPE_API_KEY = STRIPE_SECRET_KEY
 
 RECAPTCHA_SITE_KEY = os.getenv("RECAPTCHA_SITE_KEY", "")
 RECAPTCHA_SECRET_KEY = os.getenv("RECAPTCHA_SECRET_KEY", "")
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY", "")
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -8,6 +8,7 @@ import django
 django.setup()
 
 from django.contrib.auth.models import User
+from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -89,6 +90,41 @@ class SignupViewTests(TestCase):
 
         mock_outscraper.delay.assert_not_called()
         mock_scrape.delay.assert_not_called()
+
+    @patch("app.views.send_activation_email", create=True)
+    @patch("app.views.scrape_menu", create=True)
+    @patch("app.views.run_outscraper_search", create=True)
+    @patch("app.views.create_checkout_session")
+    def test_form_signup_stores_place_details_in_session(
+        self, mock_checkout, mock_outscraper, mock_scrape_menu, mock_send_activation
+    ):
+        mock_checkout.return_value = HttpResponse()
+        place_payload = {
+            "place_id": "place_123",
+            "formatted_address": "123 Test St, City",
+            "latitude": 37.123456,
+            "longitude": -122.987654,
+            "formatted_phone_number": "+1 555-555-1234",
+            "website": "https://example.com",
+        }
+        form_data = {
+            "email": "owner2@example.com",
+            "password1": "pw",
+            "password2": "pw",
+            "restaurant_name": "Second Place",
+            "location": "City, State",
+            "place_details_json": json.dumps(place_payload),
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(reverse("signup"), data=form_data)
+
+        onboarding = models.Onboarding.objects.get(user__username="owner2@example.com")
+        details = self.client.session.get("signup_place_details", {}).get(str(onboarding.uuid))
+        self.assertIsNotNone(details)
+        self.assertEqual(details["place_id"], "place_123")
+        self.assertEqual(details["formatted_address"], "123 Test St, City")
+        mock_checkout.assert_called_once()
 
     def test_activation_redirects_to_getting_started(self):
         result = signup_service.start_signup(

--- a/tests/tests_billing.py
+++ b/tests/tests_billing.py
@@ -1,9 +1,17 @@
-from django.test import TestCase
-from django.urls import reverse
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils import timezone
 
-from app.models import UserProfile, Subscription
+from app import models
+from app.billing import create_checkout_session
+from app.models import Subscription, UserProfile
 
 
 class BillingTests(TestCase):
@@ -11,7 +19,7 @@ class BillingTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username="test@example.com", password="pass")
-        UserProfile.objects.create(user=self.user, restaurant_name="Testaurant")
+        UserProfile.objects.create(user=self.user)
 
     def test_billing_page_displays_single_plan(self):
         self.client.login(username="test@example.com", password="pass")
@@ -37,3 +45,92 @@ class BillingTests(TestCase):
         self.assertEqual(subscription.subscription_status, "cancelled")
         profile.refresh_from_db()
         self.assertEqual(profile.subscription_tier, "free")
+
+
+class CheckoutMetadataTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @patch("app.billing.stripe.checkout.Session.create")
+    def test_checkout_includes_place_metadata(self, mock_create):
+        mock_create.return_value = SimpleNamespace(url="https://stripe.example")
+        onboarding_id = uuid.uuid4()
+        request = self.factory.post("/billing/checkout")
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        request.session["signup_place_details"] = {
+            str(onboarding_id): {
+                "place_id": "place_123",
+                "formatted_address": "123 Test St, City",
+                "latitude": 40.123456,
+                "longitude": -70.654321,
+                "formatted_phone_number": "+1 555-0100",
+                "website": "https://example.com",
+            }
+        }
+
+        response = create_checkout_session(request, onboarding_id)
+
+        self.assertEqual(response.status_code, 303)
+        metadata = mock_create.call_args.kwargs["metadata"]
+        self.assertEqual(metadata["place_id"], "place_123")
+        self.assertEqual(metadata["place_address"], "123 Test St, City")
+        self.assertEqual(metadata["place_lat"], "40.123456")
+        self.assertEqual(metadata["place_lng"], "-70.654321")
+        self.assertEqual(metadata["place_phone"], "+1 555-0100")
+        self.assertEqual(metadata["place_website"], "https://example.com")
+        self.assertNotIn(str(onboarding_id), request.session.get("signup_place_details", {}))
+
+
+class StripeWebhookPlaceDetailsTests(TestCase):
+    def setUp(self):
+        os.environ.setdefault("STRIPE_TEST_WEBHOOK", "whsec_test")
+
+    @patch("app.billing.run_onboarding_pipeline.delay")
+    @patch("app.billing.stripe.Webhook.construct_event")
+    def test_webhook_updates_restaurant(self, mock_construct, mock_pipeline):
+        user = User.objects.create_user(username="webhook@example.com", password="pw")
+        account = models.Account.objects.create(name="Webhook Restaurant")
+        models.Membership.objects.create(account=account, user=user, role=models.Membership.Role.OWNER)
+        restaurant = models.Restaurant.objects.create(
+            account=account,
+            name="Webhook Restaurant",
+            location_text="Initial City",
+        )
+        onboarding = models.Onboarding.objects.create(
+            user=user,
+            restaurant=restaurant,
+            activation_token="token",
+        )
+
+        metadata = {
+            "onboarding_id": str(onboarding.uuid),
+            "place_id": "place_456",
+            "place_address": "456 Updated Ave, City",
+            "place_lat": "45.000001",
+            "place_lng": "-93.000001",
+            "place_phone": "+1 555-0199",
+            "place_website": "https://updated.example.com",
+        }
+        mock_construct.return_value = {
+            "type": "checkout.session.completed",
+            "data": {"object": {"metadata": metadata}},
+        }
+
+        response = self.client.post(
+            reverse("stripe-webhook"),
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        restaurant.refresh_from_db()
+        self.assertEqual(restaurant.google_place_id, "place_456")
+        self.assertEqual(restaurant.location_text, "456 Updated Ave, City")
+        self.assertEqual(str(restaurant.latitude), "45.000001")
+        self.assertEqual(str(restaurant.longitude), "-93.000001")
+        self.assertEqual(restaurant.phone, "+1 555-0199")
+        self.assertEqual(restaurant.website, "https://updated.example.com")
+        mock_pipeline.assert_called_once_with(str(onboarding.uuid))


### PR DESCRIPTION
## Summary
- integrate the Google Places Autocomplete widget on the signup form and capture the selected place details with session tokens
- persist the place metadata through the session and Stripe checkout so the webhook can enrich the restaurant with Google identifiers and coordinates
- add latitude/longitude fields on restaurants and cover the new flow with focused tests

## Testing
- pytest tests/test_signup.py::SignupViewTests::test_form_signup_stores_place_details_in_session
- pytest tests/tests_billing.py::CheckoutMetadataTests::test_checkout_includes_place_metadata
- pytest tests/tests_billing.py::StripeWebhookPlaceDetailsTests::test_webhook_updates_restaurant


------
https://chatgpt.com/codex/tasks/task_e_68f9376caef88332820219aeaec437d2