### PR TITLE
Remove public homepage link underlines

### DIFF
--- a/app/templates/base_public.html
+++ b/app/templates/base_public.html
@@ -66,6 +66,14 @@
             overflow-x: hidden;
         }
 
+        a {
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: none;
+        }
+
         .topbar {
             position: fixed;
             top: 1.5rem;


### PR DESCRIPTION
### Motivation
- Remove default browser underlines on public-facing homepage links and CTAs by adding a layout-level anchor reset.

### Description
- Add `a { text-decoration: none; }` and `a:hover { text-decoration: none; }` to `app/templates/base_public.html` to prevent underlines on anchors in the public layout.

### Testing
- Verified the CSS change with a small Python presence check (`python - <<'PY' ... PY`) and ran `git diff --check` which passed; running `python manage.py test tests.tests_mobile_nav tests.test_appertivo_views` could not complete because the test environment is missing the `django_htmx` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22064d3f3c8332b494e8e67896188d)