### PR TITLE
Fix signup autocomplete script by removing stray handler

### DIFF
--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -352,16 +352,6 @@
             if (hiddenDetails) {
                 hiddenDetails.value = JSON.stringify(value);
             }
-            target.addEventListener('input', function() {
-                clearPlaceDetails();
-                if (hiddenName) {
-                    hiddenName.value = '';
-                }
-                if (hiddenLocation) {
-                    hiddenLocation.value = '';
-                }
-            });
-        }
 
             return { name, address };
         }


### PR DESCRIPTION
## Summary
- remove stray event handler wiring in the signup autocomplete helper that referenced an undefined variable
- keep the helper returning the place details without throwing runtime errors so the autocomplete loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f95b94f96c8332a56a18431e3714d5