### PR TITLE
Allow signup to derive restaurant details from place data

### DIFF
--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -206,7 +206,6 @@
                             value="{% if form_data and form_data.restaurant_name %}{{ form_data.restaurant_name }}{% elif form_data and form_data.location %}{{ form_data.location }}{% endif %}"
                             placeholder="Start typing your restaurant..."
                             autocomplete="off"
-                            required
                         >
                     </div>
                 </div>

--- a/app/views.py
+++ b/app/views.py
@@ -561,6 +561,8 @@ def signup_view(request):
     def _clean_str(value: object) -> str:
         return value.strip() if isinstance(value, str) else ""
 
+    details_name = ""
+    details_location = ""
     if place_details:
         prediction = place_details.get("prediction") or {}
 
@@ -584,6 +586,20 @@ def signup_view(request):
             restaurant_name = details_name
         if details_location and not location:
             location = details_location
+
+    if not restaurant_name and details_name:
+        restaurant_name = details_name
+    if not restaurant_name and email:
+        restaurant_name = email.split("@")[0]
+    if not restaurant_name:
+        restaurant_name = "New Restaurant"
+
+    if not location and details_location:
+        location = details_location
+    if not location and restaurant_name:
+        location = restaurant_name
+    if not location:
+        location = "Unknown location"
 
     form_data = {
         "email": email,
@@ -618,11 +634,14 @@ def signup_view(request):
             return render(request, "auth/signup.html", context)
         password = password1
 
-    if not email or not restaurant_name or not location:
+    if not email:
         if is_json:
-            return JsonResponse({"error": "missing_fields"}, status=400)
-        context.update({"error": "Please complete all fields.", "form_data": form_data})
+            return JsonResponse({"error": "missing_email"}, status=400)
+        context.update({"error": "Please provide your email.", "form_data": form_data})
         return render(request, "auth/signup.html", context)
+
+    if is_json and (not restaurant_name or not location):
+        return JsonResponse({"error": "missing_fields"}, status=400)
 
     if User.objects.filter(username__iexact=email).exists():
         error_message = "An account with that email already exists."

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -106,13 +106,12 @@ class SignupViewTests(TestCase):
             "longitude": -122.987654,
             "formatted_phone_number": "+1 555-555-1234",
             "website": "https://example.com",
+            "name": "Second Place",
         }
         form_data = {
             "email": "owner2@example.com",
             "password1": "pw",
             "password2": "pw",
-            "restaurant_name": "Second Place",
-            "location": "City, State",
             "place_details_json": json.dumps(place_payload),
         }
 
@@ -124,6 +123,8 @@ class SignupViewTests(TestCase):
         self.assertIsNotNone(details)
         self.assertEqual(details["place_id"], "place_123")
         self.assertEqual(details["formatted_address"], "123 Test St, City")
+        self.assertEqual(onboarding.restaurant.name, "Second Place")
+        self.assertEqual(onboarding.restaurant.location_text, "123 Test St, City")
         mock_checkout.assert_called_once()
 
     def test_activation_redirects_to_getting_started(self):


### PR DESCRIPTION
## Summary
- allow the signup view to populate missing restaurant details from Google place responses and fall back to sensible defaults
- drop the required flag on the restaurant search input so the form can submit without manual entry
- adjust the signup test to rely on place details when asserting stored data

## Testing
- pytest tests/test_signup.py *(fails: ModuleNotFoundError: No module named 'django_htmx')*

------
https://chatgpt.com/codex/tasks/task_e_68f95d6251148332a6003fe68625fcb5